### PR TITLE
feat: add forward-only database migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Vastora Agent Rules
 
-- Do not preserve backward compatibility. Remove obsolete implementations outright; do not add compatibility layers, migration code, or fallbacks.
+- Do not preserve obsolete API or implementation compatibility. Remove superseded implementations outright; do not add aliases, dual code paths, or runtime fallbacks.
+- Released Center database schemas must use tested, forward-only migrations. Back up before migrating, fail closed on migration errors, and do not support automatic database downgrade.
 - Choose the simplest implementation that fully satisfies the current requirements. Avoid speculative abstractions, unnecessary indirection, and redundant configuration layers.
 - Build the system incrementally in vertical slices. Make the smallest end-to-end version work before adding more layers, and never dismantle working functionality to accommodate unfinished complexity.
 - Keep components modular and maintain a clear separation of concerns.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ one-line Agent install command. See [`deploy/center`](deploy/center/README.md)
 for the complete bootstrap flow and local release packaging. The short address
 is `https://vastora.petauron.com/install.sh`.
 
+Released Center schemas upgrade in place through ordered, forward-only
+migrations. Center writes a private, consistent SQLite snapshot before applying
+pending migrations and refuses to start if migration, foreign-key, or integrity
+verification fails. Restore that snapshot to downgrade; database downgrades are
+never attempted automatically.
+
 ## Security model
 
 - The Center never mounts a Docker socket.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,13 @@ locations. Center is the only source of network and publication intent. Agent is
 the only component that discovers local addresses and touches host Docker,
 Caddy, optional HAProxy, cloudflared, or application-local APIs.
 
