### PR TITLE
fix: make installer release selection resilient

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,17 +159,21 @@ jobs:
           gh release edit "$RELEASE_TAG" --draft=false
 
       - name: Verify public installer endpoint
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: |
           temporary_dir="$(mktemp -d)"
-          curl --retry 5 --retry-all-errors -fsSL \
+          curl --connect-timeout 10 --max-time 30 --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 -fsSL \
             https://vastora.petauron.com/install.sh \
             -o "$temporary_dir/install.sh"
-          curl --retry 5 --retry-all-errors -fsSL \
+          curl --connect-timeout 10 --max-time 30 --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 -fsSL \
             https://vastora.petauron.com/vastora-center-install.tar.gz \
             -o "$temporary_dir/vastora-center-install.tar.gz"
-          curl --retry 5 --retry-all-errors -fsSL \
+          curl --connect-timeout 10 --max-time 30 --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 -fsSL \
             https://vastora.petauron.com/vastora-center-install.tar.gz.sha256 \
             -o "$temporary_dir/vastora-center-install.tar.gz.sha256"
           sh -n "$temporary_dir/install.sh"
           cd "$temporary_dir"
           sha256sum --check vastora-center-install.tar.gz.sha256
+          actual_version="$(tar -xOzf vastora-center-install.tar.gz release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')"
+          test "$actual_version" = "$EXPECTED_VERSION"

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ deployment-check:
 	sh -n deploy/center/upgrade.sh
 	sh -n scripts/package-center-install.sh
 	sh -n scripts/test-center-install.sh
+	node scripts/test-installer-worker.mjs
 	./install.sh --help >/dev/null
 	deploy/center/setup.sh --help >/dev/null
 	deploy/center/upgrade.sh --help >/dev/null

--- a/deploy/installer-worker/README.md
+++ b/deploy/installer-worker/README.md
@@ -2,9 +2,12 @@
 
 `worker.js` is the source deployed as the `vastora-installer` Cloudflare Worker
 behind `vastora.petauron.com`. It selects the newest non-draft GitHub release
-that contains the installer, bundle, and checksum, including prereleases. The
-five-minute cache keeps GitHub API use low without coupling the public command
-to GitHub's stable-only `releases/latest` endpoint.
+named by the repository's `version.txt`, verifies that the installer, bundle,
+and checksum are all public, and then caches the selection for one minute. A
+seven-day last-known-good selection keeps installations working while a new
+release is being assembled or GitHub is temporarily unavailable. This avoids
+GitHub's anonymous API rate limit without coupling prereleases to the
+stable-only `releases/latest` endpoint.
 
 The Worker contains no credentials. Keep the deployed source identical to this
 file and verify all three public paths after every release.

--- a/deploy/installer-worker/worker.js
+++ b/deploy/installer-worker/worker.js
@@ -4,44 +4,79 @@ const releaseAssets = new Set([
   "vastora-center-install.tar.gz",
   "vastora-center-install.tar.gz.sha256",
 ]);
