### PR TITLE
fix: resolve draft release target commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,8 @@ jobs:
             echo "release $RELEASE_TAG is not an existing draft" >&2
             exit 1
           fi
-          release_sha="$(gh api "/repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')"
+          release_target="$(printf '%s' "$release_json" | jq -er '.target_commitish')"
+          release_sha="$(gh api "/repos/$GITHUB_REPOSITORY/commits/$release_target" --jq '.sha')"
           {
             echo 'release_created=true'
             echo "release_sha=$release_sha"


### PR DESCRIPTION
## What changed

- resolve a draft retry from the release's `target_commitish`
- validate that target through the commits API before publishing

## Why

Draft releases do not create their Git tag until publication. Resolving `v0.1.0-alpha.4` as a commit therefore returned HTTP 422 even though the draft lookup succeeded. The draft already records the exact release commit in `target_commitish`.

## Verification

- reproduced the missing-tag failure in workflow run `32205940335`
- resolved the alpha.4 draft target to `dc042b876a50da221e4b28f0db3456a1d8d89cb2`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