+Center database changes use ordered, forward-only SQLite migrations. Before an
+existing database advances, Center creates a transactionally consistent
+snapshot under its private data directory. Each migration runs in a transaction,
+then Center verifies foreign keys and database integrity. Older Center binaries
+refuse newer schemas; downgrades restore the pre-migration snapshot instead of
+attempting a reverse migration.
+
 ```mermaid
 flowchart LR
   Browser["Administrator browser"] --> Center["Vastora Center"]

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
+	github.com/pressly/goose/v3 v3.27.3
 	golang.org/x/crypto v0.55.0
 	modernc.org/sqlite v1.56.0
 )
@@ -25,16 +26,20 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
+	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/sethvargo/go-retry v0.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	modernc.org/libc v1.75.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
+github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
+github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/moby/api v1.55.0 h1:2/sexvQyqIWS8pRSCFddBfpW2qE7vR7FCL+vN8pxwMc=
@@ -47,8 +49,12 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pressly/goose/v3 v3.27.3 h1:pIglVHjw99r4e/hDHHwbl9vfOsDMqUokfkXo6+n/RxA=
+github.com/pressly/goose/v3 v3.27.3/go.mod h1:Dag+xpV6o20HR2LFY1j0q6MDwc3f7vPUFDA77R+0yGY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/sethvargo/go-retry v0.4.0 h1:9qy1OoIAxBL+gBYnkTnTnWle5wlfsXQlwRzIbbpdqPw=
+github.com/sethvargo/go-retry v0.4.0/go.mod h1:tvsjdKG6xfiCx4LSiUZ06kcv38xvdVQwv8R6/VnnVWg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
@@ -65,6 +71,8 @@ go.opentelemetry.io/otel/sdk/metric v1.45.0 h1:oVFszMfyj1Am6s24Vtc7wBb8BKLcwepJj
 go.opentelemetry.io/otel/sdk/metric v1.45.0/go.mod h1:vUWUxDZvu1WVRj8JA8S0AdhsPrZoDpA2DdZauIh4mDA=
 go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOyVhxag=
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=

--- a/internal/center/migrations.go
+++ b/internal/center/migrations.go
@@ -1,0 +1,167 @@
+package center
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/database"
+)
+
+const schemaBaselineVersion int64 = 3
+
+//go:embed migrations/*.sql
+var migrationFiles embed.FS
+
+func (s *Store) migrateSchema(ctx context.Context) error {
+	provider, err := newMigrationProvider(s.db)
+	if err != nil {
+		return err
+	}
+	hasHistory, err := migrationHistoryExists(ctx, s.db)
+	if err != nil {
+		return err
+	}
+	if !hasHistory {
+		legacyVersion, err := sqliteSchemaVersion(ctx, s.db)
+		if err != nil {
+			return err
+		}
+		if legacyVersion < schemaBaselineVersion || legacyVersion > centerSchemaVersion {
+			return fmt.Errorf("center: database schema version %d cannot be upgraded by this release", legacyVersion)
+		}
+		if err := s.initializeMigrationHistory(ctx, legacyVersion); err != nil {
+			return err
+		}
+	}
+	current, target, err := provider.GetVersions(ctx)
+	if err != nil {
+		return fmt.Errorf("center: inspect database migrations: %w", err)
+	}
+	if current > target || target != centerSchemaVersion {
+		return fmt.Errorf("center: database migration range %d to %d is not supported by this release", current, target)
+	}
+	if current < target {
+		backup, err := s.createMigrationBackup(ctx, current, target)
+		if err != nil {
+			return err
+		}
+		if _, err := provider.Up(ctx); err != nil {
+			return fmt.Errorf("center: migrate database from %d to %d (backup: %s): %w", current, target, backup, err)
+		}
+	}
+	return verifyMigratedSchema(ctx, s.db, target)
+}
+
+func newMigrationProvider(db *sql.DB) (*goose.Provider, error) {
+	migrations, err := fs.Sub(migrationFiles, "migrations")
+	if err != nil {
+		return nil, fmt.Errorf("center: load embedded database migrations: %w", err)
+	}
+	provider, err := goose.NewProvider(
+		goose.DialectSQLite3,
+		db,
+		migrations,
+		goose.WithDisableGlobalRegistry(true),
+		goose.WithGoMigrations(goose.NewGoMigration(schemaBaselineVersion, nil, nil)),
+		goose.WithLogger(goose.NopLogger()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("center: configure database migrations: %w", err)
+	}
+	return provider, nil
+}
+
+func (s *Store) initializeMigrationHistory(ctx context.Context, version int64) error {
+	store, err := database.NewStore(database.DialectSQLite3, goose.DefaultTablename)
+	if err != nil {
+		return fmt.Errorf("center: configure migration history: %w", err)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("center: begin migration history: %w", err)
+	}
+	defer tx.Rollback()
+	if err := store.CreateVersionTable(ctx, tx); err != nil {
+		return fmt.Errorf("center: create migration history: %w", err)
+	}
+	if err := store.Insert(ctx, tx, database.InsertRequest{Version: 0}); err != nil {
+		return fmt.Errorf("center: initialize migration history: %w", err)
+	}
+	for applied := schemaBaselineVersion; applied <= version; applied++ {
+		if err := store.Insert(ctx, tx, database.InsertRequest{Version: applied}); err != nil {
+			return fmt.Errorf("center: record database version %d: %w", applied, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("center: commit migration history: %w", err)
+	}
+	return nil
+}
+
+func migrationHistoryExists(ctx context.Context, db *sql.DB) (bool, error) {
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)`, goose.DefaultTablename).Scan(&exists); err != nil {
+		return false, fmt.Errorf("center: inspect migration history: %w", err)
+	}
+	return exists, nil
+}
+
+func sqliteSchemaVersion(ctx context.Context, db *sql.DB) (int64, error) {
+	var version int64
+	if err := db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
+		return 0, fmt.Errorf("center: inspect SQLite schema version: %w", err)
+	}
+	return version, nil
+}
+
+func (s *Store) createMigrationBackup(ctx context.Context, from, to int64) (string, error) {
+	directory := filepath.Join(s.dataDir, "migration-backups")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return "", fmt.Errorf("center: create migration backup directory: %w", err)
+	}
+	backup := filepath.Join(directory, fmt.Sprintf("center-v%d-before-v%d-%s.db", from, to, time.Now().UTC().Format("20060102T150405.000000000Z")))
+	if _, err := s.db.ExecContext(ctx, `VACUUM INTO ?`, backup); err != nil {
+		return "", fmt.Errorf("center: create pre-migration database backup: %w", err)
+	}
+	if err := os.Chmod(backup, 0o600); err != nil {
+		return "", fmt.Errorf("center: protect pre-migration database backup: %w", err)
+	}
+	return backup, nil
+}
+
+func verifyMigratedSchema(ctx context.Context, db *sql.DB, expected int64) error {
+	version, err := sqliteSchemaVersion(ctx, db)
+	if err != nil {
+		return err
+	}
+	if version != expected {
+		return fmt.Errorf("center: migrated SQLite schema is version %d, expected %d", version, expected)
+	}
+	rows, err := db.QueryContext(ctx, `PRAGMA foreign_key_check`)
+	if err != nil {
+		return fmt.Errorf("center: verify migrated foreign keys: %w", err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		return errors.New("center: migrated database contains a foreign key violation")
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("center: verify migrated foreign keys: %w", err)
+	}
+	var integrity string
+	if err := db.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&integrity); err != nil {
+		return fmt.Errorf("center: verify migrated database integrity: %w", err)
+	}
+	if integrity != "ok" {
+		return fmt.Errorf("center: migrated database failed integrity check: %s", integrity)
+	}
+	return nil
+}

