### PR TITLE
fix: bind containerized Center to loopback

### DIFF
--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -8,8 +8,8 @@ curl -LsSf https://github.com/petauron/vastora/releases/latest/download/install.
 
 The bootstrap downloads the latest Center install bundle and its SHA-256 file,
 verifies the archive, installs it under `/opt/vastora/center`, and starts Center
-on `127.0.0.1:8080`. It does not require Git, a domain, a certificate, or an
-unused public port 443.
+with host networking on `127.0.0.1:8080`. It publishes no Docker port and does
+not require Git, a domain, a certificate, or an unused public port 443.
 
 ## Open the first-run wizard
 

--- a/deploy/center/compose.yaml
+++ b/deploy/center/compose.yaml
@@ -10,13 +10,12 @@ services:
       - --data-dir
       - /var/lib/vastora
       - --listen
-      - 0.0.0.0:8080
+      - 127.0.0.1:${VASTORA_CENTER_BOOTSTRAP_PORT:-8080}
       - --web-dir
       - /app/web/dist
       - --official-catalog
       - /app/catalog/catalog.json
-    ports:
-      - "127.0.0.1:${VASTORA_CENTER_BOOTSTRAP_PORT:-8080}:8080"
+    network_mode: host
     volumes:
       - center-data:/var/lib/vastora
     security_opt:

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -31,7 +31,12 @@ test -x "$temporary_dir/setup.sh"
 test -f "$temporary_dir/compose.yaml"
 test -f "$temporary_dir/headscale/config.yaml"
 test -f "$temporary_dir/headscale/policy.hujson"
-grep -Fq '127.0.0.1:${VASTORA_CENTER_BOOTSTRAP_PORT:-8080}:8080' "$temporary_dir/compose.yaml"
+grep -Fq '127.0.0.1:${VASTORA_CENTER_BOOTSTRAP_PORT:-8080}' "$temporary_dir/compose.yaml"
+grep -Fq 'network_mode: host' "$temporary_dir/compose.yaml"
+if sed -n '/^  center:/,/^  headscale:/p' "$temporary_dir/compose.yaml" | grep -Fq '    ports:'; then
+  echo "Center install bundle still publishes a Docker port" >&2
+  exit 1
+fi
 if grep -Fq '${VASTORA_CENTER_PORT:-443}:8080' "$temporary_dir/compose.yaml"; then
   echo "Center install bundle still claims public port 443" >&2
   exit 1


### PR DESCRIPTION
## Summary
- run the containerized Center with host networking
- bind the Center process directly to the loopback bootstrap address
- ensure the Center service publishes no Docker port

## Validation
- make check
- make security-check
- production-node-d host-network smoke test against the v0.2.0 image