### PR TITLE
fix: allow manual release retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- add workflow_dispatch to the Release workflow
- allow a startup failure or interrupted publication to be retried without an unrelated source change

## Validation

- actionlint v1.7.10
- git diff --check