### PR TITLE
feat: bootstrap Center through an SSH tunnel

### DIFF
--- a/cmd/vastora/main_test.go
+++ b/cmd/vastora/main_test.go
@@ -37,6 +37,14 @@ func TestUnimplementedCapabilitiesCannotBeAdvertised(t *testing.T) {
 	}
 }
 
+func TestCenterBootstrapDoesNotRequireSuggestedAgentURL(t *testing.T) {
+	missingCatalog := filepath.Join(t.TempDir(), "missing-catalog.json")
+	err := runCenter([]string{"serve", "--data-dir", t.TempDir(), "--official-catalog", missingCatalog})
+	if err == nil || !strings.Contains(err.Error(), "read official catalog") {
+		t.Fatalf("Center did not reach startup without --agent-connect-url: %v", err)
+	}
+}
+
 func TestSystemdAgentUnitUsesPersistentServiceConfiguration(t *testing.T) {
 	unit := systemdAgentUnit("/usr/local/bin/vastora", "/var/lib/vastora/agent", "worker,gateway", "docker,gateway,tunnel")
 	for _, expected := range []string{


### PR DESCRIPTION
## Summary

- add a regression test proving Center startup no longer requires `--agent-connect-url`
- preserve the user-facing feature classification required by Release Please

## Context

The loopback bootstrap feature is already merged and fully checked in #16. Its squash title omitted the Conventional Commit prefix, so Release Please correctly ignored it. This small follow-up gives the merged feature a parseable `feat:` title and strengthens the startup regression coverage.

## Validation

- `GOTOOLCHAIN=go1.26.6 go test ./cmd/vastora`
- all feature checks passed on #16
