### PR TITLE
fix: make Cloudflare authorization recoverable

### DIFF
--- a/internal/center/cloudflare_oauth.go
+++ b/internal/center/cloudflare_oauth.go
@@ -139,7 +139,7 @@ func (s *Store) StartCloudflareOAuth() (CloudflareOAuthStart, error) {
 		"client_id":             {config.ClientID},
 		"redirect_uri":          {cloudflareOAuthRedirectURI},
 		"response_type":         {"code"},
-		"scope":                 {"account-settings.read zone.read dns.write argotunnel.write offline_access"},
+		"scope":                 {"zone.read dns.write argotunnel.write offline_access"},
 		"state":                 {state},
 		"code_challenge":        {oauthSHA256(verifier)},
 		"code_challenge_method": {"S256"},

--- a/internal/center/cloudflare_oauth_test.go
+++ b/internal/center/cloudflare_oauth_test.go
@@ -46,7 +46,7 @@ func TestCloudflareOAuthStartUsesPKCEWithoutExposingSecrets(t *testing.T) {
 	if query.Get("state") != session.State || query.Get("code_challenge") != oauthSHA256(session.PKCEVerifier) || query.Get("code_challenge_method") != "S256" {
 		t.Fatalf("OAuth request did not bind state and PKCE: %s", started.AuthorizationURL)
 	}
-	if query.Get("scope") != "account-settings.read zone.read dns.write argotunnel.write offline_access" {
+	if query.Get("scope") != "zone.read dns.write argotunnel.write offline_access" {
 		t.Fatalf("OAuth request used unexpected scopes: %q", query.Get("scope"))
 	}
 	for _, secret := range []string{session.PollSecret, session.PKCEVerifier} {

--- a/web/src/views/CloudflareOAuthConnect.tsx
+++ b/web/src/views/CloudflareOAuthConnect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { CheckCircle2Icon, CircleAlertIcon, CloudIcon, ExternalLinkIcon } from "lucide-react";
+import { CheckCircle2Icon, CircleAlertIcon, CloudIcon, CopyIcon, ExternalLinkIcon, XIcon } from "lucide-react";
 import { api } from "../api";
 import type { CloudflareZone } from "../types";
 import type { Language } from "../translations";
@@ -20,33 +20,43 @@ type Props = {
 
 export function CloudflareOAuthConnect({ available, connected, language, zoneName, onConnected }: Props) {
   const cancelled = useRef(false);
+  const authorizationWindow = useRef<Window | null>(null);
   const [sessionID, setSessionID] = useState("");
+  const [authorizationURL, setAuthorizationURL] = useState("");
+  const [copied, setCopied] = useState(false);
   const [zones, setZones] = useState<CloudflareZone[]>([]);
   const [zoneID, setZoneID] = useState("");
   const [stage, setStage] = useState<"idle" | "opening" | "waiting" | "selecting" | "saving">("idle");
   const [error, setError] = useState("");
 
-  useEffect(() => () => { cancelled.current = true; }, []);
+  useEffect(() => () => {
+    cancelled.current = true;
+    authorizationWindow.current?.close();
+  }, []);
 
   const connect = async () => {
     cancelled.current = false;
     setError("");
     setZones([]);
+    setAuthorizationURL("");
+    setCopied(false);
     setStage("opening");
-    const popup = window.open("about:blank", "vastora-cloudflare-oauth", "popup,width=720,height=760");
+    const popup = openAuthorizationWindow(copy(language, "正在打开 Cloudflare…", "Opening Cloudflare…"));
     if (!popup) {
       setStage("idle");
       setError(copy(language, "浏览器阻止了登录窗口，请允许此站点打开弹窗。", "The browser blocked the login window. Allow pop-ups for this site."));
       return;
     }
+    authorizationWindow.current = popup;
     try {
-      popup.document.title = "Cloudflare";
       const started = await api.startCloudflareOAuth();
       setSessionID(started.sessionId);
+      setAuthorizationURL(started.authorizationUrl);
       popup.location.replace(started.authorizationUrl);
       setStage("waiting");
       while (!cancelled.current && Date.now() < new Date(started.expiresAt).getTime()) {
         await new Promise((resolve) => window.setTimeout(resolve, 1500));
+        if (cancelled.current) return;
         const result = await api.pollCloudflareOAuth(started.sessionId);
         if (result.status === "pending") continue;
         const authorizedZones = result.zones ?? [];
@@ -55,16 +65,53 @@ export function CloudflareOAuthConnect({ available, connected, language, zoneNam
         setZoneID(authorizedZones[0].id);
         setStage("selecting");
         popup.close();
+        authorizationWindow.current = null;
         return;
       }
       throw new Error(copy(language, "Cloudflare 登录已超时，请重新连接。", "Cloudflare login timed out. Connect again."));
     } catch (connectError) {
       popup.close();
+      authorizationWindow.current = null;
       if (!cancelled.current) {
         setStage("idle");
+        setAuthorizationURL("");
         setError(connectError instanceof Error ? connectError.message : "Request failed");
       }
     }
+  };
+
+  const reopenAuthorization = () => {
+    if (!authorizationURL) return;
+    const popup = window.open(authorizationURL, "_blank");
+    if (!popup) {
+      setError(copy(language, "浏览器阻止了登录标签页，请复制链接并在 Safari、Chrome 或 Edge 中打开。", "The browser blocked the sign-in tab. Copy the link and open it in Safari, Chrome, or Edge."));
+      return;
+    }
+    popup.opener = null;
+    authorizationWindow.current = popup;
+  };
+
+  const copyAuthorization = async () => {
+    if (!authorizationURL) return;
+    try {
+      await navigator.clipboard.writeText(authorizationURL);
+      authorizationWindow.current?.close();
+      authorizationWindow.current = null;
+      setCopied(true);
+    } catch {
+      setError(copy(language, "无法复制登录链接，请使用“重新打开登录页”。", "The sign-in link could not be copied. Use Reopen sign-in page."));
+    }
+  };
+
+  const cancelAuthorization = () => {
+    cancelled.current = true;
+    authorizationWindow.current?.close();
+    authorizationWindow.current = null;
+    setSessionID("");
+    setAuthorizationURL("");
+    setCopied(false);
+    setStage("idle");
+    setError("");
   };
 
   const save = async () => {
@@ -98,10 +145,27 @@ export function CloudflareOAuthConnect({ available, connected, language, zoneNam
       </div>
       {stage !== "selecting" && stage !== "saving" ? <Button className="min-h-11 shrink-0 sm:self-center" disabled={busy} onClick={() => void connect()} type="button" variant={connected ? "outline" : "default"}>{stage === "opening" ? <Spinner data-icon="inline-start" /> : <ExternalLinkIcon aria-hidden="true" data-icon="inline-start" />}{busy ? copy(language, "等待授权…", "Waiting…") : connected ? copy(language, "重新连接", "Reconnect") : copy(language, "登录 Cloudflare", "Sign in to Cloudflare")}</Button> : null}
     </div>
-    {stage === "waiting" ? <Alert className="mt-4"><Spinner /><AlertTitle>{copy(language, "在新窗口完成登录", "Finish signing in in the new window")}</AlertTitle><AlertDescription>{copy(language, "授权完成后，本页会自动让你选择域名。", "After authorization, this page will automatically ask you to choose a domain.")}</AlertDescription></Alert> : null}
+    {stage === "waiting" ? <Alert className="mt-4"><Spinner /><AlertTitle>{copy(language, "在新标签页完成登录", "Finish signing in in the new tab")}</AlertTitle><AlertDescription className="flex flex-col gap-3"><p>{copy(language, "Cloudflare 首次加载可能需要几秒。授权完成后，本页会自动让你选择域名。", "Cloudflare may take a few seconds to load. After authorization, this page will automatically ask you to choose a domain.")}</p><p>{copy(language, "如果登录页持续空白，请复制链接并在 Safari、Chrome 或 Edge 中打开。", "If the sign-in page stays blank, copy the link and open it in Safari, Chrome, or Edge.")}</p><div className="flex flex-wrap gap-2"><Button onClick={reopenAuthorization} size="sm" type="button" variant="outline"><ExternalLinkIcon data-icon="inline-start" />{copy(language, "重新打开登录页", "Reopen sign-in page")}</Button><Button onClick={() => void copyAuthorization()} size="sm" type="button" variant="outline"><CopyIcon data-icon="inline-start" />{copied ? copy(language, "已复制", "Copied") : copy(language, "复制登录链接", "Copy sign-in link")}</Button><Button onClick={cancelAuthorization} size="sm" type="button" variant="ghost"><XIcon data-icon="inline-start" />{copy(language, "取消", "Cancel")}</Button></div></AlertDescription></Alert> : null}
     {stage === "selecting" || stage === "saving" ? <div className="mt-4 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-end"><Field className="flex-1"><FieldLabel htmlFor="cloudflare-zone">{copy(language, "选择用于 Vastora 的域名", "Choose a domain for Vastora")}</FieldLabel><NativeSelect disabled={stage === "saving"} id="cloudflare-zone" onChange={(event) => setZoneID(event.target.value)} value={zoneID}>{zones.map((zone) => <option key={zone.id} value={zone.id}>{zone.name}{zone.accountName ? ` — ${zone.accountName}` : ""}</option>)}</NativeSelect><FieldDescription>{copy(language, "后续仍可以在网络设置中更换。", "You can change this later in Network settings.")}</FieldDescription></Field><Button className="min-h-11" disabled={stage === "saving"} onClick={() => void save()} type="button">{stage === "saving" ? <Spinner data-icon="inline-start" /> : <CheckCircle2Icon aria-hidden="true" data-icon="inline-start" />}{copy(language, "使用这个域名", "Use this domain")}</Button></div> : null}
     {error ? <Alert className="mt-4" variant="destructive"><CircleAlertIcon /><AlertTitle>{friendlyOAuthError(language, error)}</AlertTitle><AlertDescription><p>{copy(language, "没有保存任何授权，也没有修改 DNS。请重试。", "No authorization was saved and no DNS was changed. Try again.")}</p><details className="mt-2"><summary className="cursor-pointer text-xs font-medium">{copy(language, "查看技术详情", "Show technical details")}</summary><p className="mt-2 break-words font-mono text-xs">{error}</p></details></AlertDescription></Alert> : null}
   </section>;
+}
+
+function openAuthorizationWindow(message: string) {
+  const popup = window.open("about:blank", "_blank");
+  if (!popup) return null;
+  popup.opener = null;
+  try {
+    popup.document.title = "Cloudflare";
+    popup.document.documentElement.style.colorScheme = "light";
+    popup.document.body.style.cssText = "margin:0;min-height:100vh;display:grid;place-items:center;background:#fff;color:#18181b;font:16px system-ui,sans-serif";
+    const status = popup.document.createElement("p");
+    status.textContent = message;
+    popup.document.body.append(status);
+  } catch {
+    // Navigation still works if the browser does not expose about:blank.
+  }
+  return popup;
 }
 
 function friendlyOAuthError(language: Language, error: string) {

--- a/web/src/views/SetupWizard.tsx
+++ b/web/src/views/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { CheckIcon, ChevronDownIcon, Globe2Icon, HouseIcon, LanguagesIcon, MapPinIcon, NetworkIcon, Settings2Icon, ShieldCheckIcon, type LucideIcon } from "lucide-react";
 import { api } from "../api";
 import type { AgentConnectionMode, CloudflareZone, InitialSetupInput, NetworkCandidate } from "../types";
@@ -33,24 +33,44 @@ const connectionOptions: Array<{ mode: AgentConnectionMode; icon: LucideIcon; zh
   { mode: "public", icon: Globe2Icon, zh: "已有公网地址", en: "Existing public address", descriptionZh: "Center 已经有域名和 HTTPS。", descriptionEn: "Center already has a hostname and HTTPS." }
 ];
 
+const setupDraftKey = "vastora.initial-setup.v1";
+
+type SetupDraft = {
+  step: 1 | 2;
+  name: string;
+  timezone: string;
+  domainSuffix: string;
+  mode: AgentConnectionMode;
+  agentConnectUrl: string;
+  headscaleMode: "builtin" | "external";
+  headscaleUrl: string;
+  dnsMode: "cloudflare" | "manual";
+  publicAddress: string;
+};
+
 export function SetupWizard(props: SetupWizardProps) {
   const { language, suggestedAgentConnectUrl, builtinHeadscaleAvailable, cloudflareOAuthAvailable, publicAddressCandidates, onLanguage, onComplete } = props;
-  const [step, setStep] = useState(1);
-  const [name, setName] = useState("");
-  const [timezone, setTimezone] = useState(browserTimezone);
-  const [domainSuffix, setDomainSuffix] = useState("");
+  const [draft] = useState(readSetupDraft);
+  const [step, setStep] = useState(draft.step ?? 1);
+  const [name, setName] = useState(draft.name ?? "");
+  const [timezone, setTimezone] = useState(draft.timezone ?? browserTimezone);
+  const [domainSuffix, setDomainSuffix] = useState(draft.domainSuffix ?? "");
   const [code] = useState(() => `site-${crypto.randomUUID().slice(0, 8)}`);
-  const [mode, setMode] = useState<AgentConnectionMode>("lan");
-  const [agentConnectUrl, setAgentConnectUrl] = useState(suggestedAgentConnectUrl);
-  const [headscaleMode, setHeadscaleMode] = useState<"builtin" | "external">("builtin");
-  const [headscaleUrl, setHeadscaleUrl] = useState("");
+  const [mode, setMode] = useState<AgentConnectionMode>(draft.mode ?? "lan");
+  const [agentConnectUrl, setAgentConnectUrl] = useState(draft.agentConnectUrl ?? suggestedAgentConnectUrl);
+  const [headscaleMode, setHeadscaleMode] = useState<"builtin" | "external">(draft.headscaleMode ?? "builtin");
+  const [headscaleUrl, setHeadscaleUrl] = useState(draft.headscaleUrl ?? "");
   const [headscaleApiKey, setHeadscaleApiKey] = useState("");
-  const [dnsMode, setDNSMode] = useState<"cloudflare" | "manual">(cloudflareOAuthAvailable && publicAddressCandidates.length > 0 ? "cloudflare" : "manual");
+  const [dnsMode, setDNSMode] = useState<"cloudflare" | "manual">(draft.dnsMode ?? (cloudflareOAuthAvailable && publicAddressCandidates.length > 0 ? "cloudflare" : "manual"));
   const [cloudflareConfigured, setCloudflareConfigured] = useState(props.cloudflareConfigured);
   const [cloudflareZone, setCloudflareZone] = useState(props.cloudflareZone ?? "");
-  const [publicAddress, setPublicAddress] = useState(publicAddressCandidates[0]?.address ?? "");
+  const [publicAddress, setPublicAddress] = useState(draft.publicAddress ?? publicAddressCandidates[0]?.address ?? "");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    writeSetupDraft({ step: step === 1 ? 1 : 2, name, timezone, domainSuffix, mode, agentConnectUrl, headscaleMode, headscaleUrl, dnsMode, publicAddress });
+  }, [step, name, timezone, domainSuffix, mode, agentConnectUrl, headscaleMode, headscaleUrl, dnsMode, publicAddress]);
 
   const nextLocation = (event: FormEvent<HTMLFormElement>) => { event.preventDefault(); setError(""); setStep(2); };
   const nextNetwork = (event: FormEvent<HTMLFormElement>) => {
@@ -71,6 +91,7 @@ export function SetupWizard(props: SetupWizardProps) {
     try {
       if (mode === "headscale" && headscaleMode === "builtin" && dnsMode === "cloudflare") await api.configureSetupDNS({ centerUrl: agentConnectUrl.replace(/\/$/, ""), headscaleUrl: headscaleUrl.replace(/\/$/, ""), publicAddress });
       await onComplete(input);
+      clearSetupDraft();
     } catch (submitError) { setError(submitError instanceof Error ? submitError.message : "Request failed"); } finally { setBusy(false); }
   };
   const connectedCloudflare = (zone: CloudflareZone) => {
@@ -136,3 +157,43 @@ function SetupProgress({ language, step }: { language: Language; step: number })
 function Summary({ icon: Icon, label, value, wide }: { icon: LucideIcon; label: string; value: string; wide?: boolean }) { return <div className={wide ? "sm:col-span-2" : ""}><dt className="flex items-center gap-2 text-muted-foreground"><Icon aria-hidden="true" className="size-4" />{label}</dt><dd className="mt-1 break-words font-medium">{value}</dd></div>; }
 function TimezoneOptions() { return <datalist id="vastora-timezones"><option value="UTC" /><option value="Asia/Shanghai" /><option value="Asia/Singapore" /><option value="Asia/Tokyo" /><option value="Europe/London" /><option value="America/Los_Angeles" /><option value="America/New_York" /></datalist>; }
 function validHeadscaleURL(value: string) { try { const parsed = new URL(value); return parsed.protocol === "https:" && parsed.username === "" && parsed.password === "" && parsed.pathname === "/" && parsed.search === "" && parsed.hash === ""; } catch { return false; } }
+
+function readSetupDraft(): Partial<SetupDraft> {
+  try {
+    const parsed = JSON.parse(window.sessionStorage.getItem(setupDraftKey) ?? "null") as Partial<SetupDraft> | null;
+    if (!parsed || typeof parsed !== "object") return {};
+    const mode = connectionOptions.some((option) => option.mode === parsed.mode) ? parsed.mode : undefined;
+    const headscaleMode = parsed.headscaleMode === "builtin" || parsed.headscaleMode === "external" ? parsed.headscaleMode : undefined;
+    const dnsMode = parsed.dnsMode === "cloudflare" || parsed.dnsMode === "manual" ? parsed.dnsMode : undefined;
+    return {
+      step: parsed.step === 2 ? 2 : 1,
+      name: typeof parsed.name === "string" ? parsed.name : undefined,
+      timezone: typeof parsed.timezone === "string" ? parsed.timezone : undefined,
+      domainSuffix: typeof parsed.domainSuffix === "string" ? parsed.domainSuffix : undefined,
+      mode,
+      agentConnectUrl: typeof parsed.agentConnectUrl === "string" ? parsed.agentConnectUrl : undefined,
+      headscaleMode,
+      headscaleUrl: typeof parsed.headscaleUrl === "string" ? parsed.headscaleUrl : undefined,
+      dnsMode,
+      publicAddress: typeof parsed.publicAddress === "string" ? parsed.publicAddress : undefined
+    };
+  } catch {
+    return {};
+  }
+}
+
+function writeSetupDraft(draft: SetupDraft) {
+  try {
+    window.sessionStorage.setItem(setupDraftKey, JSON.stringify(draft));
+  } catch {
+    // Setup still works when browser storage is unavailable.
+  }
+}
+
+function clearSetupDraft() {
+  try {
+    window.sessionStorage.removeItem(setupDraftKey);
+  } catch {
+    // The completed setup does not depend on browser storage cleanup.
+  }
+}

--- a/web/src/views/SetupWizard.tsx
+++ b/web/src/views/SetupWizard.tsx
@@ -51,7 +51,7 @@ type SetupDraft = {
 export function SetupWizard(props: SetupWizardProps) {
   const { language, suggestedAgentConnectUrl, builtinHeadscaleAvailable, cloudflareOAuthAvailable, publicAddressCandidates, onLanguage, onComplete } = props;
   const [draft] = useState(readSetupDraft);
-  const [step, setStep] = useState(draft.step ?? 1);
+  const [step, setStep] = useState<1 | 2 | 3>(draft.step ?? 1);
   const [name, setName] = useState(draft.name ?? "");
   const [timezone, setTimezone] = useState(draft.timezone ?? browserTimezone);
   const [domainSuffix, setDomainSuffix] = useState(draft.domainSuffix ?? "");

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -2,14 +2,16 @@
 
 import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardData } from "../App";
+import { api } from "../api";
 import { AppsView } from "./AppsView";
 import { HomeView } from "./HomeView";
 import { NetworkView } from "./NetworkView";
 import { NodesView, agentInstallCommand, validCenterURL } from "./NodesView";
 import { SettingsView } from "./SettingsView";
 import { SetupWizard } from "./SetupWizard";
+import { CloudflareOAuthConnect } from "./CloudflareOAuthConnect";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -18,6 +20,9 @@ afterEach(() => {
   if (root) act(() => root?.unmount());
   root = undefined;
   document.body.replaceChildren();
+  window.sessionStorage.clear();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 const dashboard = (): DashboardData => ({
@@ -134,6 +139,50 @@ describe("network and app views", () => {
     const advanced = [...container.querySelectorAll("details")].find((details) => details.textContent?.includes("端口、Headscale 来源"));
     expect(advanced?.open).toBe(false);
     expect(container.querySelector("#setup-headscale-key")).toBeNull();
+  });
+
+  it("keeps a non-sensitive setup draft after a reload", () => {
+    const props = { builtinHeadscaleAvailable: true, cloudflareConfigured: false, cloudflareOAuthAvailable: true, language: "zh-CN" as const, onComplete: async () => undefined, onLanguage: () => undefined, publicAddressCandidates: [{ address: "203.0.113.10", interface: "eth0", family: "ipv4" as const, kind: "public" as const, observedAt: "2026-08-19T00:00:00Z" }], suggestedAgentConnectUrl: "" };
+    let container = render(<SetupWizard {...props} />);
+    const location = container.querySelector<HTMLInputElement>("#setup-location-name")!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(location, "DMIT");
+      location.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    act(() => [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("继续"))?.click());
+    act(() => container.querySelector<HTMLInputElement>('input[value="headscale"]')?.click());
+    act(() => root?.unmount());
+    root = undefined;
+    document.body.replaceChildren();
+
+    container = render(<SetupWizard {...props} />);
+    expect(container.textContent).toContain("你准备在哪里使用 Vastora");
+    expect(container.querySelector<HTMLInputElement>('input[value="headscale"]')?.checked).toBe(true);
+    expect(window.sessionStorage.getItem("vastora.initial-setup.v1")).not.toContain("apiKey");
+  });
+
+  it("opens Cloudflare in a normal tab and offers recovery actions", async () => {
+    vi.useFakeTimers();
+    const popupDocument = document.implementation.createHTMLDocument("Cloudflare");
+    const replace = vi.fn();
+    const close = vi.fn();
+    const popup = { close, document: popupDocument, location: { replace }, opener: window } as unknown as Window;
+    const open = vi.spyOn(window, "open").mockReturnValue(popup);
+    vi.spyOn(api, "startCloudflareOAuth").mockResolvedValue({ sessionId: "session", authorizationUrl: "https://dash.cloudflare.test/oauth2/auth", expiresAt: new Date(Date.now() + 60_000).toISOString() });
+    vi.spyOn(api, "pollCloudflareOAuth").mockResolvedValue({ status: "pending" });
+    const container = render(<CloudflareOAuthConnect available connected={false} language="zh-CN" onConnected={() => undefined} />);
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("登录 Cloudflare"))?.click();
+      await Promise.resolve();
+    });
+
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(replace).toHaveBeenCalledWith("https://dash.cloudflare.test/oauth2/auth");
+    expect(container.textContent).toContain("Cloudflare 首次加载可能需要几秒");
+    expect(container.textContent).toContain("重新打开登录页");
+    expect(container.textContent).toContain("复制登录链接");
+    expect(container.textContent).toContain("取消");
   });
 
   it("uses the saved Center address when adding a node and keeps editing advanced", () => {


### PR DESCRIPTION
## What changed

- Open Cloudflare authorization in a regular browser tab with an immediate loading message.
- Add recovery actions to reopen or copy the short-lived sign-in link, plus an explicit cancel action.
- Preserve non-sensitive initial-setup draft fields across reloads while excluding the Headscale API key.
- Remove the optional `account-settings.read` OAuth scope; Vastora already obtains the account ID from the selected zone.
- Add regression coverage for the OAuth UI and setup draft.

## Root cause

Cloudflare can spend several seconds on its login-to-consent transition. Vastora forced that flow into a feature-sized popup that stayed blank without feedback or any recovery path, so the setup page appeared permanently stuck. Refreshing the wizard also discarded all unsaved progress.

## Validation

- Real browser QA against the production-node-d Center through the local frontend: normal page render, recovery controls visible, cancel returns to idle, and setup progress survives reload.
- Cloudflare authorization endpoint and consent page were verified without authorizing or changing DNS.
- `git diff --check` passed.
- Full Go/web/security validation is intentionally delegated to GitHub CI.