### PR TITLE
ci: secure amd64 container releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,46 @@ jobs:
         with:
           path: .
           artifact-name: vastora-sbom.spdx.json
+
+  container-image-security:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
+
+      - name: Build Center image for scanning
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
+        with:
+          context: .
+          file: Dockerfile.center
+          platforms: linux/amd64
+          load: true
+          push: false
+          build-args: VASTORA_VERSION=0.0.0-ci
+          tags: local/vastora-center:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan Center image for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: local/vastora-center:${{ github.sha }}
+          format: sarif
+          output: trivy-center-image.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          limit-severities-for-sarif: true
+          exit-code: "1"
+
+      - name: Upload Center image scan results
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: trivy-center-image.sarif
+          category: trivy-vastora-center-ci

--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -1,0 +1,66 @@
+name: Released Image Security
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "41 4 * * 1"
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: released-image-security
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve released image digest
+        id: image
+        env:
+          IMAGE: ghcr.io/petauron/vastora-center:latest
+        run: |
+          digest="$(docker buildx imagetools inspect "$IMAGE" --format '{{ .Manifest.Digest }}')"
+          case "$digest" in
+            sha256:*) ;;
+            *)
+              echo "Could not resolve $IMAGE to an immutable digest: $digest" >&2
+              exit 1
+              ;;
+          esac
+          resolved_image="ghcr.io/petauron/vastora-center@$digest"
+          echo "image=$resolved_image" >> "$GITHUB_OUTPUT"
+
+      - name: Scan released Center image for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image.outputs.image }}
+          format: sarif
+          output: trivy-released-center-image.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          limit-severities-for-sarif: true
+          exit-code: "1"
+
+      - name: Upload released image scan results
+        if: ${{ always() && steps.image.outputs.image != '' }}
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: trivy-released-center-image.sarif
+          category: trivy-vastora-center-released

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,6 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.release_sha }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.0.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
 
