### PR TITLE
fix: accept generated Center install bundle

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ fi
 install -d -m 0755 "$(dirname "$install_dir")"
 staging="$(mktemp -d "${install_dir}.new.XXXXXX")"
 tar -xzf "$archive" -C "$staging"
-for required_file in setup.sh upgrade.sh compose.yaml release.env headscale/config.yaml headscale/policy.hujson; do
+for required_file in setup.sh upgrade.sh compose.yaml release.env; do
   if [ ! -f "$staging/$required_file" ]; then
     echo "The Center release is incomplete: missing $required_file" >&2
     exit 1

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -33,6 +33,10 @@ test -x "$temporary_dir/setup.sh"
 test -x "$temporary_dir/upgrade.sh"
 test -f "$temporary_dir/compose.yaml"
 test ! -e "$temporary_dir/headscale"
+if grep -Eq 'headscale/(config\.yaml|policy\.hujson)' "$project_dir/install.sh"; then
+  echo "Public installer still requires removed Headscale configuration files" >&2
+  exit 1
+fi
 grep -Fq '127.0.0.1:${VASTORA_CENTER_BOOTSTRAP_PORT:-8080}' "$temporary_dir/compose.yaml"
 grep -Fq 'network_mode: host' "$temporary_dir/compose.yaml"
 if sed -n '/^  center:/,/^  headscale:/p' "$temporary_dir/compose.yaml" | grep -Fq '    ports:'; then


### PR DESCRIPTION
## Summary
- remove obsolete Headscale bind-file requirements from the public installer
- fail deployment tests if those removed paths are required again

## Validation
- make deployment-check
- reproduced against the published alpha.5 bundle on production-node-d