--- a/internal/center/migrations/00004_shared_443.sql
+++ b/internal/center/migrations/00004_shared_443.sql
@@ -1,0 +1,65 @@
+-- +goose Up
+CREATE TABLE publications_v4 (
+    id TEXT PRIMARY KEY,
+    service_id TEXT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK(kind IN ('lan_gateway', 'headscale_gateway', 'public_direct', 'public_shared_443', 'cloudflare_tunnel')),
+    gateway_node_id TEXT REFERENCES agents(id) ON DELETE RESTRICT,
+    hostname TEXT NOT NULL,
+    dns_provider TEXT NOT NULL CHECK(dns_provider IN ('manual', 'cloudflare', 'headscale')),
+    dns_record_id TEXT NOT NULL DEFAULT '',
+    tls_enabled INTEGER NOT NULL DEFAULT 0,
+    desired_revision INTEGER NOT NULL DEFAULT 1,
+    applied_revision INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL CHECK(status IN ('pending', 'applying', 'ready', 'degraded', 'failed', 'stopped')),
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(service_id, kind, hostname)
+);
+
+INSERT INTO publications_v4 (
+    id, service_id, kind, gateway_node_id, hostname, dns_provider,
+    dns_record_id, tls_enabled, desired_revision, applied_revision,
+    status, last_error, created_at, updated_at
+)
+SELECT
+    id, service_id, kind, gateway_node_id, hostname, dns_provider,
+    dns_record_id, tls_enabled, desired_revision, applied_revision,
+    status, last_error, created_at, updated_at
+FROM publications;
+
+CREATE TABLE routes_v4 (
+    id TEXT PRIMARY KEY,
+    publication_id TEXT NOT NULL REFERENCES publications_v4(id) ON DELETE CASCADE,
+    site_id TEXT NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+    service_id TEXT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+    gateway_node_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    hostname TEXT NOT NULL,
+    protocol TEXT NOT NULL CHECK(protocol IN ('http', 'https')),
+    upstreams_json BLOB NOT NULL,
+    tls_enabled INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL CHECK(status IN ('pending', 'applying', 'ready', 'failed')),
+    desired_revision INTEGER NOT NULL DEFAULT 0,
+    applied_revision INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(publication_id, gateway_node_id)
+);
+
+INSERT INTO routes_v4 (
+    id, publication_id, site_id, service_id, gateway_node_id, hostname,
+    protocol, upstreams_json, tls_enabled, status, desired_revision,
+    applied_revision, last_error, created_at, updated_at
+)
+SELECT
+    id, publication_id, site_id, service_id, gateway_node_id, hostname,
+    protocol, upstreams_json, tls_enabled, status, desired_revision,
+    applied_revision, last_error, created_at, updated_at
+FROM routes;
+
+DROP TABLE routes;
+DROP TABLE publications;
+ALTER TABLE publications_v4 RENAME TO publications;
+ALTER TABLE routes_v4 RENAME TO routes;
+PRAGMA user_version = 4;