@@ -72,7 +69,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.center
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           build-args: |
             VASTORA_VERSION=${{ needs.prepare.outputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
     if: needs.prepare.outputs.release_created == 'true'
     runs-on: ubuntu-24.04
     permissions:
+      attestations: write
       contents: write
+      id-token: write
       packages: write
     steps:
       - name: Check out release commit
@@ -84,6 +86,13 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
+
+      - name: Attest Center image
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ghcr.io/petauron/vastora-center
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
 
       - name: Package release installer
         env:

--- a/Dockerfile.center
+++ b/Dockerfile.center
@@ -15,13 +15,7 @@ COPY internal/ ./internal/
 RUN CGO_ENABLED=0 GOTOOLCHAIN=go1.26.6 go build -trimpath \
     -ldflags="-s -w -X github.com/petauron/vastora/internal/center.Version=${VASTORA_VERSION} -X github.com/petauron/vastora/internal/agent.Version=${VASTORA_VERSION}" \
     -o /out/vastora ./cmd/vastora
-RUN mkdir -p /out/agent-binaries && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOTOOLCHAIN=go1.26.6 go build -trimpath \
-      -ldflags="-s -w -X github.com/petauron/vastora/internal/center.Version=${VASTORA_VERSION} -X github.com/petauron/vastora/internal/agent.Version=${VASTORA_VERSION}" \
-      -o /out/agent-binaries/linux-amd64 ./cmd/vastora && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOTOOLCHAIN=go1.26.6 go build -trimpath \
-      -ldflags="-s -w -X github.com/petauron/vastora/internal/center.Version=${VASTORA_VERSION} -X github.com/petauron/vastora/internal/agent.Version=${VASTORA_VERSION}" \
-      -o /out/agent-binaries/linux-arm64 ./cmd/vastora
+RUN mkdir -p /out/agent-binaries && cp /out/vastora /out/agent-binaries/linux-amd64
 RUN mkdir /out/center-data && chown 65532:65532 /out/center-data
 
 FROM gcr.io/distroless/static-debian13:nonroot

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ dependency-security-check:
 agent-binaries:
 	mkdir -p bin/agent-binaries
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -trimpath -ldflags="-s -w" -o bin/agent-binaries/linux-amd64 ./cmd/vastora
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build -trimpath -ldflags="-s -w" -o bin/agent-binaries/linux-arm64 ./cmd/vastora
 
 center-install-bundle:
 	scripts/package-center-install.sh --version "$${VASTORA_VERSION:?set VASTORA_VERSION}" --image "$${VASTORA_CENTER_IMAGE:?set VASTORA_CENTER_IMAGE}" --output-dir dist

--- a/cmd/vastora/main.go
+++ b/cmd/vastora/main.go
@@ -148,7 +148,7 @@ func runCenter(arguments []string) error {
 		listen := flags.String("listen", "127.0.0.1:8080", "listen address")
 		webDir := flags.String("web-dir", "web/dist", "compiled React web directory")
 		officialCatalog := flags.String("official-catalog", "catalog/catalog.json", "official Catalog JSON file")
-		agentBinariesDir := flags.String("agent-binaries-dir", "agent-binaries", "directory containing linux-amd64 and linux-arm64 Agent binaries")
+		agentBinariesDir := flags.String("agent-binaries-dir", "agent-binaries", "directory containing the linux-amd64 Agent binary")
 		agentConnectURL := flags.String("agent-connect-url", "", "Agent-reachable Center URL suggested during first setup")
 		var headscaleAllowedURLs stringListFlag
 		flags.Var(&headscaleAllowedURLs, "headscale-allowed-url", "authorized Headscale control-plane URL (repeat for multiple URLs)")
@@ -531,8 +531,8 @@ func validatedNodeRuntime(rolesValue, capabilitiesValue string) ([]string, agent
 }
 
 func updateAgentExecutable(ctx context.Context, client *http.Client, connection agent.Connection, executable string, restart func() error) (string, error) {
-	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
-		return "", errors.New("agent update is available only for amd64 and arm64")
+	if runtime.GOARCH != "amd64" {
+		return "", errors.New("agent update is available only for amd64")
 	}
 	endpoint := strings.TrimRight(connection.CenterURL, "/") + "/api/v1/agents/" + url.PathEscape(connection.AgentID) + "/binary/linux/" + runtime.GOARCH
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -81,7 +81,7 @@ location; both are bootstrap options before the `--` separator.
 
 Merges to `main` update a Release Please pull request from conventional commit
 messages. Merging that pull request creates a draft release, builds and pushes
-the `linux/amd64` and `linux/arm64` Center image to GHCR, packages the installer
+the `linux/amd64` Center image to GHCR, packages the installer
 against the image manifest digest, uploads all three assets, and publishes the
 release only after every step succeeds. Failed builds leave the release as a
 draft, so `releases/latest` never points to incomplete installer assets.

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,10 @@ if [ "$(uname -s)" != "Linux" ]; then
   echo "Vastora Center installation currently supports Linux hosts." >&2
   exit 1
 fi
+case "$(uname -m)" in
+  x86_64|amd64) ;;
+  *) echo "Vastora Center currently supports only Ubuntu 24.04 on amd64." >&2; exit 1 ;;
+esac
 if [ "$(id -u)" -ne 0 ]; then
   echo "Run the Center installer with sudo." >&2
   exit 1

--- a/internal/center/agent_install.go
+++ b/internal/center/agent_install.go
@@ -56,8 +56,7 @@ fi
 
 case "$(uname -m)" in
   x86_64|amd64) arch="amd64" ;;
-  aarch64|arm64) arch="arm64" ;;
-  *) echo "This CPU architecture is not supported." >&2; exit 1 ;;
+  *) echo "Vastora Agent currently supports only Ubuntu 24.04 on amd64." >&2; exit 1 ;;
 esac
 
 temporary="$(mktemp -t vastora-agent.XXXXXX)"
