### PR TITLE
fix: harden upgrades and runtime lifecycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,3 +119,19 @@ jobs:
             dist/vastora-center-install.tar.gz.sha256 \
             --clobber
           gh release edit "$RELEASE_TAG" --draft=false
+
+      - name: Verify public installer endpoint
+        run: |
+          temporary_dir="$(mktemp -d)"
+          curl --retry 5 --retry-all-errors -fsSL \
+            https://vastora.petauron.com/install.sh \
+            -o "$temporary_dir/install.sh"
+          curl --retry 5 --retry-all-errors -fsSL \
+            https://vastora.petauron.com/vastora-center-install.tar.gz \
+            -o "$temporary_dir/vastora-center-install.tar.gz"
+          curl --retry 5 --retry-all-errors -fsSL \
+            https://vastora.petauron.com/vastora-center-install.tar.gz.sha256 \
+            -o "$temporary_dir/vastora-center-install.tar.gz.sha256"
+          sh -n "$temporary_dir/install.sh"
+          cd "$temporary_dir"
+          sha256sum --check vastora-center-install.tar.gz.sha256

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,12 @@ web-check:
 deployment-check:
 	sh -n install.sh
 	sh -n deploy/center/setup.sh
+	sh -n deploy/center/upgrade.sh
 	sh -n scripts/package-center-install.sh
 	sh -n scripts/test-center-install.sh
 	./install.sh --help >/dev/null
 	deploy/center/setup.sh --help >/dev/null
+	deploy/center/upgrade.sh --help >/dev/null
 	scripts/package-center-install.sh --help >/dev/null
 	scripts/test-center-install.sh
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and key.
 Released versions use one public Center bootstrap command:
 
 ```sh
-curl -LsSf https://github.com/petauron/vastora/releases/latest/download/install.sh | sudo sh -s -- center
+curl -LsSf https://vastora.petauron.com/install.sh | sudo sh -s -- center
 ```
 
 It downloads a verified release bundle and starts Center only on the server's
@@ -78,8 +78,9 @@ local URL starts the administrator, location, and network wizard without
 claiming public port 443. Users do not clone this repository or enter a
 container image digest. Each Center then generates its own short-lived,
 one-line Agent install command. See [`deploy/center`](deploy/center/README.md)
-for the complete bootstrap flow and local release packaging. The short address
-is `https://vastora.petauron.com/install.sh`.
+for the complete bootstrap flow and local release packaging. Running the same
+command again upgrades an existing managed installation in place while keeping
+its configuration.
 
 Released Center schemas upgrade in place through ordered, forward-only
 migrations. Center writes a private, consistent SQLite snapshot before applying

