### PR TITLE
fix: resolve draft releases from the release list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,14 @@ jobs:
             echo "invalid release tag: $RELEASE_TAG" >&2
             exit 1
           fi
-          release_json="$(gh api "/repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
+          release_json="$(
+            gh api --paginate --slurp "/repos/$GITHUB_REPOSITORY/releases?per_page=100" |
+              jq -c --arg tag "$RELEASE_TAG" '[.[][] | select(.tag_name == $tag)] | first'
+          )"
+          if [ "$release_json" = 'null' ]; then
+            echo "draft release $RELEASE_TAG was not found" >&2
+            exit 1
+          fi
           if [ "$(printf '%s' "$release_json" | jq -r '.draft')" != 'true' ]; then
             echo "release $RELEASE_TAG is not an existing draft" >&2
             exit 1


### PR DESCRIPTION
## What changed

- resolve manual retry targets from the authenticated release list
- keep exact tag matching and the existing `draft=true` guard
- report a clear error when the requested draft does not exist

## Why

GitHub returned 404 for `/releases/tags/v0.1.0-alpha.4` from the workflow token while the same token can enumerate the draft release. This blocked the new guarded retry before publication began.

## Verification

- reproduced the tag endpoint failure in workflow run `32205608363`
- verified the paginated release-list query selects only `v0.1.0-alpha.4` and reports `draft: true`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