--- a/internal/center/migrations_test.go
+++ b/internal/center/migrations_test.go
@@ -1,0 +1,222 @@
+package center
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenMigratesVersion3WithoutLosingPublicationsOrRoutes(t *testing.T) {
+	directory := t.TempDir()
+	createLegacyVersion3Database(t, directory)
+
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	version, err := sqliteSchemaVersion(ctx, store.db)
+	if err != nil || version != centerSchemaVersion {
+		t.Fatalf("schema version = %d, err = %v", version, err)
+	}
+	provider, err := newMigrationProvider(store.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationVersion, err := provider.GetDBVersion(ctx)
+	if err != nil || migrationVersion != centerSchemaVersion {
+		t.Fatalf("migration version = %d, err = %v", migrationVersion, err)
+	}
+	for table, expected := range map[string]int{"publications": 1, "routes": 1} {
+		var count int
+		if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&count); err != nil || count != expected {
+			t.Fatalf("%s count = %d, err = %v", table, count, err)
+		}
+	}
+	var routePublication string
+	if err := store.db.QueryRowContext(ctx, `SELECT publication_id FROM routes WHERE id = 'route-v3'`).Scan(&routePublication); err != nil || routePublication != "publication-v3" {
+		t.Fatalf("route publication = %q, err = %v", routePublication, err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO publications(
+		id, service_id, kind, gateway_node_id, hostname, dns_provider, status, created_at, updated_at
+	) VALUES('publication-v4', 'service-v3', 'public_shared_443', 'agent-v3', 'raw.example.test', 'manual', 'pending', ?, ?)`, time.Now().UTC().Format(time.RFC3339Nano), time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("new publication kind was not accepted: %v", err)
+	}
+	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "center-v3-before-v4-*.db"))
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("migration backups = %v, err = %v", backups, err)
+	}
+	info, err := os.Stat(backups[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("migration backup mode = %v", info.Mode().Perm())
+	}
+	backupDB, err := sql.Open("sqlite", backups[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backupDB.Close()
+	backupVersion, err := sqliteSchemaVersion(ctx, backupDB)
+	if err != nil || backupVersion != schemaBaselineVersion {
+		t.Fatalf("backup schema version = %d, err = %v", backupVersion, err)
+	}
+}
+
+func TestOpenRejectsDatabaseFromANewerRelease(t *testing.T) {
+	directory := t.TempDir()
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO goose_db_version(version_id, is_applied) VALUES(5, 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`PRAGMA user_version = 5`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(directory); err == nil || !strings.Contains(err.Error(), "not supported by this release") {
+		t.Fatalf("newer database error = %v", err)
+	}
+	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "*.db"))
+	if err != nil || len(backups) != 0 {
+		t.Fatalf("rejected database unexpectedly created backups: %v, err = %v", backups, err)
+	}
+}
+
+func TestFailedMigrationRollsBackSchemaAndLeavesBackup(t *testing.T) {
+	directory := t.TempDir()
+	createLegacyVersion3Database(t, directory)
+	db, err := sql.Open("sqlite", filepath.Join(directory, "center.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(`PRAGMA ignore_check_constraints = ON`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE publications SET kind = 'invalid-legacy-kind' WHERE id = 'publication-v3'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(directory); err == nil || !strings.Contains(err.Error(), "migrate database from 3 to 4") {
+		t.Fatalf("migration error = %v", err)
+	}
+	db, err = sql.Open("sqlite", filepath.Join(directory, "center.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	version, err := sqliteSchemaVersion(context.Background(), db)
+	if err != nil || version != schemaBaselineVersion {
+		t.Fatalf("rolled-back schema version = %d, err = %v", version, err)
+	}
+	var kind string
+	if err := db.QueryRow(`SELECT kind FROM publications WHERE id = 'publication-v3'`).Scan(&kind); err != nil || kind != "invalid-legacy-kind" {
+		t.Fatalf("rolled-back publication kind = %q, err = %v", kind, err)
+	}
+	var temporaryTables int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('publications_v4', 'routes_v4')`).Scan(&temporaryTables); err != nil || temporaryTables != 0 {
+		t.Fatalf("temporary migration tables = %d, err = %v", temporaryTables, err)
+	}
+	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "center-v3-before-v4-*.db"))
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("failed migration backups = %v, err = %v", backups, err)
+	}
+}
+
+func createLegacyVersion3Database(t *testing.T, directory string) {
+	t.Helper()
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	statements := []string{
+		`INSERT INTO sites(id, organization_id, name, code, timezone, status, created_at, updated_at) VALUES('site-v3', '` + defaultOrganizationID + `', 'Legacy', 'legacy', 'UTC', 'active', '` + now + `', '` + now + `')`,
+		`INSERT INTO agents(id, name, credential_hash, version, status, enrolled_at, last_seen_at, site_id) VALUES('agent-v3', 'Legacy Agent', X'0102', '0.1.0-alpha.1', 'active', '` + now + `', '` + now + `', 'site-v3')`,
+		`INSERT INTO applications(id, name, node_id, site_id, app_key, status, created_at, updated_at) VALUES('application-v3', 'Legacy App', 'agent-v3', 'site-v3', 'legacy/app', 'running', '` + now + `', '` + now + `')`,
+		`INSERT INTO services(id, application_id, site_id, name, protocol, container_port, host_port, endpoint, source, status, created_at, updated_at) VALUES('service-v3', 'application-v3', 'site-v3', 'manager', 'http', 8080, 8080, '10.0.0.2:8080', 'catalog', 'ready', '` + now + `', '` + now + `')`,
+		`INSERT INTO publications(id, service_id, kind, gateway_node_id, hostname, dns_provider, status, created_at, updated_at) VALUES('publication-v3', 'service-v3', 'lan_gateway', 'agent-v3', 'legacy.example.test', 'manual', 'ready', '` + now + `', '` + now + `')`,
+		`INSERT INTO routes(id, publication_id, site_id, service_id, gateway_node_id, hostname, protocol, upstreams_json, status, created_at, updated_at) VALUES('route-v3', 'publication-v3', 'site-v3', 'service-v3', 'agent-v3', 'legacy.example.test', 'http', '[]', 'ready', '` + now + `', '` + now + `')`,
+	}
+	for _, statement := range statements {
+		if _, err := store.db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", filepath.Join(directory, "center.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	for _, statement := range []string{
+		`CREATE TABLE publications_v3 (
+			id TEXT PRIMARY KEY, service_id TEXT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+			kind TEXT NOT NULL CHECK(kind IN ('lan_gateway', 'headscale_gateway', 'public_direct', 'cloudflare_tunnel')),
+			gateway_node_id TEXT REFERENCES agents(id) ON DELETE RESTRICT, hostname TEXT NOT NULL,
+			dns_provider TEXT NOT NULL CHECK(dns_provider IN ('manual', 'cloudflare', 'headscale')),
+			dns_record_id TEXT NOT NULL DEFAULT '', tls_enabled INTEGER NOT NULL DEFAULT 0,
+			desired_revision INTEGER NOT NULL DEFAULT 1, applied_revision INTEGER NOT NULL DEFAULT 0,
+			status TEXT NOT NULL CHECK(status IN ('pending', 'applying', 'ready', 'degraded', 'failed', 'stopped')),
+			last_error TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+			UNIQUE(service_id, kind, hostname))`,
+		`INSERT INTO publications_v3 SELECT * FROM publications`,
+		`CREATE TABLE routes_v3 (
+			id TEXT PRIMARY KEY, publication_id TEXT NOT NULL REFERENCES publications_v3(id) ON DELETE CASCADE,
+			site_id TEXT NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+			service_id TEXT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+			gateway_node_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+			hostname TEXT NOT NULL, protocol TEXT NOT NULL CHECK(protocol IN ('http', 'https')),
+			upstreams_json BLOB NOT NULL, tls_enabled INTEGER NOT NULL DEFAULT 0,
+			status TEXT NOT NULL CHECK(status IN ('pending', 'applying', 'ready', 'failed')),
+			desired_revision INTEGER NOT NULL DEFAULT 0, applied_revision INTEGER NOT NULL DEFAULT 0,
+			last_error TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+			UNIQUE(publication_id, gateway_node_id))`,
+		`INSERT INTO routes_v3 SELECT * FROM routes`,
+		`DROP TABLE routes`,
+		`DROP TABLE publications`,
+		`ALTER TABLE publications_v3 RENAME TO publications`,
+		`ALTER TABLE routes_v3 RENAME TO routes`,
+		`DROP TABLE goose_db_version`,
+		`PRAGMA user_version = 3`,
+	} {
+		if _, err := tx.Exec(statement); err != nil {
+			t.Fatalf("prepare legacy schema: %v\n%s", err, statement)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO publications(
+		id, service_id, kind, gateway_node_id, hostname, dns_provider, status, created_at, updated_at
+	) VALUES('unsupported-v3', 'service-v3', 'public_shared_443', 'agent-v3', 'unsupported.example.test', 'manual', 'pending', ?, ?)`, now, now); err == nil {
+		t.Fatal("legacy publications constraint unexpectedly accepted public_shared_443")
+	}
+}

--- a/internal/center/schema.go
+++ b/internal/center/schema.go
@@ -2,16 +2,12 @@ package center
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 )
 
 const centerSchemaVersion = 4
 
-// initializeSchema deliberately supports only the current schema. Vastora is
-// pre-release and changing this model requires rebuilding the Center data
-// directory instead of carrying migration or compatibility code indefinitely.
 func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
 		return fmt.Errorf("center: enable WAL: %w", err)
@@ -20,16 +16,15 @@ func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 		return fmt.Errorf("center: enable foreign keys: %w", err)
 	}
 	if existing {
-		var version int
-		if err := s.db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
-			return fmt.Errorf("center: inspect schema version: %w", err)
-		}
-		if version != centerSchemaVersion {
-			return errors.New("center: database schema is obsolete; back up any needed data, then rebuild the Center data directory")
-		}
-		return nil
+		return s.migrateSchema(ctx)
 	}
+	if err := s.initializeCurrentSchema(ctx); err != nil {
+		return err
+	}
+	return s.initializeMigrationHistory(ctx, centerSchemaVersion)
+}
 
+func (s *Store) initializeCurrentSchema(ctx context.Context) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("center: begin schema initialization: %w", err)
@@ -310,7 +305,7 @@ func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := tx.ExecContext(ctx, `INSERT INTO organizations(id, name, created_at, updated_at) VALUES(?, 'Vastora', ?, ?)`, defaultOrganizationID, now, now); err != nil {
 		return fmt.Errorf("center: create default organization: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `PRAGMA user_version = 4`); err != nil {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`PRAGMA user_version = %d`, centerSchemaVersion)); err != nil {
 		return fmt.Errorf("center: set schema version: %w", err)
 	}
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## What changed

- add Goose-backed, embedded, forward-only Center database migrations
- bridge existing schema v3/v4 databases into migration history without resetting data
- add a transactional v3 to v4 migration that preserves Publications and Routes
- create a private SQLite snapshot before applying pending migrations
- verify schema version, foreign keys, and database integrity after migration
- reject newer schemas and leave failed migrations rolled back
- update project rules and architecture documentation for released schema upgrades

## Why

Published Center releases must be upgradeable without deleting accounts, locations, nodes, or application state. The previous pre-alpha behavior rejected every older schema and required rebuilding the Center data directory.

## Validation

- `GOCACHE=/tmp/vastora-go-build-cache make check`
- `GOCACHE=/tmp/vastora-go-build-cache make security-check`
- migration tests cover v3 data preservation, automatic backup, transactional rollback, and newer-schema rejection