@@ -110,11 +109,9 @@ func (s *Store) ValidateAgentEnrollment(ctx context.Context, token string) error
 }
 
 func (s *Server) agentInstallerAvailable() bool {
-	for _, target := range []string{"linux-amd64", "linux-arm64"} {
-		info, err := os.Stat(filepath.Join(s.agentBinariesDir, target))
-		if err != nil || !info.Mode().IsRegular() {
-			return false
-		}
+	info, err := os.Stat(filepath.Join(s.agentBinariesDir, "linux-amd64"))
+	if err != nil || !info.Mode().IsRegular() {
+		return false
 	}
 	return true
 }
@@ -148,7 +145,7 @@ func (s *Server) handleAgentUpdateBinary(writer http.ResponseWriter, request *ht
 }
 
 func (s *Server) serveAgentBinary(writer http.ResponseWriter, request *http.Request, operatingSystem, architecture string) {
-	if operatingSystem != "linux" || (architecture != "amd64" && architecture != "arm64") {
+	if operatingSystem != "linux" || architecture != "amd64" {
 		writeError(writer, http.StatusNotFound, errors.New("center: Agent binary target is not available"))
 		return
 	}

--- a/internal/center/agent_install_test.go
+++ b/internal/center/agent_install_test.go
@@ -21,10 +21,8 @@ func TestAgentBinaryDownloadRequiresLiveEnrollmentAndDoesNotConsumeIt(t *testing
 	}
 	defer store.Close()
 	binaries := t.TempDir()
-	for _, target := range []string{"linux-amd64", "linux-arm64"} {
-		if err := os.WriteFile(filepath.Join(binaries, target), []byte("binary-"+target), 0o600); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.WriteFile(filepath.Join(binaries, "linux-amd64"), []byte("binary-linux-amd64"), 0o600); err != nil {
+		t.Fatal(err)
 	}
 	server := NewServer(store, "", false).WithAgentBinaries(binaries)
 	if !server.agentInstallerAvailable() {
@@ -58,6 +56,14 @@ func TestAgentBinaryDownloadRequiresLiveEnrollmentAndDoesNotConsumeIt(t *testing
 	}
 	if response.Header().Get("X-Vastora-Version") != Version {
 		t.Fatalf("initial Agent download version = %q", response.Header().Get("X-Vastora-Version"))
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/v1/agent-binaries/linux/arm64", nil)
+	request.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("arm64 binary download status = %d", response.Code)
 	}
 	if _, err := store.EnrollAgent(context.Background(), enrollment.Token, "downloaded-agent", "test"); err != nil {
 		t.Fatalf("binary download consumed enrollment token: %v", err)
@@ -121,7 +127,7 @@ func TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload(t *testing.T) {
 	response := httptest.NewRecorder()
 	NewServer(store, "", false).Handler().ServeHTTP(response, request)
 	script := response.Body.String()
-	for _, expected := range []string{"command -v \"$required\"", "docker info", "sha256sum", "--proto \"=$curl_protocol\"", "--max-filesize 268435456", "Authorization: Bearer $token", "${center_url%/}/api/v1/agent-binaries/linux/$arch", "x-vastora-sha256:", "failed its SHA-256 integrity check", "failed its version check", "install -m 0755", "agent install --center-url"} {
+	for _, expected := range []string{"command -v \"$required\"", "docker info", "sha256sum", "x86_64|amd64", "supports only Ubuntu 24.04 on amd64", "--proto \"=$curl_protocol\"", "--max-filesize 268435456", "Authorization: Bearer $token", "${center_url%/}/api/v1/agent-binaries/linux/$arch", "x-vastora-sha256:", "failed its SHA-256 integrity check", "failed its version check", "install -m 0755", "agent install --center-url"} {
 		if !strings.Contains(script, expected) {
 			t.Fatalf("installer is missing %q:\n%s", expected, script)
 		}


### PR DESCRIPTION
## Summary

- publish and package Vastora releases for Linux amd64 only
- build and scan the final Center image with Trivy during CI
- upload image findings to GitHub code scanning
- attest released GHCR image digests with GitHub artifact attestations
- rescan the immutable digest behind `latest` every week

## Why

The existing security job scanned the repository filesystem but not the final container image. Released images also lacked a GitHub-verifiable attestation and were not rescanned when vulnerability databases changed.

## Validation

- `actionlint .github/workflows/*.yml`
- `make deployment-check`
- local `linux/amd64` Center image build
- Trivy 0.70.0 image scan: 0 HIGH/CRITICAL findings
- GHCR `latest` digest resolution with Docker Buildx
