### PR TITLE
fix: verify packaged release metadata path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,5 +175,5 @@ jobs:
           sh -n "$temporary_dir/install.sh"
           cd "$temporary_dir"
           sha256sum --check vastora-center-install.tar.gz.sha256
-          actual_version="$(tar -xOzf vastora-center-install.tar.gz release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')"
+          actual_version="$(tar -xOzf vastora-center-install.tar.gz ./release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')"
           test "$actual_version" = "$EXPECTED_VERSION"

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -17,6 +17,7 @@ image="ghcr.io/petauron/vastora-center@sha256:$digest"
 archive="$temporary_dir/output/vastora-center-install.tar.gz"
 test -f "$archive"
 test -f "$archive.sha256"
+test "$(tar -xOzf "$archive" ./release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')" = "0.1.0-test"
 expected_digest="$(awk 'NR == 1 {print $1}' "$archive.sha256")"
 test "$(awk 'NR == 1 {print $2}' "$archive.sha256")" = "vastora-center-install.tar.gz"
 if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- read the archive member by its actual ./release.env path
- add the exact release metadata extraction to the installer bundle test

## Validation
- make deployment-check