--- a/cmd/vastora/main.go
+++ b/cmd/vastora/main.go
@@ -186,6 +186,11 @@ func runCenter(arguments []string) error {
 		if err := store.SeedOfficialCatalog(context.Background(), catalogPayload); err != nil {
 			return err
 		}
+		maintenanceContext, stopMaintenance := context.WithCancel(context.Background())
+		defer stopMaintenance()
+		go store.RunPublicationCleanup(maintenanceContext, time.Minute, func(err error) {
+			fmt.Fprintf(os.Stderr, "Center publication cleanup: %v\n", err)
+		})
 		handler := center.NewServer(store, *webDir, *tlsCert != "").
 			WithOfficialCatalog(catalogPayload).
 			WithAgentBinaries(*agentBinariesDir).

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -3,10 +3,10 @@
 Vastora releases use one public installation command:
 
 ```sh
-curl -LsSf https://github.com/petauron/vastora/releases/latest/download/install.sh | sudo sh -s -- center
+curl -LsSf https://vastora.petauron.com/install.sh | sudo sh -s -- center
 ```
 
-The bootstrap downloads the latest Center install bundle and its SHA-256 file,
+The bootstrap downloads the newest complete Center release bundle and its SHA-256 file,
 verifies the archive, installs it under `/opt/vastora/center`, and starts Center
 with host networking on `127.0.0.1:8080`. It publishes no Docker port and does
 not require Git, a domain, a certificate, or an unused public port 443.
@@ -62,6 +62,13 @@ supports `--release-url` for a trusted mirror and `--install-dir` for a custom
 location. `setup.sh` supports `--bootstrap-port` and `--ssh-host` after the `--`
 separator.
 
+Run the same public command to upgrade. It keeps `.env`, replaces only managed
+deployment files, validates and pulls the new immutable image before changing
+anything, then starts Center and waits for health. If the new Center has already
+started, the upgrader never rolls the database or image backward automatically;
+inspect the printed logs and restore Center's pre-migration SQLite backup when a
+manual downgrade is required.
+
 ## Automated releases
 
 Merges to `main` update a Release Please pull request from conventional commit
@@ -69,18 +76,19 @@ messages. Merging that pull request creates a draft release, builds and pushes
 the `linux/amd64` Center image to GHCR, packages the installer
 against the image manifest digest, uploads all three assets, and publishes the
 release only after every step succeeds. Failed builds leave the release as a
-draft, so `releases/latest` never points to incomplete installer assets.
+draft. The Cloudflare Worker behind `vastora.petauron.com` selects the newest
+non-draft release containing all three assets, including prereleases, so it does
+not depend on GitHub's stable-only `releases/latest` endpoint.
 
 The GHCR package must allow unauthenticated pulls. The release job checks that
-before publishing. The planned short installer address is
-`https://vastora.petauron.com/install.sh`; keep using the GitHub Release URL
-until that endpoint has been configured and verified publicly.
+before publishing and then downloads the public short URLs and verifies the
+published checksum.
 
 Repository owners must enable **Settings → Actions → General → Allow GitHub
 Actions to create and approve pull requests** once. The first image publication
 may also require changing the new `vastora-center` package visibility to
 **Public** and rerunning only the failed `publish` job. Until that succeeds, the
-draft release is not exposed through `releases/latest`.
+draft release is not exposed by the installer Worker.
 
 To validate a later Headscale configuration change before restarting:
 

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+set -eu
+
+source_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+install_dir="/opt/vastora/center"
+
+usage() {
+  cat <<'EOF'
+Usage: ./upgrade.sh [--install-dir DIR]
+
+Replaces only Vastora-managed deployment files, preserves the existing Center
+configuration, pulls the immutable release image, and waits for Center health.
+Database migrations and their backups are handled by Center before it serves.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --install-dir) install_dir="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$install_dir" in
+  /*) ;;
+  *) echo "The installation directory must be absolute." >&2; exit 2 ;;
+esac
+if [ ! -f "$install_dir/.env" ] || [ ! -f "$install_dir/compose.yaml" ]; then
+  echo "$install_dir is not a complete Center installation." >&2
+  exit 1
+fi
+for required_file in setup.sh upgrade.sh compose.yaml release.env headscale/config.yaml headscale/policy.hujson; do
+  if [ ! -f "$source_dir/$required_file" ]; then
+    echo "The upgrade bundle is incomplete: missing $required_file" >&2
+    exit 1
+  fi
+done
+for required in awk curl docker install mktemp mv; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    echo "Required command is not installed: $required" >&2
+    exit 1
+  fi
+done
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Docker Compose v2 is required." >&2
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker is installed but the daemon is not running." >&2
+  exit 1
+fi
+
+new_image="$(awk -F= '$1 == "VASTORA_CENTER_IMAGE" {sub(/^[^=]*=/, ""); print; exit}' "$source_dir/release.env")"
+new_version="$(awk -F= '$1 == "VASTORA_VERSION" {sub(/^[^=]*=/, ""); print; exit}' "$source_dir/release.env")"
+case "$new_image" in
+  *@sha256:????????????????????????????????????????????????????????????????) ;;
+  *) echo "The release image is not pinned by a complete sha256 digest." >&2; exit 2 ;;
+esac
+image_digest="${new_image##*@sha256:}"
+case "$image_digest" in
+  *[!0-9a-fA-F]*) echo "The release image digest is invalid." >&2; exit 2 ;;
+esac
+
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-center-upgrade.XXXXXX")"
+candidate_env="$temporary_dir/.env"
+backup_dir="$(mktemp -d "${install_dir}.backup.XXXXXX")"
+files_changed=no
+center_started=no
+
+restore_files() {
+  for relative in setup.sh upgrade.sh compose.yaml release.env headscale/config.yaml headscale/policy.hujson .env; do
+    if [ -f "$backup_dir/$relative" ]; then
+      install -d -m 0755 "$(dirname "$install_dir/$relative")"
+      install -m 0644 "$backup_dir/$relative" "$install_dir/$relative"
+    elif [ "$relative" != ".env" ]; then
+      rm -f "$install_dir/$relative"
+    fi
+  done
+  chmod 0755 "$install_dir/setup.sh"
+  if [ -f "$install_dir/upgrade.sh" ]; then chmod 0755 "$install_dir/upgrade.sh"; fi
+}
+
+cleanup() {
+  status=$?
+  if [ "$status" -ne 0 ] && [ "$files_changed" = yes ] && [ "$center_started" = no ]; then
+    echo "Upgrade stopped before Center was started; restoring the previous managed files." >&2
+    restore_files
+  fi
+  rm -rf "$temporary_dir" "$backup_dir"
+  exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+awk -v image="$new_image" '
+  BEGIN { replaced = 0 }
+  /^VASTORA_CENTER_IMAGE=/ {
+    if (!replaced) print "VASTORA_CENTER_IMAGE=" image
+    replaced = 1
+    next
+  }
+  { print }
+  END { if (!replaced) print "VASTORA_CENTER_IMAGE=" image }
+' "$install_dir/.env" > "$candidate_env"
+chmod 0600 "$candidate_env"
+
+echo "Validating the new deployment with the existing configuration..."
+docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" config --quiet
+echo "Downloading the immutable Center image..."
+docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" pull center
+
+install -d -m 0755 "$backup_dir/headscale"
+for relative in setup.sh upgrade.sh compose.yaml release.env headscale/config.yaml headscale/policy.hujson .env; do
+  if [ -f "$install_dir/$relative" ]; then
+    install -d -m 0755 "$(dirname "$backup_dir/$relative")"
+    install -m 0644 "$install_dir/$relative" "$backup_dir/$relative"
+  fi
+done
+
+install -d -m 0755 "$install_dir/headscale"
+install -m 0755 "$source_dir/setup.sh" "$install_dir/setup.sh"
+install -m 0755 "$source_dir/upgrade.sh" "$install_dir/upgrade.sh"
+install -m 0644 "$source_dir/compose.yaml" "$install_dir/compose.yaml"
+install -m 0644 "$source_dir/release.env" "$install_dir/release.env"
+install -m 0644 "$source_dir/headscale/config.yaml" "$install_dir/headscale/config.yaml"
+install -m 0644 "$source_dir/headscale/policy.hujson" "$install_dir/headscale/policy.hujson"
+install -m 0600 "$candidate_env" "$install_dir/.env"
+files_changed=yes
+
+bootstrap_port="$(awk -F= '$1 == "VASTORA_CENTER_BOOTSTRAP_PORT" {sub(/^[^=]*=/, ""); print; exit}' "$install_dir/.env")"
+if [ -z "$bootstrap_port" ]; then bootstrap_port=8080; fi
+
+echo "Starting the updated Center..."
+cd "$install_dir"
+center_started=yes
+docker compose up -d center
+
+attempt=0
+until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 30 ]; then
+    echo "The updated Center did not become healthy." >&2
+    echo "The new files were kept because its database migration may already have run; an automatic downgrade would be unsafe." >&2
+    echo "Inspect: cd '$install_dir' && docker compose logs center" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+files_changed=no
+center_started=no
+echo "Vastora Center was updated successfully${new_version:+ to $new_version}."

--- a/deploy/installer-worker/README.md
+++ b/deploy/installer-worker/README.md
@@ -1,0 +1,10 @@
+# Installer redirect Worker
+
+`worker.js` is the source deployed as the `vastora-installer` Cloudflare Worker
+behind `vastora.petauron.com`. It selects the newest non-draft GitHub release
+that contains the installer, bundle, and checksum, including prereleases. The
+five-minute cache keeps GitHub API use low without coupling the public command
+to GitHub's stable-only `releases/latest` endpoint.
+
+The Worker contains no credentials. Keep the deployed source identical to this
+file and verify all three public paths after every release.

--- a/deploy/installer-worker/worker.js
+++ b/deploy/installer-worker/worker.js
@@ -1,0 +1,83 @@
+const repository = "petauron/vastora";
+const releaseAssets = new Set([
+  "install.sh",
+  "vastora-center-install.tar.gz",
+  "vastora-center-install.tar.gz.sha256",
+]);
+const cacheKey = new Request("https://vastora-installer.internal/selected-release");
+
+async function selectedRelease(ctx) {
+  const cache = caches.default;
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached.json();
+
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/releases?per_page=20`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "vastora-installer-worker",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) throw new Error(`GitHub releases returned ${response.status}`);
+
+  const releases = await response.json();
+  const release = releases.find((candidate) => {
+    if (candidate.draft || !/^v[0-9A-Za-z._-]+$/.test(candidate.tag_name)) return false;
+    const names = new Set(candidate.assets.map((asset) => asset.name));
+    return [...releaseAssets].every((name) => names.has(name));
+  });
+  if (!release) throw new Error("No complete Vastora release is available");
+
+  const result = { tag: release.tag_name };
+  const cachedResponse = Response.json(result, {
+    headers: { "Cache-Control": "public, max-age=300" },
+  });
+  ctx.waitUntil(cache.put(cacheKey, cachedResponse));
+  return result;
+}
+
+function responseHeaders() {
+  return {
+    "Cache-Control": "public, max-age=300",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+  };
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method not allowed\n", {
+        status: 405,
+        headers: { ...responseHeaders(), Allow: "GET, HEAD" },
+      });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname === "/") {
+      return Response.redirect(`https://github.com/${repository}`, 302);
+    }
+    const asset = url.pathname.slice(1);
+    if (!releaseAssets.has(asset)) {
+      return new Response("Not found\n", { status: 404, headers: responseHeaders() });
+    }
+
+    try {
+      const release = await selectedRelease(ctx);
+      const location = `https://github.com/${repository}/releases/download/${encodeURIComponent(release.tag)}/${asset}`;
+      return new Response(null, {
+        status: 302,
+        headers: { ...responseHeaders(), Location: location },
+      });
+    } catch (error) {
+      console.error("Unable to select installer release", error);
+      return new Response("No complete Vastora release is currently available.\n", {
+        status: 503,
+        headers: { ...responseHeaders(), "Retry-After": "300" },
+      });
+    }
+  },
+};

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-default_release_url="https://github.com/petauron/vastora/releases/latest/download/vastora-center-install.tar.gz"
+default_release_url="https://vastora.petauron.com/vastora-center-install.tar.gz"
 release_url="$default_release_url"
 install_dir="/opt/vastora/center"
 
@@ -13,7 +13,7 @@ Installs the verified Vastora Center release bundle on loopback, then prints an
 SSH tunnel command for the first-run wizard. Agent commands come from Center.
 
 Examples:
-  curl -LsSf https://github.com/petauron/vastora/releases/latest/download/install.sh | sudo sh -s -- center
+  curl -LsSf https://vastora.petauron.com/install.sh | sudo sh -s -- center
   ./install.sh center -- --ssh-host center.example.com
 EOF
 }
@@ -58,12 +58,6 @@ case "$install_dir" in
   /*) ;;
   *) echo "The installation directory must be an absolute path." >&2; exit 2 ;;
 esac
-if [ -e "$install_dir" ]; then
-  echo "Center installation already exists at $install_dir; no files were changed." >&2
-  echo "Inspect it there before retrying setup or performing an upgrade." >&2
-  exit 1
-fi
-
 for required in curl tar mktemp install awk dirname mv; do
   if ! command -v "$required" >/dev/null 2>&1; then
     echo "Required command is not installed: $required" >&2
@@ -124,13 +118,29 @@ fi
 install -d -m 0755 "$(dirname "$install_dir")"
 staging="$(mktemp -d "${install_dir}.new.XXXXXX")"
 tar -xzf "$archive" -C "$staging"
-for required_file in setup.sh compose.yaml release.env headscale/config.yaml headscale/policy.hujson; do
+for required_file in setup.sh upgrade.sh compose.yaml release.env headscale/config.yaml headscale/policy.hujson; do
   if [ ! -f "$staging/$required_file" ]; then
     echo "The Center release is incomplete: missing $required_file" >&2
     exit 1
   fi
 done
 chmod 0755 "$staging/setup.sh"
+chmod 0755 "$staging/upgrade.sh"
+
+if [ -d "$install_dir" ]; then
+  if [ ! -f "$install_dir/.env" ]; then
+    echo "$install_dir exists but is not a managed Center installation; no files were changed." >&2
+    exit 1
+  fi
+  echo "Existing Center installation found; upgrading it in place..."
+  "$staging/upgrade.sh" --install-dir "$install_dir"
+  exit 0
+fi
+if [ -e "$install_dir" ]; then
+  echo "$install_dir exists but is not a directory; no files were changed." >&2
+  exit 1
+fi
+
 mv "$staging" "$install_dir"
 staging=""
 

--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -204,12 +204,14 @@ func (c Client) RunHeartbeats(ctx context.Context, store *Store, interval time.D
 	if interval < time.Second {
 		interval = 15 * time.Second
 	}
+	restoreContext, restoreCancel := context.WithTimeout(ctx, 5*time.Minute)
+	if gatewayErr := restoreGatewayState(restoreContext, store, c.GatewayDriver); gatewayErr != nil && report != nil {
+		report(gatewayErr)
+	}
+	restoreCancel()
 	send := func() {
 		requestContext, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer cancel()
-		if gatewayErr := restoreGatewayState(requestContext, store, c.GatewayDriver); gatewayErr != nil && report != nil {
-			report(gatewayErr)
-		}
 		observeErr, err := c.heartbeat(requestContext, store)
 		if observeErr != nil && report != nil {
 			report(observeErr)

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -8,6 +8,9 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
+
+	"github.com/petauron/vastora/internal/gateway"
 )
 
 func TestObserveThreeXUISynchronizesEnabledInboundsWithoutChangingThem(t *testing.T) {
@@ -51,6 +54,54 @@ func TestObserveThreeXUISynchronizesEnabledInboundsWithoutChangingThem(t *testin
 	}
 	if observed[1].Name != "inbound-8" || observed[1].AppProtocol != "vmess/ws" || observed[1].Enabled {
 		t.Fatalf("disabled inbound state was not preserved: %#v", observed[1])
+	}
+}
+
+func TestHeartbeatsRestoreGatewayStateOnlyAtStartup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	heartbeats := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/agents/agent-1/heartbeat":
+			heartbeats++
+			response.Header().Set("Content-Type", "application/json")
+			_, _ = response.Write([]byte(`{}`))
+			if heartbeats == 2 {
+				cancel()
+			}
+		case "/api/v1/agents/agent-1/tasks/next":
+			response.Header().Set("Content-Type", "application/json")
+			_, _ = response.Write([]byte(`{"task":null}`))
+		default:
+			t.Fatalf("unexpected request path: %s", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "agent-1", Name: "test", CenterURL: server.URL, Credential: "credential"}); err != nil {
+		t.Fatal(err)
+	}
+	state := gateway.DesiredState{Revision: 3, Listeners: []gateway.Listener{{Kind: "lan", Address: "192.0.2.10", HTTPPort: 80, HTTPSPort: 443}}}
+	if _, err := store.RecordGatewayState(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	driver := &fakeGatewayDriver{}
+	(Client{GatewayDriver: driver}).RunHeartbeats(ctx, store, time.Second, func(err error) {
+		if ctx.Err() == nil {
+			t.Errorf("heartbeat error: %v", err)
+		}
+	})
+	if heartbeats != 2 {
+		t.Fatalf("expected two heartbeat cycles, got %d", heartbeats)
+	}
+	if len(driver.applied) != 1 || driver.applied[0].Revision != 3 {
+		t.Fatalf("persisted gateway state was restored %d times: %#v", len(driver.applied), driver.applied)
 	}
 }
 

--- a/internal/agent/layer4_gateway.go
+++ b/internal/agent/layer4_gateway.go
@@ -52,7 +52,9 @@ func (driver *ManagedGatewayDriver) ApplyConfiguration(ctx context.Context, desi
 	driver.mu.RUnlock()
 	if err := driver.apply(ctx, desired.Sorted()); err != nil {
 		if previous.Revision > 0 {
-			_ = driver.apply(ctx, previous)
+			if rollbackErr := driver.apply(ctx, previous); rollbackErr != nil {
+				return errors.Join(err, fmt.Errorf("agent: restore previous gateway revision %d: %w", previous.Revision, rollbackErr))
+			}
 		}
 		return err
 	}

--- a/internal/center/dashboard.go
+++ b/internal/center/dashboard.go
@@ -1,0 +1,101 @@
+package center
+
+import (
+	"net/http"
+)
+
+type DashboardStatusView struct {
+	Version                 string `json:"version"`
+	CatalogSources          int    `json:"catalogSources"`
+	CatalogApps             int    `json:"catalogApps"`
+	Agents                  int    `json:"agents"`
+	Deployments             int    `json:"deployments"`
+	AgentInstallerAvailable bool   `json:"agentInstallerAvailable"`
+	AgentConnectionMode     string `json:"agentConnectionMode"`
+	AgentConnectURL         string `json:"agentConnectUrl"`
+}
+
+type DashboardView struct {
+	Status        DashboardStatusView `json:"status"`
+	Sources       []CatalogSource     `json:"sources"`
+	Apps          []AppView           `json:"apps"`
+	Agents        []AgentView         `json:"agents"`
+	Deployments   []DeploymentView    `json:"deployments"`
+	Organizations []OrganizationView  `json:"organizations"`
+	Sites         []SiteView          `json:"sites"`
+	Applications  []ApplicationView   `json:"applications"`
+	Services      []ServiceView       `json:"services"`
+	Publications  []PublicationView   `json:"publications"`
+	Routes        []RouteView         `json:"routes"`
+	Integrations  []IntegrationView   `json:"integrations"`
+	Actions       []ActionView        `json:"actions"`
+}
+
+func (s *Server) handleDashboard(writer http.ResponseWriter, request *http.Request) {
+	ctx := request.Context()
+	networkConfig, err := s.store.CenterNetworkConfig(ctx)
+	if err != nil {
+		writeError(writer, http.StatusConflict, err)
+		return
+	}
+	value := DashboardView{}
+	if value.Sources, err = s.store.ListSources(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Apps, err = s.store.ListApps(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Agents, err = s.store.ListAgents(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Deployments, err = s.store.ListDeployments(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Organizations, err = s.store.ListOrganizations(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Sites, err = s.store.ListSites(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Applications, err = s.store.ListApplications(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Services, err = s.store.ListServices(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Publications, err = s.store.listPublications(ctx, value.Apps); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Routes, err = s.store.ListRoutes(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Integrations, err = s.store.ListIntegrations(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	if value.Actions, err = s.store.ListActions(ctx); err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	value.Status = DashboardStatusView{
+		Version:                 Version,
+		CatalogSources:          len(value.Sources),
+		CatalogApps:             len(value.Apps),
+		Agents:                  countActiveAgents(value.Agents),
+		Deployments:             len(value.Deployments),
+		AgentInstallerAvailable: s.agentInstallerAvailable(),
+		AgentConnectionMode:     networkConfig.AgentConnectionMode,
+		AgentConnectURL:         networkConfig.AgentConnectURL,
+	}
+	writeJSON(writer, http.StatusOK, value)
+}

--- a/internal/center/deployment.go
+++ b/internal/center/deployment.go
@@ -691,7 +691,9 @@ func (s *Store) CompleteTask(ctx context.Context, agentID, credential, taskID st
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	_ = s.cleanupStoppedPublications(ctx, publicationCleanups)
+	if err := s.cleanupStoppedPublications(ctx, publicationCleanups); err != nil {
+		return fmt.Errorf("center: record publication cleanup state: %w", err)
+	}
 	return nil
 }
 

--- a/internal/center/migrations/00005_publication_cleanup.sql
+++ b/internal/center/migrations/00005_publication_cleanup.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE publications ADD COLUMN cleanup_pending INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE publications ADD COLUMN cleanup_attempt INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE publications ADD COLUMN cleanup_retry_at TEXT NOT NULL DEFAULT '';
+PRAGMA user_version = 5;

--- a/internal/center/migrations_test.go
+++ b/internal/center/migrations_test.go
@@ -5,10 +5,123 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 )
+
+type schemaColumn struct {
+	Name, Type, Default string
+	NotNull, PrimaryKey int
+}
+
+type schemaIndex struct {
+	Name            string
+	Unique, Partial int
+	Columns         []string
+}
+
+type schemaTable struct {
+	Columns []schemaColumn
+	Indexes []schemaIndex
+}
+
+func TestFreshAndMigratedDatabasesHaveEquivalentSchema(t *testing.T) {
+	fresh, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Close()
+
+	migratedDirectory := t.TempDir()
+	createLegacyVersion3Database(t, migratedDirectory)
+	migrated, err := Open(migratedDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrated.Close()
+
+	freshShape := databaseSchemaShape(t, fresh.db)
+	migratedShape := databaseSchemaShape(t, migrated.db)
+	if !reflect.DeepEqual(freshShape, migratedShape) {
+		t.Fatalf("fresh and migrated schema differ:\nfresh=%#v\nmigrated=%#v", freshShape, migratedShape)
+	}
+}
+
+func databaseSchemaShape(t *testing.T, db *sql.DB) map[string]schemaTable {
+	t.Helper()
+	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatal(err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	shape := make(map[string]schemaTable, len(tables))
+	for _, tableName := range tables {
+		value := schemaTable{}
+		columnRows, err := db.Query(`SELECT name, type, "notnull", COALESCE(dflt_value, ''), pk FROM pragma_table_info(?) ORDER BY cid`, tableName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for columnRows.Next() {
+			var column schemaColumn
+			if err := columnRows.Scan(&column.Name, &column.Type, &column.NotNull, &column.Default, &column.PrimaryKey); err != nil {
+				t.Fatal(err)
+			}
+			value.Columns = append(value.Columns, column)
+		}
+		if err := columnRows.Close(); err != nil {
+			t.Fatal(err)
+		}
+		sort.Slice(value.Columns, func(i, j int) bool { return value.Columns[i].Name < value.Columns[j].Name })
+		indexRows, err := db.Query(`SELECT name, "unique", partial FROM pragma_index_list(?)`, tableName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		indexes := []schemaIndex{}
+		for indexRows.Next() {
+			var index schemaIndex
+			if err := indexRows.Scan(&index.Name, &index.Unique, &index.Partial); err != nil {
+				t.Fatal(err)
+			}
+			indexes = append(indexes, index)
+		}
+		if err := indexRows.Close(); err != nil {
+			t.Fatal(err)
+		}
+		for _, index := range indexes {
+			columnNames, err := db.Query(`SELECT name FROM pragma_index_info(?) ORDER BY seqno`, index.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for columnNames.Next() {
+				var name string
+				if err := columnNames.Scan(&name); err != nil {
+					t.Fatal(err)
+				}
+				index.Columns = append(index.Columns, name)
+			}
+			if err := columnNames.Close(); err != nil {
+				t.Fatal(err)
+			}
+			value.Indexes = append(value.Indexes, index)
+		}
+		sort.Slice(value.Indexes, func(i, j int) bool { return value.Indexes[i].Name < value.Indexes[j].Name })
+		shape[tableName] = value
+	}
+	return shape
+}
 
 func TestOpenMigratesVersion3WithoutLosingPublicationsOrRoutes(t *testing.T) {
 	directory := t.TempDir()
@@ -47,7 +160,7 @@ func TestOpenMigratesVersion3WithoutLosingPublicationsOrRoutes(t *testing.T) {
 	) VALUES('publication-v4', 'service-v3', 'public_shared_443', 'agent-v3', 'raw.example.test', 'manual', 'pending', ?, ?)`, time.Now().UTC().Format(time.RFC3339Nano), time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
 		t.Fatalf("new publication kind was not accepted: %v", err)
 	}
-	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "center-v3-before-v4-*.db"))
+	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "center-v3-before-v5-*.db"))
 	if err != nil || len(backups) != 1 {
 		t.Fatalf("migration backups = %v, err = %v", backups, err)
 	}
@@ -75,10 +188,10 @@ func TestOpenRejectsDatabaseFromANewerRelease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.db.Exec(`INSERT INTO goose_db_version(version_id, is_applied) VALUES(5, 1)`); err != nil {
+	if _, err := store.db.Exec(`INSERT INTO goose_db_version(version_id, is_applied) VALUES(6, 1)`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.db.Exec(`PRAGMA user_version = 5`); err != nil {
+	if _, err := store.db.Exec(`PRAGMA user_version = 6`); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Close(); err != nil {
@@ -112,7 +225,7 @@ func TestFailedMigrationRollsBackSchemaAndLeavesBackup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := Open(directory); err == nil || !strings.Contains(err.Error(), "migrate database from 3 to 4") {
+	if _, err := Open(directory); err == nil || !strings.Contains(err.Error(), "migrate database from 3 to 5") {
 		t.Fatalf("migration error = %v", err)
 	}
 	db, err = sql.Open("sqlite", filepath.Join(directory, "center.db"))
@@ -132,7 +245,7 @@ func TestFailedMigrationRollsBackSchemaAndLeavesBackup(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('publications_v4', 'routes_v4')`).Scan(&temporaryTables); err != nil || temporaryTables != 0 {
 		t.Fatalf("temporary migration tables = %d, err = %v", temporaryTables, err)
 	}
-	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "center-v3-before-v4-*.db"))
+	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "center-v3-before-v5-*.db"))
 	if err != nil || len(backups) != 1 {
 		t.Fatalf("failed migration backups = %v, err = %v", backups, err)
 	}
@@ -187,7 +300,8 @@ func createLegacyVersion3Database(t *testing.T, directory string) {
 			status TEXT NOT NULL CHECK(status IN ('pending', 'applying', 'ready', 'degraded', 'failed', 'stopped')),
 			last_error TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
 			UNIQUE(service_id, kind, hostname))`,
-		`INSERT INTO publications_v3 SELECT * FROM publications`,
+		`INSERT INTO publications_v3(id, service_id, kind, gateway_node_id, hostname, dns_provider, dns_record_id, tls_enabled, desired_revision, applied_revision, status, last_error, created_at, updated_at)
+		 SELECT id, service_id, kind, gateway_node_id, hostname, dns_provider, dns_record_id, tls_enabled, desired_revision, applied_revision, status, last_error, created_at, updated_at FROM publications`,
 		`CREATE TABLE routes_v3 (
 			id TEXT PRIMARY KEY, publication_id TEXT NOT NULL REFERENCES publications_v3(id) ON DELETE CASCADE,
 			site_id TEXT NOT NULL REFERENCES sites(id) ON DELETE CASCADE,

--- a/internal/center/observations.go
+++ b/internal/center/observations.go
@@ -119,7 +119,9 @@ func (s *Store) stopServicePublications(ctx context.Context, tx *sql.Tx, service
 	if err := rows.Close(); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1, last_error = '', updated_at = ? WHERE service_id = ? AND status <> 'stopped'`, now.Format(time.RFC3339Nano), serviceID); err != nil {
+	if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1,
+		cleanup_pending = CASE WHEN dns_record_id <> '' OR kind = 'cloudflare_tunnel' OR dns_provider = 'headscale' THEN 1 ELSE 0 END,
+		cleanup_attempt = 0, cleanup_retry_at = '', last_error = '', updated_at = ? WHERE service_id = ? AND status <> 'stopped'`, now.Format(time.RFC3339Nano), serviceID); err != nil {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM routes WHERE service_id = ?`, serviceID); err != nil {

--- a/internal/center/orchestration.go
+++ b/internal/center/orchestration.go
@@ -83,7 +83,10 @@ func (s *Store) completeApplication(ctx context.Context, tx *sql.Tx, deploymentI
 		if _, err := tx.ExecContext(ctx, `UPDATE services SET status = 'stopped', updated_at = ? WHERE application_id = ?`, now.Format(time.RFC3339Nano), applicationID); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1, last_error = '', updated_at = ? WHERE service_id IN (SELECT id FROM services WHERE application_id = ?) AND status <> 'stopped'`, now.Format(time.RFC3339Nano), applicationID); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1,
+			cleanup_pending = CASE WHEN dns_record_id <> '' OR kind = 'cloudflare_tunnel' OR dns_provider = 'headscale' THEN 1 ELSE 0 END,
+			cleanup_attempt = 0, cleanup_retry_at = '', last_error = '', updated_at = ?
+			WHERE service_id IN (SELECT id FROM services WHERE application_id = ?) AND status <> 'stopped'`, now.Format(time.RFC3339Nano), applicationID); err != nil {
 			return err
 		}
 		if err := s.queueAffectedGateways(ctx, tx, applicationID, now); err != nil {
@@ -167,7 +170,9 @@ func (s *Store) completeApplication(ctx context.Context, tx *sql.Tx, deploymentI
 		if _, err := tx.ExecContext(ctx, `UPDATE services SET status = 'stopped', updated_at = ? WHERE id = ?`, now.Format(time.RFC3339Nano), service.id); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1, last_error = '', updated_at = ? WHERE service_id = ? AND status <> 'stopped'`, now.Format(time.RFC3339Nano), service.id); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1,
+			cleanup_pending = CASE WHEN dns_record_id <> '' OR kind = 'cloudflare_tunnel' OR dns_provider = 'headscale' THEN 1 ELSE 0 END,
+			cleanup_attempt = 0, cleanup_retry_at = '', last_error = '', updated_at = ? WHERE service_id = ? AND status <> 'stopped'`, now.Format(time.RFC3339Nano), service.id); err != nil {
 			return err
 		}
 		*cleanups = append(*cleanups, values...)

--- a/internal/center/orchestration_test.go
+++ b/internal/center/orchestration_test.go
@@ -84,6 +84,13 @@ func TestApplicationInstallAndPublicationAreIndependent(t *testing.T) {
 	if stopped != 1 || ready != 1 {
 		t.Fatalf("stopping one publication affected its sibling: %#v", publications)
 	}
+	reactivated, err := store.CreatePublication(ctx, PublicationInput{ServiceID: services[0].ID, Kind: publicationLAN, GatewayNodeID: node.ID, Hostname: "cpa.lan.example.test", DNSProvider: "manual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reactivated.ID != lan.ID || reactivated.Status != "pending" || reactivated.DesiredRevision <= lan.DesiredRevision {
+		t.Fatalf("stopped publication was not safely reactivated: before=%#v after=%#v", lan, reactivated)
+	}
 }
 
 func TestShared443AddsHAProxyInFrontOfCaddy(t *testing.T) {
@@ -198,6 +205,58 @@ func TestUninstallRemovesManagedHeadscaleDNS(t *testing.T) {
 	}
 	if !foundRemoval {
 		t.Fatalf("automatic DNS cleanup was not recorded in Actions: %#v", actions)
+	}
+}
+
+func TestFailedPublicationCleanupIsPersistedAndRetried(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	configureBuiltinHeadscaleForTest(t, store)
+	node := enrollOrchestrationNode(t, store, "cleanup-node", NodeCapabilities{Docker: true, Gateway: true}, []networking.Candidate{{Address: "100.64.0.41", Interface: "tailscale0", Family: "ipv4", Kind: networking.KindHeadscale}}, networking.Profile{ServiceAddress: "100.64.0.41", HeadscaleAddress: "100.64.0.41", EnabledKinds: []string{networking.KindHeadscale}})
+	if _, err := store.UpdateSite(ctx, testSiteID(t, store), SiteInput{Name: "Cleanup", Code: "cleanup", Timezone: "UTC", GatewayNodes: []string{node.ID}}); err != nil {
+		t.Fatal(err)
+	}
+	completeNextTask(t, store, node, "gateway.component.apply", nil)
+	installCPA(t, store, node, "100.64.0.41")
+	services, err := store.ListServices(ctx)
+	if err != nil || len(services) != 1 {
+		t.Fatalf("unexpected services: %#v err=%v", services, err)
+	}
+	publication, err := store.CreatePublication(ctx, PublicationInput{ServiceID: services[0].ID, Kind: publicationHeadscale, GatewayNodeID: node.ID, Hostname: "retry.tail.example.test", DNSProvider: "headscale"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalDataDir := store.dataDir
+	blocker := t.TempDir() + "/not-a-directory"
+	if err := os.WriteFile(blocker, []byte("block"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store.dataDir = blocker
+	if err := store.StopPublication(ctx, publication.ID); err != nil {
+		t.Fatalf("durably queued cleanup should not fail the stop operation: %v", err)
+	}
+	var pending, attempt int
+	var retryAt string
+	if err := store.db.QueryRowContext(ctx, `SELECT cleanup_pending, cleanup_attempt, cleanup_retry_at FROM publications WHERE id = ?`, publication.ID).Scan(&pending, &attempt, &retryAt); err != nil {
+		t.Fatal(err)
+	}
+	if pending != 1 || attempt != 1 || retryAt == "" {
+		t.Fatalf("failed cleanup was not scheduled: pending=%d attempt=%d retryAt=%q", pending, attempt, retryAt)
+	}
+
+	store.dataDir = originalDataDir
+	future := time.Now().UTC().Add(2 * time.Minute)
+	store.now = func() time.Time { return future }
+	if err := store.retryPublicationCleanups(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT cleanup_pending, cleanup_attempt, cleanup_retry_at FROM publications WHERE id = ?`, publication.ID).Scan(&pending, &attempt, &retryAt); err != nil {
+		t.Fatal(err)
+	}
+	if pending != 0 || attempt != 0 || retryAt != "" {
+		t.Fatalf("successful cleanup retry was not finalized: pending=%d attempt=%d retryAt=%q", pending, attempt, retryAt)
 	}
 }
 

--- a/internal/center/publication.go
+++ b/internal/center/publication.go
@@ -199,19 +199,39 @@ func (s *Store) CreatePublication(ctx context.Context, input PublicationInput) (
 		}
 	}
 
-	id, err := randomToken(18)
-	if err != nil {
-		return PublicationView{}, err
-	}
 	now := s.now().UTC()
 	tlsEnabled := webService && (input.Kind == publicationPublic || input.Kind == publicationCloudflare)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO publications(id, service_id, kind, gateway_node_id, hostname, dns_provider, tls_enabled, status, created_at, updated_at)
-		VALUES(?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`, id, input.ServiceID, input.Kind, nullableString(gatewayID), input.Hostname, input.DNSProvider, tlsEnabled, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-		return PublicationView{}, fmt.Errorf("center: create publication: %w", err)
+	id, revision := "", int64(1)
+	var existingStatus string
+	var cleanupPending int
+	err = tx.QueryRowContext(ctx, `SELECT id, status, cleanup_pending, desired_revision FROM publications WHERE service_id = ? AND kind = ? AND hostname = ?`, input.ServiceID, input.Kind, input.Hostname).Scan(&id, &existingStatus, &cleanupPending, &revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		id, err = randomToken(18)
+		if err != nil {
+			return PublicationView{}, err
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO publications(id, service_id, kind, gateway_node_id, hostname, dns_provider, tls_enabled, status, created_at, updated_at)
+			VALUES(?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`, id, input.ServiceID, input.Kind, nullableString(gatewayID), input.Hostname, input.DNSProvider, tlsEnabled, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			return PublicationView{}, fmt.Errorf("center: create publication: %w", err)
+		}
+		revision = 1
+	} else if err != nil {
+		return PublicationView{}, err
+	} else {
+		if existingStatus != "stopped" {
+			return PublicationView{}, errors.New("center: this service access entry already exists")
+		}
+		if cleanupPending != 0 {
+			return PublicationView{}, errors.New("center: the previous access entry is still removing external resources; retry after cleanup succeeds")
+		}
+		revision++
+		if _, err := tx.ExecContext(ctx, `UPDATE publications SET gateway_node_id = ?, dns_provider = ?, dns_record_id = '', tls_enabled = ?, desired_revision = ?, status = 'pending', last_error = '', cleanup_attempt = 0, cleanup_retry_at = '', updated_at = ? WHERE id = ?`, nullableString(gatewayID), input.DNSProvider, tlsEnabled, revision, now.Format(time.RFC3339Nano), id); err != nil {
+			return PublicationView{}, fmt.Errorf("center: reactivate publication: %w", err)
+		}
 	}
-	dnsTaskID := dnsTaskID(id, 1)
+	taskID := dnsTaskID(id, revision)
 	if input.DNSProvider != "manual" {
-		if err := s.recordTaskEvent(ctx, tx, dnsTaskID, gatewayID, "dns.record.apply", 1, "queued", input.DNSProvider+" DNS record queued"); err != nil {
+		if err := s.recordTaskEvent(ctx, tx, taskID, gatewayID, "dns.record.apply", revision, "queued", input.DNSProvider+" DNS record queued"); err != nil {
 			return PublicationView{}, err
 		}
 	}
@@ -230,31 +250,46 @@ func (s *Store) CreatePublication(ctx context.Context, input PublicationInput) (
 	if err := tx.Commit(); err != nil {
 		return PublicationView{}, err
 	}
-	if input.DNSProvider == "cloudflare" {
-		if err := s.reconcileCloudflarePublication(ctx, id); err != nil {
-			message := strings.TrimSpace(err.Error())
-			if len(message) > 1024 {
-				message = message[:1024]
-			}
-			_, _ = s.db.ExecContext(ctx, `UPDATE publications SET status = 'failed', last_error = ?, updated_at = ? WHERE id = ?`, message, s.now().UTC().Format(time.RFC3339Nano), id)
-			_ = s.recordStandaloneTaskEvent(ctx, dnsTaskID, gatewayID, "dns.record.apply", 1, "failed", message)
-		} else {
-			_ = s.recordStandaloneTaskEvent(ctx, dnsTaskID, gatewayID, "dns.record.apply", 1, "succeeded", "Cloudflare DNS record applied")
-		}
-	}
-	if input.DNSProvider == "headscale" {
-		if err := s.reconcileHeadscaleDNS(ctx); err != nil {
-			message := strings.TrimSpace(err.Error())
-			if len(message) > 1024 {
-				message = message[:1024]
-			}
-			_, _ = s.db.ExecContext(ctx, `UPDATE publications SET status = 'failed', last_error = ?, updated_at = ? WHERE id = ?`, message, s.now().UTC().Format(time.RFC3339Nano), id)
-			_ = s.recordStandaloneTaskEvent(ctx, dnsTaskID, gatewayID, "dns.record.apply", 1, "failed", message)
-		} else {
-			_ = s.recordStandaloneTaskEvent(ctx, dnsTaskID, gatewayID, "dns.record.apply", 1, "succeeded", "Headscale DNS records applied")
-		}
+	if _, err := s.reconcilePublicationDNS(ctx, id, gatewayID, input.DNSProvider, revision); err != nil {
+		return PublicationView{}, err
 	}
 	return s.Publication(ctx, id)
+}
+
+func (s *Store) reconcilePublicationDNS(ctx context.Context, id, gatewayID, provider string, revision int64) (bool, error) {
+	var operationErr error
+	successMessage := ""
+	switch provider {
+	case "cloudflare":
+		operationErr = s.reconcileCloudflarePublication(ctx, id)
+		successMessage = "Cloudflare DNS record applied"
+	case "headscale":
+		operationErr = s.reconcileHeadscaleDNS(ctx)
+		successMessage = "Headscale DNS records applied"
+	default:
+		return true, nil
+	}
+	taskID := dnsTaskID(id, revision)
+	if operationErr != nil {
+		message := strings.TrimSpace(operationErr.Error())
+		if len(message) > 1024 {
+			message = message[:1024]
+		}
+		if _, err := s.db.ExecContext(ctx, `UPDATE publications SET status = 'failed', last_error = ?, updated_at = ? WHERE id = ? AND status <> 'stopped'`, message, s.now().UTC().Format(time.RFC3339Nano), id); err != nil {
+			return false, errors.Join(operationErr, err)
+		}
+		if err := s.recordStandaloneTaskEvent(ctx, taskID, gatewayID, "dns.record.apply", revision, "failed", message); err != nil {
+			return false, errors.Join(operationErr, err)
+		}
+		return false, nil
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE publications SET status = 'pending', last_error = '', updated_at = ? WHERE id = ? AND status = 'failed'`, s.now().UTC().Format(time.RFC3339Nano), id); err != nil {
+		return false, err
+	}
+	if err := s.recordStandaloneTaskEvent(ctx, taskID, gatewayID, "dns.record.apply", revision, "succeeded", successMessage); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *Store) StopPublication(ctx context.Context, id string) error {
@@ -263,16 +298,21 @@ func (s *Store) StopPublication(ctx context.Context, id string) error {
 		return err
 	}
 	defer tx.Rollback()
-	var kind, dnsProvider, dnsRecordID string
+	var kind, dnsProvider, dnsRecordID, status string
 	var revision int64
 	var gatewayID sql.NullString
-	if err := tx.QueryRowContext(ctx, `SELECT kind, gateway_node_id, dns_provider, dns_record_id, desired_revision FROM publications WHERE id = ?`, id).Scan(&kind, &gatewayID, &dnsProvider, &dnsRecordID, &revision); errors.Is(err, sql.ErrNoRows) {
+	if err := tx.QueryRowContext(ctx, `SELECT kind, gateway_node_id, dns_provider, dns_record_id, desired_revision, status FROM publications WHERE id = ?`, id).Scan(&kind, &gatewayID, &dnsProvider, &dnsRecordID, &revision, &status); errors.Is(err, sql.ErrNoRows) {
 		return errors.New("center: publication not found")
 	} else if err != nil {
 		return err
 	}
+	if status == "stopped" {
+		return errors.New("center: publication is already stopped")
+	}
 	now := s.now().UTC()
-	if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1, last_error = '', updated_at = ? WHERE id = ?`, now.Format(time.RFC3339Nano), id); err != nil {
+	if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'stopped', desired_revision = desired_revision + 1,
+		cleanup_pending = CASE WHEN dns_record_id <> '' OR kind = 'cloudflare_tunnel' OR dns_provider = 'headscale' THEN 1 ELSE 0 END,
+		cleanup_attempt = 0, cleanup_retry_at = '', last_error = '', updated_at = ? WHERE id = ?`, now.Format(time.RFC3339Nano), id); err != nil {
 		return err
 	}
 	if gatewayID.Valid {
@@ -291,103 +331,8 @@ func (s *Store) StopPublication(ctx context.Context, id string) error {
 	return s.cleanupStoppedPublications(ctx, []publicationCleanup{{ID: id, Kind: kind, GatewayID: gatewayID.String, DNSProvider: dnsProvider, DNSRecordID: dnsRecordID, Revision: revision + 1}})
 }
 
-type publicationCleanup struct {
-	ID          string
-	Kind        string
-	GatewayID   string
-	DNSProvider string
-	DNSRecordID string
-	Revision    int64
-}
-
-func publicationCleanups(rows *sql.Rows) ([]publicationCleanup, error) {
-	defer rows.Close()
-	values := []publicationCleanup{}
-	for rows.Next() {
-		var value publicationCleanup
-		if err := rows.Scan(&value.ID, &value.Kind, &value.GatewayID, &value.DNSProvider, &value.DNSRecordID, &value.Revision); err != nil {
-			return nil, err
-		}
-		values = append(values, value)
-	}
-	return values, rows.Err()
-}
-
-func (s *Store) servicePublicationCleanups(ctx context.Context, tx *sql.Tx, serviceID string) ([]publicationCleanup, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT id, kind, COALESCE(gateway_node_id, ''), dns_provider, dns_record_id, desired_revision + 1
-		FROM publications WHERE service_id = ? AND status <> 'stopped' ORDER BY id`, serviceID)
-	if err != nil {
-		return nil, err
-	}
-	return publicationCleanups(rows)
-}
-
-func (s *Store) applicationPublicationCleanups(ctx context.Context, tx *sql.Tx, applicationID string) ([]publicationCleanup, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT p.id, p.kind, COALESCE(p.gateway_node_id, ''), p.dns_provider, p.dns_record_id, p.desired_revision + 1
-		FROM publications p JOIN services s ON s.id = p.service_id
-		WHERE s.application_id = ? AND p.status <> 'stopped' ORDER BY p.id`, applicationID)
-	if err != nil {
-		return nil, err
-	}
-	return publicationCleanups(rows)
-}
-
-func (s *Store) cleanupStoppedPublications(ctx context.Context, values []publicationCleanup) error {
-	var cleanupErrors []error
-	headscaleValues := []publicationCleanup{}
-	for _, value := range values {
-		if value.DNSRecordID != "" || value.Kind == publicationCloudflare {
-			err := s.removeCloudflarePublication(ctx, value.ID, value.Kind, value.GatewayID, value.DNSRecordID)
-			if recordErr := s.finishPublicationCleanup(ctx, value, "cloudflare", err); recordErr != nil {
-				cleanupErrors = append(cleanupErrors, recordErr)
-			}
-			continue
-		}
-		if value.DNSProvider == "headscale" {
-			headscaleValues = append(headscaleValues, value)
-		}
-	}
-	if len(headscaleValues) != 0 {
-		err := s.reconcileHeadscaleDNS(ctx)
-		for _, value := range headscaleValues {
-			if recordErr := s.finishPublicationCleanup(ctx, value, "headscale", err); recordErr != nil {
-				cleanupErrors = append(cleanupErrors, recordErr)
-			}
-		}
-	}
-	return errors.Join(cleanupErrors...)
-}
-
-func (s *Store) finishPublicationCleanup(ctx context.Context, value publicationCleanup, provider string, operationErr error) error {
-	message := ""
-	if operationErr != nil {
-		message = strings.TrimSpace(operationErr.Error())
-		if len(message) > 1024 {
-			message = message[:1024]
-		}
-	}
-	if _, err := s.db.ExecContext(ctx, `UPDATE publications SET last_error = ?, updated_at = ? WHERE id = ? AND status = 'stopped'`, message, s.now().UTC().Format(time.RFC3339Nano), value.ID); err != nil {
-		if operationErr != nil {
-			return errors.Join(operationErr, err)
-		}
-		return err
-	}
-	return s.recordDNSRemoval(ctx, value.ID, value.GatewayID, value.Revision, provider, operationErr)
-}
-
 func dnsTaskID(publicationID string, revision int64) string {
 	return fmt.Sprintf("dns-%s-r%d", publicationID, revision)
-}
-
-func (s *Store) recordDNSRemoval(ctx context.Context, publicationID, agentID string, revision int64, provider string, operationErr error) error {
-	event, message := "succeeded", provider+" DNS record removed"
-	if operationErr != nil {
-		event, message = "failed", operationErr.Error()
-	}
-	if err := s.recordStandaloneTaskEvent(ctx, dnsTaskID(publicationID, revision), agentID, "dns.record.remove", revision, event, message); err != nil && operationErr == nil {
-		return err
-	}
-	return operationErr
 }
 
 func (s *Store) Publication(ctx context.Context, id string) (PublicationView, error) {
@@ -501,6 +446,19 @@ func (s *Store) VerifyPublication(ctx context.Context, id string) (PublicationVi
 	if publication.Status == "stopped" {
 		return PublicationView{}, errors.New("center: stopped publication cannot be verified")
 	}
+	if publication.Status == "failed" && publication.DNSProvider != "manual" {
+		succeeded, reconcileErr := s.reconcilePublicationDNS(ctx, publication.ID, publication.GatewayNodeID, publication.DNSProvider, publication.DesiredRevision)
+		if reconcileErr != nil {
+			return PublicationView{}, reconcileErr
+		}
+		if !succeeded {
+			return s.Publication(ctx, id)
+		}
+		publication, err = s.Publication(ctx, id)
+		if err != nil {
+			return PublicationView{}, err
+		}
+	}
 	var protocol, endpoint, routeStatus string
 	err = s.db.QueryRowContext(ctx, `SELECT s.protocol, s.endpoint,
 		COALESCE((SELECT r.status FROM routes r WHERE r.publication_id = p.id LIMIT 1), '')
@@ -587,31 +545,101 @@ func (s *Store) markPublicationReady(ctx context.Context, id string) (Publicatio
 }
 
 func (s *Store) ListPublications(ctx context.Context) ([]PublicationView, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id FROM publications ORDER BY updated_at DESC, id`)
+	apps, err := s.ListApps(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ids := []string{}
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			rows.Close()
-			return nil, err
+	return s.listPublications(ctx, apps)
+}
+
+func (s *Store) listPublications(ctx context.Context, apps []AppView) ([]PublicationView, error) {
+	homepagePaths := map[string]string{}
+	for _, app := range apps {
+		if app.App.Homepage != nil {
+			homepagePaths[app.Key+"\x00"+app.App.Homepage.Service] = app.App.Homepage.Path
 		}
-		ids = append(ids, id)
 	}
-	if err := rows.Close(); err != nil {
+	rows, err := s.db.QueryContext(ctx, `SELECT
+		p.id, p.service_id, p.kind, COALESCE(p.gateway_node_id, ''), p.hostname, p.dns_provider, p.dns_record_id,
+		p.tls_enabled, p.desired_revision, p.applied_revision, p.status, p.last_error, p.created_at, p.updated_at,
+		s.protocol, s.name, a.app_key,
+		COALESCE(n.lan_address, ''), COALESCE(n.headscale_address, ''), COALESCE(n.public_address, ''), COALESCE(t.tunnel_id, '')
+		FROM publications p
+		JOIN services s ON s.id = p.service_id
+		JOIN applications a ON a.id = s.application_id
+		LEFT JOIN agent_network_profiles n ON n.agent_id = p.gateway_node_id
+		LEFT JOIN cloudflare_tunnels t ON t.agent_id = p.gateway_node_id
+		ORDER BY p.updated_at DESC, p.id`)
+	if err != nil {
 		return nil, err
 	}
-	values := make([]PublicationView, 0, len(ids))
-	for _, id := range ids {
-		value, err := s.Publication(ctx, id)
-		if err != nil {
+	defer rows.Close()
+	values := []PublicationView{}
+	for rows.Next() {
+		var value PublicationView
+		var tls int
+		var created, updated, protocol, serviceName, appKey string
+		var lanAddress, headscaleAddress, publicAddress, tunnelID string
+		if err := rows.Scan(
+			&value.ID, &value.ServiceID, &value.Kind, &value.GatewayNodeID, &value.Hostname, &value.DNSProvider, &value.DNSRecordID,
+			&tls, &value.DesiredRevision, &value.AppliedRevision, &value.Status, &value.LastError, &created, &updated,
+			&protocol, &serviceName, &appKey, &lanAddress, &headscaleAddress, &publicAddress, &tunnelID,
+		); err != nil {
 			return nil, err
+		}
+		value.TLSEnabled = tls == 1
+		value.CreatedAt, err = time.Parse(time.RFC3339Nano, created)
+		if err != nil {
+			return nil, errors.New("center: invalid publication creation timestamp")
+		}
+		value.UpdatedAt, err = time.Parse(time.RFC3339Nano, updated)
+		if err != nil {
+			return nil, errors.New("center: invalid publication update timestamp")
+		}
+		if value.Status == "ready" && (protocol == "http" || protocol == "https") {
+			path := homepagePaths[appKey+"\x00"+serviceName]
+			if path == "" {
+				path = "/"
+			}
+			scheme := "http"
+			if value.TLSEnabled {
+				scheme = "https"
+			}
+			value.AccessURL = (&url.URL{Scheme: scheme, Host: value.Hostname, Path: path}).String()
+		}
+		address := ""
+		switch value.Kind {
+		case publicationLAN:
+			address = lanAddress
+		case publicationHeadscale:
+			address = headscaleAddress
+		case publicationPublic, publicationShared443:
+			address = publicAddress
+		case publicationCloudflare:
+			if tunnelID != "" {
+				value.DNSRecord = &DNSRecordInstruction{Type: "CNAME", Name: value.Hostname, Value: tunnelID + ".cfargotunnel.com", Proxy: true}
+			}
+		default:
+			return nil, errors.New("center: stored publication kind is invalid")
+		}
+		if value.Kind != publicationCloudflare {
+			ip := net.ParseIP(address)
+			if ip == nil {
+				if value.Status == "stopped" {
+					values = append(values, value)
+					continue
+				}
+				return nil, errors.New("center: publication entry address is invalid")
+			}
+			recordType := "AAAA"
+			if ip.To4() != nil {
+				recordType = "A"
+			}
+			value.DNSRecord = &DNSRecordInstruction{Type: recordType, Name: value.Hostname, Value: ip.String()}
 		}
 		values = append(values, value)
 	}
-	return values, nil
+	return values, rows.Err()
 }
 
 func (s *Store) upsertPublicationRoute(ctx context.Context, tx *sql.Tx, publicationID, siteID, serviceID, gatewayID, hostname, protocol, endpoint string, tlsEnabled bool, now time.Time) error {

--- a/internal/center/publication_cleanup.go
+++ b/internal/center/publication_cleanup.go
@@ -1,0 +1,167 @@
+package center
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+type publicationCleanup struct {
+	ID          string
+	Kind        string
+	GatewayID   string
+	DNSProvider string
+	DNSRecordID string
+	Revision    int64
+}
+
+func publicationCleanups(rows *sql.Rows) ([]publicationCleanup, error) {
+	defer rows.Close()
+	values := []publicationCleanup{}
+	for rows.Next() {
+		var value publicationCleanup
+		if err := rows.Scan(&value.ID, &value.Kind, &value.GatewayID, &value.DNSProvider, &value.DNSRecordID, &value.Revision); err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func (s *Store) servicePublicationCleanups(ctx context.Context, tx *sql.Tx, serviceID string) ([]publicationCleanup, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT id, kind, COALESCE(gateway_node_id, ''), dns_provider, dns_record_id, desired_revision + 1
+		FROM publications WHERE service_id = ? AND status <> 'stopped' ORDER BY id`, serviceID)
+	if err != nil {
+		return nil, err
+	}
+	return publicationCleanups(rows)
+}
+
+func (s *Store) applicationPublicationCleanups(ctx context.Context, tx *sql.Tx, applicationID string) ([]publicationCleanup, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT p.id, p.kind, COALESCE(p.gateway_node_id, ''), p.dns_provider, p.dns_record_id, p.desired_revision + 1
+		FROM publications p JOIN services s ON s.id = p.service_id
+		WHERE s.application_id = ? AND p.status <> 'stopped' ORDER BY p.id`, applicationID)
+	if err != nil {
+		return nil, err
+	}
+	return publicationCleanups(rows)
+}
+
+func (s *Store) cleanupStoppedPublications(ctx context.Context, values []publicationCleanup) error {
+	s.publicationCleanupMu.Lock()
+	defer s.publicationCleanupMu.Unlock()
+
+	var cleanupErrors []error
+	headscaleValues := []publicationCleanup{}
+	for _, queued := range values {
+		var value publicationCleanup
+		err := s.db.QueryRowContext(ctx, `SELECT id, kind, COALESCE(gateway_node_id, ''), dns_provider, dns_record_id, desired_revision
+			FROM publications WHERE id = ? AND status = 'stopped' AND cleanup_pending = 1`, queued.ID).Scan(&value.ID, &value.Kind, &value.GatewayID, &value.DNSProvider, &value.DNSRecordID, &value.Revision)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+		if value.DNSRecordID != "" || value.Kind == publicationCloudflare {
+			operationErr := s.removeCloudflarePublication(ctx, value.ID, value.Kind, value.GatewayID, value.DNSRecordID)
+			if recordErr := s.finishPublicationCleanup(ctx, value, "cloudflare", operationErr); recordErr != nil {
+				cleanupErrors = append(cleanupErrors, recordErr)
+			}
+			continue
+		}
+		if value.DNSProvider == "headscale" {
+			headscaleValues = append(headscaleValues, value)
+		}
+	}
+	if len(headscaleValues) != 0 {
+		err := s.reconcileHeadscaleDNS(ctx)
+		for _, value := range headscaleValues {
+			if recordErr := s.finishPublicationCleanup(ctx, value, "headscale", err); recordErr != nil {
+				cleanupErrors = append(cleanupErrors, recordErr)
+			}
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func (s *Store) finishPublicationCleanup(ctx context.Context, value publicationCleanup, provider string, operationErr error) error {
+	now := s.now().UTC()
+	message := ""
+	if operationErr != nil {
+		message = strings.TrimSpace(operationErr.Error())
+		if len(message) > 1024 {
+			message = message[:1024]
+		}
+		var attempt int
+		if err := s.db.QueryRowContext(ctx, `SELECT cleanup_attempt FROM publications WHERE id = ?`, value.ID).Scan(&attempt); err != nil {
+			return errors.Join(operationErr, err)
+		}
+		retryAt := now.Add(publicationCleanupBackoff(attempt + 1))
+		if _, err := s.db.ExecContext(ctx, `UPDATE publications SET cleanup_pending = 1, cleanup_attempt = cleanup_attempt + 1, cleanup_retry_at = ?, last_error = ?, updated_at = ? WHERE id = ? AND status = 'stopped'`, retryAt.Format(time.RFC3339Nano), message, now.Format(time.RFC3339Nano), value.ID); err != nil {
+			return errors.Join(operationErr, err)
+		}
+	} else if _, err := s.db.ExecContext(ctx, `UPDATE publications SET cleanup_pending = 0, cleanup_attempt = 0, cleanup_retry_at = '', last_error = '', updated_at = ? WHERE id = ? AND status = 'stopped'`, now.Format(time.RFC3339Nano), value.ID); err != nil {
+		return err
+	}
+	return s.recordDNSRemoval(ctx, value.ID, value.GatewayID, value.Revision, provider, operationErr)
+}
+
+func publicationCleanupBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	if attempt > 7 {
+		attempt = 7
+	}
+	return time.Duration(1<<(attempt-1)) * time.Minute
+}
+
+func (s *Store) recordDNSRemoval(ctx context.Context, publicationID, agentID string, revision int64, provider string, operationErr error) error {
+	event, message := "succeeded", provider+" DNS record removed"
+	if operationErr != nil {
+		event, message = "failed", operationErr.Error()
+	}
+	return s.recordStandaloneTaskEvent(ctx, dnsTaskID(publicationID, revision), agentID, "dns.record.remove", revision, event, message)
+}
+
+func (s *Store) retryPublicationCleanups(ctx context.Context) error {
+	now := s.now().UTC().Format(time.RFC3339Nano)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, kind, COALESCE(gateway_node_id, ''), dns_provider, dns_record_id, desired_revision
+		FROM publications
+		WHERE status = 'stopped' AND cleanup_pending = 1 AND (cleanup_retry_at = '' OR cleanup_retry_at <= ?)
+		ORDER BY cleanup_retry_at, updated_at, id LIMIT 20`, now)
+	if err != nil {
+		return err
+	}
+	values, err := publicationCleanups(rows)
+	if err != nil {
+		return err
+	}
+	return s.cleanupStoppedPublications(ctx, values)
+}
+
+func (s *Store) RunPublicationCleanup(ctx context.Context, interval time.Duration, report func(error)) {
+	if interval < time.Minute {
+		interval = time.Minute
+	}
+	run := func() {
+		if err := s.retryPublicationCleanups(ctx); err != nil && report != nil {
+			report(err)
+		}
+	}
+	run()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
+	}
+}

--- a/internal/center/schema.go
+++ b/internal/center/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const centerSchemaVersion = 4
+const centerSchemaVersion = 5
 
 func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
@@ -188,6 +188,9 @@ func (s *Store) initializeCurrentSchema(ctx context.Context) error {
 			applied_revision INTEGER NOT NULL DEFAULT 0,
 			status TEXT NOT NULL CHECK(status IN ('pending', 'applying', 'ready', 'degraded', 'failed', 'stopped')),
 			last_error TEXT NOT NULL DEFAULT '',
+			cleanup_pending INTEGER NOT NULL DEFAULT 0,
+			cleanup_attempt INTEGER NOT NULL DEFAULT 0,
+			cleanup_retry_at TEXT NOT NULL DEFAULT '',
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL,
 			UNIQUE(service_id, kind, hostname)

--- a/internal/center/server.go
+++ b/internal/center/server.go
@@ -61,6 +61,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/v1/auth/logout", s.requireAuth(true, s.handleLogout))
 	mux.HandleFunc("PUT /api/v1/auth/password", s.requireAuth(true, s.handleChangePassword))
 	mux.HandleFunc("GET /api/v1/status", s.requireAuth(false, s.handleStatus))
+	mux.HandleFunc("GET /api/v1/dashboard", s.requireAuth(false, s.handleDashboard))
 	mux.HandleFunc("GET /api/v1/diagnostics", s.requireAuth(false, s.handleDiagnostics))
 	mux.HandleFunc("POST /api/v1/backups", s.requireAuth(true, s.handleCreateBackup))
 	mux.HandleFunc("GET /api/v1/deployments", s.requireAuth(false, s.handleListDeployments))
@@ -173,7 +174,16 @@ func (s *Server) handleLogin(writer http.ResponseWriter, request *http.Request) 
 	writeJSON(writer, http.StatusOK, map[string]bool{"authenticated": true})
 }
 
-func (s *Server) handleLogout(writer http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleLogout(writer http.ResponseWriter, request *http.Request) {
+	cookie, err := request.Cookie("vastora_session")
+	if err != nil {
+		writeError(writer, http.StatusUnauthorized, errors.New("center: authentication required"))
+		return
+	}
+	if err := s.store.Logout(request.Context(), cookie.Value); err != nil {
+		writeError(writer, http.StatusUnauthorized, err)
+		return
+	}
 	s.clearSessionCookies(writer)
 	writeJSON(writer, http.StatusOK, map[string]bool{"authenticated": false})
 }

--- a/internal/center/server_test.go
+++ b/internal/center/server_test.go
@@ -106,6 +106,32 @@ func TestCredentialsCanCreateOnlyOneAdministrator(t *testing.T) {
 	}
 }
 
+func TestLogoutRevokesServerSideSession(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	session, csrf, err := store.CreateFirstAdmin(ctx, "admin", "correct-horse-battery-staple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(store, "", false)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", strings.NewReader("{}"))
+	request.AddCookie(&http.Cookie{Name: "vastora_session", Value: session})
+	request.AddCookie(&http.Cookie{Name: "vastora_csrf", Value: csrf})
+	request.Header.Set("X-CSRF-Token", csrf)
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("logout status = %d body=%s", response.Code, response.Body.String())
+	}
+	if err := store.ValidateSession(ctx, session, csrf, false); err == nil || !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("logged-out session remained valid: %v", err)
+	}
+}
+
 func TestSetupHTTPStateSeparatesAdministratorFromOnboarding(t *testing.T) {
 	store, err := Open(t.TempDir())
 	if err != nil {

--- a/internal/center/store.go
+++ b/internal/center/store.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/petauron/vastora/internal/catalog"
@@ -36,6 +37,7 @@ type Store struct {
 	key                       []byte
 	headscaleAllowedEndpoints []string
 	headscaleHTTPClient       *http.Client
+	publicationCleanupMu      sync.Mutex
 	now                       func() time.Time
 }
 
@@ -259,6 +261,24 @@ func (s *Store) ValidateSession(ctx context.Context, sessionToken, csrfToken str
 	}
 	if mutation && subtle.ConstantTimeCompare([]byte(storedCSRF), []byte(csrfToken)) != 1 {
 		return errors.New("center: CSRF token is invalid")
+	}
+	return nil
+}
+
+func (s *Store) Logout(ctx context.Context, sessionToken string) error {
+	if sessionToken == "" {
+		return errors.New("center: authentication required")
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE token_hash = ?`, tokenHash(sessionToken))
+	if err != nil {
+		return fmt.Errorf("center: revoke session: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("center: revoke session: %w", err)
+	}
+	if changed != 1 {
+		return errors.New("center: session is invalid")
 	}
 	return nil
 }
@@ -741,7 +761,9 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	_ = s.cleanupStoppedPublications(ctx, publicationCleanups)
+	if err := s.cleanupStoppedPublications(ctx, publicationCleanups); err != nil {
+		return fmt.Errorf("center: record publication cleanup state: %w", err)
+	}
 	return nil
 }
 
@@ -781,19 +803,70 @@ func (s *Store) ListAgents(ctx context.Context) ([]AgentView, error) {
 	if err := rows.Close(); err != nil {
 		return nil, err
 	}
+	byID := make(map[string]int, len(agents))
 	for index := range agents {
-		candidates, err := s.networkCandidates(ctx, agents[index].ID)
-		if err != nil {
-			return nil, err
-		}
-		agents[index].NetworkCandidates = candidates
-		profile, err := s.networkProfile(ctx, agents[index].ID)
-		if err != nil {
-			return nil, err
-		}
-		agents[index].NetworkProfile = profile
+		byID[agents[index].ID] = index
+		agents[index].NetworkCandidates = []networking.Candidate{}
 	}
-	return agents, rows.Err()
+	candidateRows, err := s.db.QueryContext(ctx, `SELECT agent_id, address, interface_name, family, kind, observed_at FROM agent_network_candidates ORDER BY agent_id, kind, interface_name, address`)
+	if err != nil {
+		return nil, fmt.Errorf("center: list network candidates: %w", err)
+	}
+	for candidateRows.Next() {
+		var agentID, observed string
+		var candidate networking.Candidate
+		if err := candidateRows.Scan(&agentID, &candidate.Address, &candidate.Interface, &candidate.Family, &candidate.Kind, &observed); err != nil {
+			candidateRows.Close()
+			return nil, err
+		}
+		candidate.ObservedAt, err = time.Parse(time.RFC3339Nano, observed)
+		if err != nil {
+			candidateRows.Close()
+			return nil, errors.New("center: invalid network candidate timestamp")
+		}
+		if index, ok := byID[agentID]; ok {
+			agents[index].NetworkCandidates = append(agents[index].NetworkCandidates, candidate)
+		}
+	}
+	if err := candidateRows.Close(); err != nil {
+		return nil, err
+	}
+	profileRows, err := s.db.QueryContext(ctx, `SELECT agent_id, service_address, lan_address, headscale_address, public_address, enabled_kinds_json, direct_public, confirmed_at, candidate_observed_at FROM agent_network_profiles ORDER BY agent_id`)
+	if err != nil {
+		return nil, fmt.Errorf("center: list network profiles: %w", err)
+	}
+	for profileRows.Next() {
+		var agentID, confirmed, observed string
+		var enabled []byte
+		var direct int
+		profile := networking.Profile{}
+		if err := profileRows.Scan(&agentID, &profile.ServiceAddress, &profile.LANAddress, &profile.HeadscaleAddress, &profile.PublicAddress, &enabled, &direct, &confirmed, &observed); err != nil {
+			profileRows.Close()
+			return nil, err
+		}
+		if json.Unmarshal(enabled, &profile.EnabledKinds) != nil {
+			profileRows.Close()
+			return nil, errors.New("center: invalid stored network profile")
+		}
+		profile.DirectPublic = direct == 1
+		profile.ConfirmedAt, err = time.Parse(time.RFC3339Nano, confirmed)
+		if err != nil {
+			profileRows.Close()
+			return nil, errors.New("center: invalid network profile timestamp")
+		}
+		profile.CandidateObserved, err = time.Parse(time.RFC3339Nano, observed)
+		if err != nil {
+			profileRows.Close()
+			return nil, errors.New("center: invalid network observation timestamp")
+		}
+		if index, ok := byID[agentID]; ok {
+			agents[index].NetworkProfile = &profile
+		}
+	}
+	if err := profileRows.Close(); err != nil {
+		return nil, err
+	}
+	return agents, nil
 }
 
 func containsString(values []string, wanted string) bool {

--- a/scripts/package-center-install.sh
+++ b/scripts/package-center-install.sh
@@ -45,7 +45,7 @@ case "$image" in
   *[[:space:]]*) echo "Center image cannot contain whitespace." >&2; exit 2 ;;
 esac
 
-for required in install mktemp tar; do
+for required in awk basename install mktemp tar; do
   if ! command -v "$required" >/dev/null 2>&1; then
     echo "Required command is not installed: $required" >&2
     exit 1
@@ -68,6 +68,7 @@ trap cleanup EXIT HUP INT TERM
 
 install -d -m 0755 "$temporary_dir/headscale"
 install -m 0755 "$project_dir/deploy/center/setup.sh" "$temporary_dir/setup.sh"
+install -m 0755 "$project_dir/deploy/center/upgrade.sh" "$temporary_dir/upgrade.sh"
 install -m 0644 "$project_dir/deploy/center/compose.yaml" "$temporary_dir/compose.yaml"
 install -m 0644 "$project_dir/deploy/center/headscale/config.yaml" "$temporary_dir/headscale/config.yaml"
 install -m 0644 "$project_dir/deploy/center/headscale/policy.hujson" "$temporary_dir/headscale/policy.hujson"
@@ -81,6 +82,7 @@ install -d -m 0755 "$output_dir"
 archive="$output_dir/vastora-center-install.tar.gz"
 checksum="$archive.sha256"
 tar -czf "$archive" -C "$temporary_dir" .
-$digest_command "$archive" > "$checksum"
+archive_digest="$($digest_command "$archive" | awk 'NR == 1 {print $1}')"
+printf '%s  %s\n' "$archive_digest" "$(basename "$archive")" > "$checksum"
 echo "Created $archive"
 echo "Created $checksum"

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -18,6 +18,7 @@ archive="$temporary_dir/output/vastora-center-install.tar.gz"
 test -f "$archive"
 test -f "$archive.sha256"
 expected_digest="$(awk 'NR == 1 {print $1}' "$archive.sha256")"
+test "$(awk 'NR == 1 {print $2}' "$archive.sha256")" = "vastora-center-install.tar.gz"
 if command -v sha256sum >/dev/null 2>&1; then
   actual_digest="$(sha256sum "$archive" | awk 'NR == 1 {print $1}')"
 else
@@ -28,6 +29,7 @@ tar -xzf "$archive" -C "$temporary_dir"
 grep -Fqx 'VASTORA_VERSION=0.1.0-test' "$temporary_dir/release.env"
 grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$temporary_dir/release.env"
 test -x "$temporary_dir/setup.sh"
+test -x "$temporary_dir/upgrade.sh"
 test -f "$temporary_dir/compose.yaml"
 test -f "$temporary_dir/headscale/config.yaml"
 test -f "$temporary_dir/headscale/policy.hujson"
@@ -43,6 +45,31 @@ if grep -Fq '${VASTORA_CENTER_PORT:-443}:8080' "$temporary_dir/compose.yaml"; th
 fi
 grep -Fq 'ssh -N -L 18082:127.0.0.1:$bootstrap_port' "$temporary_dir/setup.sh"
 grep -Fq 'Public port 443: unchanged' "$temporary_dir/setup.sh"
+
+fake_bin="$temporary_dir/fake-bin"
+existing="$temporary_dir/existing"
+install -d "$fake_bin" "$existing/headscale"
+install -m 0644 "$temporary_dir/compose.yaml" "$existing/compose.yaml"
+install -m 0644 "$temporary_dir/headscale/config.yaml" "$existing/headscale/config.yaml"
+install -m 0644 "$temporary_dir/headscale/policy.hujson" "$existing/headscale/policy.hujson"
+printf '%s\n' 'old setup' > "$existing/setup.sh"
+printf '%s\n' 'VASTORA_VERSION=old' 'VASTORA_CENTER_IMAGE=old-image' > "$existing/release.env"
+printf '%s\n' 'VASTORA_CENTER_IMAGE=old-image' 'VASTORA_CENTER_BOOTSTRAP_PORT=19090' 'VASTORA_CUSTOM_VALUE=preserved' > "$existing/.env"
+cat > "$fake_bin/docker" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+cat > "$fake_bin/curl" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod 0755 "$fake_bin/docker" "$fake_bin/curl"
+PATH="$fake_bin:$PATH" "$temporary_dir/upgrade.sh" --install-dir "$existing" >/dev/null
+grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$existing/.env"
+grep -Fqx 'VASTORA_CENTER_BOOTSTRAP_PORT=19090' "$existing/.env"
+grep -Fqx 'VASTORA_CUSTOM_VALUE=preserved' "$existing/.env"
+grep -Fqx 'VASTORA_VERSION=0.1.0-test' "$existing/release.env"
+test -x "$existing/upgrade.sh"
 
 if "$project_dir/scripts/package-center-install.sh" \
   --version 0.1.0-test \

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { AppWindowIcon, CircleCheckIcon, HistoryIcon, HomeIcon, LanguagesIcon, LogOutIcon, NetworkIcon, ServerIcon, SettingsIcon, type LucideIcon } from "lucide-react";
 import { APIError, api } from "./api";
-import type { Action, AgentView, AppView, Application, CatalogSource, DashboardStatus, Deployment, Integration, Organization, Publication, Route, Service, SetupStatus, Site } from "./types";
+import type { DashboardData, SetupStatus } from "./types";
 import type { Language } from "./translations";
 import { ActivityView } from "./views/ActivityView";
 import { AppsView } from "./views/AppsView";
@@ -21,21 +21,7 @@ import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupConte
 import { Spinner } from "@/components/ui/spinner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
-export type DashboardData = {
-  status: DashboardStatus;
-  sources: CatalogSource[];
-  apps: AppView[];
-  agents: AgentView[];
-  deployments: Deployment[];
-  organizations: Organization[];
-  sites: Site[];
-  applications: Application[];
-  services: Service[];
-  publications: Publication[];
-  routes: Route[];
-  integrations: Integration[];
-  actions: Action[];
-};
+export type { DashboardData } from "./types";
 
 export type Screen = "home" | "nodes" | "apps" | "network" | "activity" | "settings";
 type Phase = "loading" | "setup-admin" | "setup-wizard" | "login" | "ready" | "unavailable";
@@ -70,24 +56,7 @@ export function App() {
   };
 
   const loadDashboard = useCallback(async () => {
-    const [status, sources, apps, agents, deployments, organizations, sites, applications, services, publications, routes, integrations, actions] = await Promise.all([
-      api.status(), api.sources(), api.apps(), api.agents(), api.deployments(), api.organizations(), api.sites(), api.applications(), api.services(), api.publications(), api.routes(), api.integrations(), api.actions()
-    ]);
-    setData({
-      status,
-      sources: sources.sources,
-      apps: apps.apps,
-      agents: agents.agents,
-      deployments: deployments.deployments,
-      organizations: organizations.organizations,
-      sites: sites.sites,
-      applications: applications.applications,
-      services: services.services,
-      publications: publications.publications,
-      routes: routes.routes,
-      integrations: integrations.integrations,
-      actions: actions.actions
-    });
+    setData(await api.dashboard());
   }, []);
 
   const initialize = useCallback(async () => {
@@ -149,8 +118,6 @@ export function App() {
   const mutate = useCallback<Mutate>(async (operation, success) => {
     try {
       await operation();
-      await loadDashboard();
-      setNotice(success ? { message: success } : null);
     } catch (error) {
       if (error instanceof APIError && error.status === 401) {
         setPhase("login");
@@ -159,7 +126,18 @@ export function App() {
       setNotice({ message: error instanceof Error ? error.message : "Request failed", error: true });
       throw error;
     }
-  }, [loadDashboard]);
+    setNotice(success ? { message: success } : null);
+    try {
+      await loadDashboard();
+    } catch (error) {
+      if (error instanceof APIError && error.status === 401) {
+        setPhase("login");
+      } else {
+        const refreshMessage = copy(language, "操作已完成，但页面状态刷新失败；系统会自动重试。", "The operation completed, but the page could not refresh; it will retry automatically.");
+        setNotice({ message: success ? `${success} ${refreshMessage}` : refreshMessage });
+      }
+    }
+  }, [language, loadDashboard]);
 
   if (phase === "loading") return <CenteredState language={language} loading />;
   if (phase === "unavailable") return <CenteredState language={language} message={notice?.message} onRetry={initialize} />;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { Action, AgentEnrollment, AgentView, AppView, Application, CatalogSource, DashboardStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Route, Service, SetupStatus, Site, SiteInput } from "./types";
+import type { Action, AgentEnrollment, AgentView, AppView, Application, CatalogSource, DashboardData, DashboardStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Route, Service, SetupStatus, Site, SiteInput } from "./types";
 
 export class APIError extends Error {
   constructor(
@@ -69,6 +69,7 @@ export const api = {
   logout: () => request<{ authenticated: boolean }>("/api/v1/auth/logout", { method: "POST", body: "{}" }),
   changePassword: (currentPassword: string, newPassword: string) => request<{ changed: boolean }>("/api/v1/auth/password", { method: "PUT", body: JSON.stringify({ currentPassword, newPassword }) }),
   status: () => request<DashboardStatus>("/api/v1/status"),
+  dashboard: () => request<DashboardData>("/api/v1/dashboard"),
   diagnostics: () => request<Diagnostics>("/api/v1/diagnostics"),
   downloadDiagnostics: () => download("/api/v1/diagnostics", `vastora-diagnostics-${new Date().toISOString().slice(0, 10)}.json`),
   downloadBackup: (password: string) => download("/api/v1/backups", "vastora-center.vastora", { method: "POST", body: JSON.stringify({ password }) }),

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -24,6 +24,22 @@ export type DashboardStatus = {
   agentConnectUrl: string;
 };
 
+export type DashboardData = {
+  status: DashboardStatus;
+  sources: CatalogSource[];
+  apps: AppView[];
+  agents: AgentView[];
+  deployments: Deployment[];
+  organizations: Organization[];
+  sites: Site[];
+  applications: Application[];
+  services: Service[];
+  publications: Publication[];
+  routes: Route[];
+  integrations: Integration[];
+  actions: Action[];
+};
+
 export type AgentConnectionMode = "lan" | "headscale" | "public";
 export type SetupStatus = {
   administratorConfigured: boolean;

--- a/web/src/views/AppsView.tsx
+++ b/web/src/views/AppsView.tsx
@@ -4,6 +4,7 @@ import { api } from "../api";
 import type { DashboardData, Mutate } from "../App";
 import type { AgentView, Application, AppView, Deployment, Publication, PublicationKind, Service } from "../types";
 import type { Language } from "../translations";
+import { canInstall, gatewaysForKind, installBlocker, isActiveApplication, latestOperations, localized, operationLabel, publicationKindLabel, publicationOptions } from "./appAccess";
 import { HighPrivilegeBadge, PageHeading, StateBadge, copy } from "./shared";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -165,68 +166,4 @@ function UninstallSheet({ application, app, language, onClose, onSubmit }: { app
   return <Sheet onOpenChange={(next) => { if (!next) onClose(); }} open={Boolean(application)}><SheetContent><SheetHeader><SheetTitle>{copy(language, `卸载 ${app ? localized(app, language, "name") : application?.name ?? ""}`, `Uninstall ${app ? localized(app, language, "name") : application?.name ?? ""}`)}</SheetTitle><SheetDescription>{copy(language, "卸载会停止应用并移除所有访问入口。默认保留持久数据，便于以后重新安装。", "Uninstalling stops the app and removes all access points. Persistent data is kept by default for a later reinstall.")}</SheetDescription></SheetHeader><div className="px-4"><Field orientation="horizontal"><div className="flex flex-1 flex-col gap-1"><FieldLabel htmlFor="delete-data">{copy(language, "同时永久删除应用数据", "Permanently delete app data too")}</FieldLabel><FieldDescription>{copy(language, "此操作不可恢复，包括配置、账号和历史数据。", "This cannot be undone and includes configuration, accounts, and history.")}</FieldDescription></div><Switch checked={deleteData} id="delete-data" onCheckedChange={setDeleteData} /></Field>{deleteData ? <Alert className="mt-4" variant="destructive"><Trash2Icon /><AlertTitle>{copy(language, "应用数据将永久删除", "App data will be permanently deleted")}</AlertTitle></Alert> : null}{error ? <FieldError className="mt-3">{error}</FieldError> : null}</div><SheetFooter><Button onClick={onClose} variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy} onClick={() => void submit()} variant={deleteData ? "destructive" : "default"}>{busy ? <Spinner data-icon="inline-start" /> : null}{deleteData ? copy(language, "卸载并删除数据", "Uninstall and delete data") : copy(language, "卸载并保留数据", "Uninstall and keep data")}</Button></SheetFooter></SheetContent></Sheet>;
 }
 
-function publicationOptions(data: DashboardData, service: Service | null, language: Language) {
-  if (!service) return [];
-  const web = service.protocol === "http" || service.protocol === "https";
-  const cloudflare = data.integrations.some((value) => value.kind === "cloudflare" && value.status === "configured");
-  const lan = gatewaysForKind(data, service, "lan_gateway").length > 0;
-  const headscale = gatewaysForKind(data, service, "headscale_gateway").length > 0;
-  const direct = gatewaysForKind(data, service, "public_direct").length > 0;
-  const shared443 = gatewaysForKind(data, service, "public_shared_443").length > 0;
-  const tunnel = gatewaysForKind(data, service, "cloudflare_tunnel").length > 0 && cloudflare;
-  const options: Array<{ kind: PublicationKind; enabled: boolean; reason: string }> = [];
-  if (web) {
-    options.push({ kind: "lan_gateway", enabled: lan, reason: lan ? "HTTP · LAN Gateway" : copy(language, "没有可用的局域网 Gateway", "No LAN Gateway is available") });
-    options.push({ kind: "headscale_gateway", enabled: headscale, reason: headscale ? "HTTP · Headscale Gateway" : copy(language, "没有可用的 Headscale Gateway", "No Headscale Gateway is available") });
-    options.push({ kind: "public_direct", enabled: direct, reason: direct ? "HTTPS · Public Gateway" : copy(language, "没有已批准的公网 Gateway", "No approved public Gateway is available") });
-    options.push({ kind: "cloudflare_tunnel", enabled: tunnel, reason: tunnel ? "HTTPS · Cloudflare Tunnel" : copy(language, "请先连接 Cloudflare 并启用 Tunnel 节点", "Connect Cloudflare and enable a Tunnel node first") });
-  } else {
-    options.push({ kind: "public_direct", enabled: direct, reason: direct ? copy(language, "原始端口 · 仅应用节点", "Direct raw port · app node only") : copy(language, "应用节点没有已批准的公网地址", "The app node has no approved public address") });
-    if (service.protocol === "tcp") options.push({ kind: "public_shared_443", enabled: shared443, reason: shared443 ? copy(language, "与 Web 共用公网 443 · 自动启用 HAProxy", "Share public 443 with Web · enables HAProxy automatically") : copy(language, "没有可用的公网 Gateway", "No public Gateway is available") });
-  }
-  return options;
-}
-
-function gatewaysForKind(data: DashboardData, service: Service, kind: PublicationKind): AgentView[] {
-  const app = data.applications.find((value) => value.id === service.applicationId);
-  const site = data.sites.find((value) => value.id === service.siteId);
-  return data.agents.filter((agent) => {
-    if (!agent.connected || agent.siteId !== service.siteId || !agent.networkProfile) return false;
-    if (kind === "cloudflare_tunnel") return agent.capabilities.tunnel;
-    if (kind === "public_direct" && service.protocol !== "http" && service.protocol !== "https") return agent.id === app?.nodeId && agent.networkProfile.directPublic && agent.networkProfile.enabledKinds.includes("public");
-    if (!agent.capabilities.gateway || !site?.gatewayNodes.includes(agent.id)) return false;
-    if (kind === "lan_gateway") return agent.networkProfile.enabledKinds.includes("lan");
-    if (kind === "headscale_gateway") return agent.networkProfile.enabledKinds.includes("headscale");
-    return agent.networkProfile.directPublic && agent.networkProfile.enabledKinds.includes("public");
-  });
-}
-
-function canInstall(agent: AgentView) { return agent.connected && agent.capabilities.docker && Boolean(agent.networkProfile); }
-function isActiveApplication(status: string) { return ["pending", "deploying", "running"].includes(status); }
-function latestOperations(deployments: Deployment[]) {
-  const seen = new Set<string>();
-  return deployments.filter((deployment) => {
-    const key = `${deployment.agentId}\n${deployment.appKey}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-}
-function operationLabel(language: Language, operation: Deployment["operation"]) {
-  const labels: Record<Deployment["operation"], [string, string]> = { install: ["安装", "Install"], upgrade: ["升级", "Upgrade"], uninstall: ["卸载", "Uninstall"] };
-  return copy(language, ...labels[operation]);
-}
-function installBlocker(data: DashboardData, appKey: string, language: Language) {
-  if (data.agents.length === 0) return copy(language, "先添加一台节点，再安装应用。", "Add a node before installing apps.");
-  if (!data.agents.some((agent) => agent.connected)) return copy(language, "没有在线节点。请检查 Agent 服务。", "No node is online. Check the Agent service.");
-  if (!data.agents.some((agent) => agent.connected && agent.capabilities.docker)) return copy(language, "在线节点没有 Docker 应用能力。", "Online nodes do not provide Docker app capability.");
-  if (!data.agents.some((agent) => agent.connected && agent.capabilities.docker && agent.networkProfile)) return copy(language, "请先在“网络”页面确认节点地址。", "Confirm a node address on the Network page first.");
-  if (data.agents.every((agent) => !canInstall(agent) || data.applications.some((application) => application.nodeId === agent.id && application.appKey === appKey && isActiveApplication(application.status)))) return copy(language, "所有可用节点都已安装此应用。", "This app is already installed on every eligible node.");
-  return copy(language, "当前没有符合条件的节点。", "No eligible node is currently available.");
-}
-function localized(app: AppView, language: Language, field: "name" | "description") { return app.app[field][language] || app.app[field].en; }
-function publicationKindLabel(language: Language, kind: PublicationKind) {
-  const labels: Record<PublicationKind, [string, string]> = { lan_gateway: ["局域网", "Local network"], headscale_gateway: ["Headscale 私网", "Headscale private network"], public_direct: ["公网直连", "Direct public"], public_shared_443: ["共享 443", "Shared 443"], cloudflare_tunnel: ["Cloudflare Tunnel", "Cloudflare Tunnel"] };
-  return copy(language, ...labels[kind]);
-}
 function CopyButton({ language, value }: { language: Language; value: string }) { return <Button aria-label={copy(language, "复制", "Copy")} onClick={() => void navigator.clipboard.writeText(value)} size="icon-sm" variant="ghost"><CopyIcon /></Button>; }

--- a/web/src/views/appAccess.ts
+++ b/web/src/views/appAccess.ts
@@ -1,0 +1,83 @@
+import type { DashboardData } from "../types";
+import type { AgentView, AppView, Deployment, PublicationKind, Service } from "../types";
+import type { Language } from "../translations";
+import { copy } from "./shared";
+
+export function publicationOptions(data: DashboardData, service: Service | null, language: Language) {
+  if (!service) return [];
+  const web = service.protocol === "http" || service.protocol === "https";
+  const cloudflare = data.integrations.some((value) => value.kind === "cloudflare" && value.status === "configured");
+  const available = (kind: PublicationKind) => gatewaysForKind(data, service, kind).length > 0;
+  const options: Array<{ kind: PublicationKind; enabled: boolean; reason: string }> = [];
+  if (web) {
+    const lan = available("lan_gateway");
+    const headscale = available("headscale_gateway");
+    const direct = available("public_direct");
+    const tunnel = available("cloudflare_tunnel") && cloudflare;
+    options.push({ kind: "lan_gateway", enabled: lan, reason: lan ? "HTTP · LAN Gateway" : copy(language, "没有可用的局域网 Gateway", "No LAN Gateway is available") });
+    options.push({ kind: "headscale_gateway", enabled: headscale, reason: headscale ? "HTTP · Headscale Gateway" : copy(language, "没有可用的 Headscale Gateway", "No Headscale Gateway is available") });
+    options.push({ kind: "public_direct", enabled: direct, reason: direct ? "HTTPS · Public Gateway" : copy(language, "没有已批准的公网 Gateway", "No approved public Gateway is available") });
+    options.push({ kind: "cloudflare_tunnel", enabled: tunnel, reason: tunnel ? "HTTPS · Cloudflare Tunnel" : copy(language, "请先连接 Cloudflare 并启用 Tunnel 节点", "Connect Cloudflare and enable a Tunnel node first") });
+  } else {
+    const direct = available("public_direct");
+    const shared443 = available("public_shared_443");
+    options.push({ kind: "public_direct", enabled: direct, reason: direct ? copy(language, "原始端口 · 仅应用节点", "Direct raw port · app node only") : copy(language, "应用节点没有已批准的公网地址", "The app node has no approved public address") });
+    if (service.protocol === "tcp") options.push({ kind: "public_shared_443", enabled: shared443, reason: shared443 ? copy(language, "与 Web 共用公网 443 · 自动启用 HAProxy", "Share public 443 with Web · enables HAProxy automatically") : copy(language, "没有可用的公网 Gateway", "No public Gateway is available") });
+  }
+  return options;
+}
+
+export function gatewaysForKind(data: DashboardData, service: Service, kind: PublicationKind): AgentView[] {
+  const app = data.applications.find((value) => value.id === service.applicationId);
+  const site = data.sites.find((value) => value.id === service.siteId);
+  return data.agents.filter((agent) => {
+    if (!agent.connected || agent.siteId !== service.siteId || !agent.networkProfile) return false;
+    if (kind === "cloudflare_tunnel") return agent.capabilities.tunnel;
+    if (kind === "public_direct" && service.protocol !== "http" && service.protocol !== "https") return agent.id === app?.nodeId && agent.networkProfile.directPublic && agent.networkProfile.enabledKinds.includes("public");
+    if (!agent.capabilities.gateway || !site?.gatewayNodes.includes(agent.id)) return false;
+    if (kind === "lan_gateway") return agent.networkProfile.enabledKinds.includes("lan");
+    if (kind === "headscale_gateway") return agent.networkProfile.enabledKinds.includes("headscale");
+    return agent.networkProfile.directPublic && agent.networkProfile.enabledKinds.includes("public");
+  });
+}
+
+export function canInstall(agent: AgentView) {
+  return agent.connected && agent.capabilities.docker && Boolean(agent.networkProfile);
+}
+
+export function isActiveApplication(status: string) {
+  return ["pending", "deploying", "running"].includes(status);
+}
+
+export function latestOperations(deployments: Deployment[]) {
+  const seen = new Set<string>();
+  return deployments.filter((deployment) => {
+    const key = `${deployment.agentId}\n${deployment.appKey}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function operationLabel(language: Language, operation: Deployment["operation"]) {
+  const labels: Record<Deployment["operation"], [string, string]> = { install: ["安装", "Install"], upgrade: ["升级", "Upgrade"], uninstall: ["卸载", "Uninstall"] };
+  return copy(language, ...labels[operation]);
+}
+
+export function installBlocker(data: DashboardData, appKey: string, language: Language) {
+  if (data.agents.length === 0) return copy(language, "先添加一台节点，再安装应用。", "Add a node before installing apps.");
+  if (!data.agents.some((agent) => agent.connected)) return copy(language, "没有在线节点。请检查 Agent 服务。", "No node is online. Check the Agent service.");
+  if (!data.agents.some((agent) => agent.connected && agent.capabilities.docker)) return copy(language, "在线节点没有 Docker 应用能力。", "Online nodes do not provide Docker app capability.");
+  if (!data.agents.some((agent) => agent.connected && agent.capabilities.docker && agent.networkProfile)) return copy(language, "请先在“网络”页面确认节点地址。", "Confirm a node address on the Network page first.");
+  if (data.agents.every((agent) => !canInstall(agent) || data.applications.some((application) => application.nodeId === agent.id && application.appKey === appKey && isActiveApplication(application.status)))) return copy(language, "所有可用节点都已安装此应用。", "This app is already installed on every eligible node.");
+  return copy(language, "当前没有符合条件的节点。", "No eligible node is currently available.");
+}
+
+export function localized(app: AppView, language: Language, field: "name" | "description") {
+  return app.app[field][language] || app.app[field].en;
+}
+
+export function publicationKindLabel(language: Language, kind: PublicationKind) {
+  const labels: Record<PublicationKind, [string, string]> = { lan_gateway: ["局域网", "Local network"], headscale_gateway: ["Headscale 私网", "Headscale private network"], public_direct: ["公网直连", "Direct public"], public_shared_443: ["共享 443", "Shared 443"], cloudflare_tunnel: ["Cloudflare Tunnel", "Cloudflare Tunnel"] };
+  return copy(language, ...labels[kind]);
+}


### PR DESCRIPTION
## What changed

- add safe in-place Center upgrades with persisted configuration and schema migration support
- retry publication cleanup/reconciliation and restore gateway state after Agent restarts
- reduce dashboard/API fan-out and remove redundant frontend access logic
- publish installer assets and keep the public installer Worker source in the repository

## Why

Existing installations could not be upgraded safely, transient publication cleanup failures could become stuck, and runtime/UI paths performed unnecessary repeated work. This release makes upgrades repeatable and lifecycle state recoverable before deploying the next development version.

## Impact

- existing `/opt/vastora/center/.env` data is preserved during upgrades
- database migrations run automatically when the new Center starts
- no compatibility layer or legacy schema path is retained

## Verification

- Go race tests
- `go vet ./...`
- `staticcheck ./...`
- frontend ESLint, Vitest, and production build
- Center install bundle and upgrade rehearsal
- public installer Worker live asset/checksum verification
- `git diff --check`