-const cacheKey = new Request("https://vastora-installer.internal/selected-release");
+const currentCacheKey = new Request("https://vastora-installer.internal/current-release");
+const lastKnownCacheKey = new Request("https://vastora-installer.internal/last-known-release");
+const versionURL = `https://raw.githubusercontent.com/${repository}/main/version.txt`;
+
+function releaseAssetURL(tag, asset) {
+  return `https://github.com/${repository}/releases/download/${encodeURIComponent(tag)}/${asset}`;
+}
+
+function cachedSelection(result, maxAge) {
+  return Response.json(result, {
+    headers: { "Cache-Control": `public, max-age=${maxAge}` },
+  });
+}
+
+async function requestedRelease() {
+  const versionResponse = await fetch(versionURL, {
+    headers: { "User-Agent": "vastora-installer-worker" },
+  });
+  if (!versionResponse.ok) {
+    throw new Error(`Version pointer returned ${versionResponse.status}`);
+  }
+
+  const version = (await versionResponse.text()).trim();
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error("Version pointer is invalid");
+  }
+
+  const tag = `v${version}`;
+  const assetResponses = await Promise.all(
+    [...releaseAssets].map((asset) =>
+      fetch(releaseAssetURL(tag, asset), {
+        method: "HEAD",
+        redirect: "manual",
+        headers: { "User-Agent": "vastora-installer-worker" },
+      }),
+    ),
+  );
+  if (!assetResponses.every((response) => response.ok || response.status === 302)) {
+    throw new Error("Requested release assets are incomplete");
+  }
+
+  return { tag };
+}
 
 async function selectedRelease(ctx) {
   const cache = caches.default;
-  const cached = await cache.match(cacheKey);
+  const cached = await cache.match(currentCacheKey);
   if (cached) return cached.json();
 
-  const response = await fetch(
-    `https://api.github.com/repos/${repository}/releases?per_page=20`,
-    {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "vastora-installer-worker",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    },
-  );
-  if (!response.ok) throw new Error(`GitHub releases returned ${response.status}`);
-
-  const releases = await response.json();
-  const release = releases.find((candidate) => {
-    if (candidate.draft || !/^v[0-9A-Za-z._-]+$/.test(candidate.tag_name)) return false;
-    const names = new Set(candidate.assets.map((asset) => asset.name));
-    return [...releaseAssets].every((name) => names.has(name));
-  });
-  if (!release) throw new Error("No complete Vastora release is available");
-
-  const result = { tag: release.tag_name };
-  const cachedResponse = Response.json(result, {
-    headers: { "Cache-Control": "public, max-age=300" },
-  });
-  ctx.waitUntil(cache.put(cacheKey, cachedResponse));
-  return result;
+  try {
+    const result = await requestedRelease();
+    ctx.waitUntil(
+      Promise.all([
+        cache.put(currentCacheKey, cachedSelection(result, 60)),
+        cache.put(lastKnownCacheKey, cachedSelection(result, 604800)),
+      ]),
+    );
+    return result;
+  } catch (error) {
+    const lastKnown = await cache.match(lastKnownCacheKey);
+    if (lastKnown) {
+      console.warn("Using the last known installer release", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return lastKnown.json();
+    }
+    throw error;
+  }
 }
 
 function responseHeaders() {
   return {
-    "Cache-Control": "public, max-age=300",
+    "Cache-Control": "public, max-age=60",
     "Referrer-Policy": "no-referrer",
     "X-Content-Type-Options": "nosniff",
   };
@@ -67,7 +102,7 @@ export default {
 
     try {
       const release = await selectedRelease(ctx);
-      const location = `https://github.com/${repository}/releases/download/${encodeURIComponent(release.tag)}/${asset}`;
+      const location = releaseAssetURL(release.tag, asset);
       return new Response(null, {
         status: 302,
         headers: { ...responseHeaders(), Location: location },
@@ -76,7 +111,12 @@ export default {
       console.error("Unable to select installer release", error);
       return new Response("No complete Vastora release is currently available.\n", {
         status: 503,
-        headers: { ...responseHeaders(), "Retry-After": "300" },
+        headers: {
+          ...responseHeaders(),
+          "Cache-Control": "no-store",
+          "Cloudflare-CDN-Cache-Control": "no-store",
+          "Retry-After": "60",
+        },
       });
     }
   },

--- a/scripts/test-installer-worker.mjs
+++ b/scripts/test-installer-worker.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(
+  new URL("../deploy/installer-worker/worker.js", import.meta.url),
+  "utf8",
+);
+const worker = (
+  await import(`data:text/javascript;base64,${Buffer.from(source).toString("base64")}`)
+).default;
+const originalWarn = console.warn;
+const originalError = console.error;
+const workerLogs = [];
+console.warn = (...arguments_) => workerLogs.push(["warn", ...arguments_]);
+console.error = (...arguments_) => workerLogs.push(["error", ...arguments_]);
+
+function cacheStorage() {
+  const entries = new Map();
+  return {
+    entries,
+    cache: {
+      async match(request) {
+        return entries.get(request.url)?.clone();
+      },
+      async put(request, response) {
+        entries.set(request.url, response.clone());
+      },
+    },
+  };
+}
+
+function executionContext() {
+  const pending = [];
+  return {
+    context: {
+      waitUntil(promise) {
+        pending.push(promise);
+      },
+    },
+    flush: () => Promise.all(pending),
+  };
+}
+
+function request(path = "/install.sh", method = "GET") {
+  return new Request(`https://vastora.petauron.com${path}`, { method });
+}
+
+{
+  const storage = cacheStorage();
+  globalThis.caches = { default: storage.cache };
+  const fetched = [];
+  globalThis.fetch = async (url) => {
+    fetched.push(String(url));
+    if (new URL(url).hostname === "raw.githubusercontent.com") {
+      return new Response("0.1.0-alpha.4\n");
+    }
+    return new Response(null, { status: 302 });
+  };
+
+  const execution = executionContext();
+  const response = await worker.fetch(request(), {}, execution.context);
+  await execution.flush();
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    "https://github.com/petauron/vastora/releases/download/v0.1.0-alpha.4/install.sh",
+  );
+  assert.equal(fetched.length, 4);
+
+  const cachedResponse = await worker.fetch(request("/vastora-center-install.tar.gz"), {}, executionContext().context);
+  assert.equal(cachedResponse.status, 302);
+  assert.equal(fetched.length, 4);
+
+  storage.entries.delete("https://vastora-installer.internal/current-release");
+  globalThis.fetch = async () => new Response(null, { status: 503 });
+  const fallback = await worker.fetch(request(), {}, executionContext().context);
+  assert.equal(fallback.status, 302);
+}
+
+{
+  const storage = cacheStorage();
+  globalThis.caches = { default: storage.cache };
+  globalThis.fetch = async () => new Response(null, { status: 503 });
+  const response = await worker.fetch(request(), {}, executionContext().context);
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(response.headers.get("cloudflare-cdn-cache-control"), "no-store");
+}
+
+{
+  const response = await worker.fetch(request("/install.sh", "POST"), {}, executionContext().context);
+  assert.equal(response.status, 405);
+}
+
+assert.deepEqual(workerLogs.map(([level]) => level), ["warn", "error"]);
+console.warn = originalWarn;
+console.error = originalError;
+console.log("installer worker tests: OK");


### PR DESCRIPTION
## What changed

- select the installer release from the repository `version.txt` pointer instead of GitHub's anonymous releases API
- verify all three public release assets before redirecting
- retain a seven-day last-known-good selection and never cache 503 responses
- reduce redirect cache TTL to one minute and add deterministic Worker tests
- bound public endpoint verification and assert the downloaded bundle is the expected release version

## Why

The shared anonymous GitHub API path intermittently returned no usable release from Cloudflare, producing a cacheable 503 at `vastora.petauron.com` and leaving the release workflow waiting. The repository version pointer is already maintained by Release Please and needs no secret or API quota.

## Live verification

- deployed the matching Worker source to `vastora-installer`
- purged only the three stale installer URLs
- all three public URLs now resolve to `v0.1.0-alpha.4`
- public bundle checksum and embedded release version pass
- release workflow `32206323301` completed successfully

## Local verification

- `actionlint .github/workflows/release.yml`
- `make deployment-check`
- `git diff --check`
