### PR TITLE
fix: pin executable release action commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Create or update release pull request
         id: release
-        uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5.0.0
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ github.token }}
           target-branch: main


### PR DESCRIPTION
## Summary

- replace the annotated Release Please v5 tag object SHA with the underlying executable commit SHA
- keep all Docker release actions pinned to verified commit objects

## Validation

- actionlint v1.7.10
- git diff --check
- verified the new SHA through the GitHub commits API

## Root cause

GitHub Actions cannot execute an annotated tag object SHA in a uses reference, so the Release workflow ended with startup_failure before creating a job.