### PR TITLE
fix: dispatch release pull request checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
           head_branch="$(printf '%s' "$RELEASE_PR" | jq -er '.headBranchName')"
-          gh workflow run ci.yml --ref "$head_branch"
-          gh workflow run codeql.yml --ref "$head_branch"
+          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$head_branch"
+          gh workflow run codeql.yml --repo "$GITHUB_REPOSITORY" --ref "$head_branch"
 
   publish:
     needs: prepare


### PR DESCRIPTION
## Summary

- pass the repository explicitly when dispatching CI and CodeQL for a Release Please branch
- avoid relying on a local checkout in the prepare job

## Validation

- actionlint v1.7.10
- git diff --check

The squash merge will include a Release-As 0.1.0 footer so the first pre-alpha release is not incorrectly published as 1.0.0.