### PR TITLE
fix: run Agent installer as an executable

### DIFF
--- a/internal/center/agent_install.go
+++ b/internal/center/agent_install.go
@@ -14,11 +14,47 @@ import (
 	"time"
 )
 
+const agentInstallLoaderScript = `#!/bin/sh
+set -eu
+
+token="${1:-}"
+if [ -z "$token" ]; then
+  echo "Usage: ./vastora-agent-install.sh <one-time-token>" >&2
+  exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "Root privileges are required and sudo is not installed." >&2
+    exit 1
+  fi
+  exec sudo "$0" "$token"
+fi
+
+center_url=@@CENTER_URL@@
+case "$center_url" in
+  https://*) curl_protocol="https" ;;
+  http://127.0.0.1:*|http://127.0.0.1|http://localhost:*|http://localhost) curl_protocol="http" ;;
+  *) echo "Center must use HTTPS; only loopback development addresses may use HTTP." >&2; exit 1 ;;
+esac
+
+installer="$(mktemp -t vastora-agent-installer.XXXXXX)"
+trap 'rm -f "$installer"' EXIT HUP INT TERM
+curl --proto "=$curl_protocol" --tlsv1.2 --max-filesize 1048576 -fsS \
+  -H "Authorization: Bearer $token" \
+  "${center_url%/}/install/agent.sh" -o "$installer"
+printf '%s\n' "$token" | sh "$installer"
+`
+
 const agentInstallScript = `#!/bin/sh
 set -eu
 
 center_url=@@CENTER_URL@@
-token=@@TOKEN@@
+IFS= read -r token
+if [ -z "$token" ]; then
+  echo "The one-time Agent token is required." >&2
+  exit 1
+fi
 
 if [ "$(id -u)" -ne 0 ]; then
   echo "Run this installer with sudo." >&2
@@ -72,7 +108,11 @@ echo "Registering this node and starting the system service..."
 printf '%s' "$token" | /usr/local/bin/vastora agent install --center-url "$center_url" --token-file -
 `
 
-func renderAgentInstallScript(profile AgentEnrollmentInstallProfile, token string) string {
+func renderAgentInstallLoader(centerURL string) string {
+	return strings.ReplaceAll(agentInstallLoaderScript, "@@CENTER_URL@@", shellQuote(centerURL))
+}
+
+func renderAgentInstallScript(profile AgentEnrollmentInstallProfile) string {
 	headscaleBootstrap := ":"
 	if profile.HeadscaleCommand != "" {
 		headscaleBootstrap = `if ! command -v tailscale >/dev/null 2>&1; then
@@ -84,7 +124,6 @@ echo "Joining the private network..."
 	}
 	return strings.NewReplacer(
 		"@@CENTER_URL@@", shellQuote(profile.CenterURL),
-		"@@TOKEN@@", shellQuote(token),
 		"@@HEADSCALE_BOOTSTRAP@@", headscaleBootstrap,
 	).Replace(agentInstallScript)
 }
@@ -121,7 +160,14 @@ func (s *Server) handleAgentInstallScript(writer http.ResponseWriter, request *h
 	writer.Header().Set("Cache-Control", "no-store")
 	token := strings.TrimSpace(strings.TrimPrefix(request.Header.Get("Authorization"), "Bearer "))
 	if token == "" || !strings.HasPrefix(request.Header.Get("Authorization"), "Bearer ") {
-		writeError(writer, http.StatusUnauthorized, errors.New("center: agent enrollment token is required"))
+		centerURL, err := agentInstallerRequestURL(request)
+		if err != nil {
+			writeError(writer, http.StatusBadRequest, err)
+			return
+		}
+		writer.Header().Set("Content-Type", "text/x-shellscript; charset=utf-8")
+		writer.Header().Set("Content-Disposition", `inline; filename="vastora-agent-install.sh"`)
+		_, _ = writer.Write([]byte(renderAgentInstallLoader(centerURL)))
 		return
 	}
 	profile, err := s.store.AgentEnrollmentInstallProfile(request.Context(), token)
@@ -131,7 +177,22 @@ func (s *Server) handleAgentInstallScript(writer http.ResponseWriter, request *h
 	}
 	writer.Header().Set("Content-Type", "text/x-shellscript; charset=utf-8")
 	writer.Header().Set("Content-Disposition", `attachment; filename="vastora-agent-install.sh"`)
-	_, _ = writer.Write([]byte(renderAgentInstallScript(profile, token)))
+	_, _ = writer.Write([]byte(renderAgentInstallScript(profile)))
+}
+
+func agentInstallerRequestURL(request *http.Request) (string, error) {
+	scheme := "http"
+	if request.TLS != nil {
+		scheme = "https"
+	}
+	if forwarded := strings.TrimSpace(strings.Split(request.Header.Get("X-Forwarded-Proto"), ",")[0]); forwarded != "" {
+		scheme = forwarded
+	}
+	centerURL, err := NormalizeAgentConnectURL(scheme + "://" + request.Host)
+	if err != nil {
+		return "", errors.New("center: installer URL must use HTTPS; only loopback development addresses may use HTTP")
+	}
+	return centerURL, nil
 }
 
 func (s *Server) handleAgentBinary(writer http.ResponseWriter, request *http.Request) {

--- a/internal/center/agent_install_test.go
+++ b/internal/center/agent_install_test.go
@@ -124,17 +124,23 @@ func TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload(t *testing.T) {
 	}
 	defer store.Close()
 	handler := NewServer(store, "", false).Handler()
-	request := httptest.NewRequest(http.MethodGet, "/install/agent.sh", nil)
+	request := httptest.NewRequest(http.MethodGet, "https://center.example.com/install/agent.sh", nil)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
-	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("unauthenticated installer status = %d", response.Code)
+	if response.Code != http.StatusOK {
+		t.Fatalf("public installer status = %d", response.Code)
+	}
+	loader := response.Body.String()
+	for _, expected := range []string{"token=\"${1:-}\"", "exec sudo \"$0\" \"$token\"", "center_url='https://center.example.com'", "Authorization: Bearer $token", "${center_url%/}/install/agent.sh", "printf '%s\\n' \"$token\" | sh \"$installer\""} {
+		if !strings.Contains(loader, expected) {
+			t.Fatalf("installer loader is missing %q:\n%s", expected, loader)
+		}
 	}
 	enrollment, err := store.CreateAgentEnrollment(context.Background(), AgentEnrollmentSpec{SiteID: testSiteID(t, store), Name: "bound-node", CenterURL: "https://center.example.com", Gateway: true, Tunnel: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	request = httptest.NewRequest(http.MethodGet, "/install/agent.sh", nil)
+	request = httptest.NewRequest(http.MethodGet, "https://center.example.com/install/agent.sh", nil)
 	request.Header.Set("Authorization", "Bearer "+enrollment.Token)
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
@@ -142,10 +148,13 @@ func TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload(t *testing.T) {
 		t.Fatalf("authenticated installer status = %d, body = %q", response.Code, response.Body.String())
 	}
 	script := response.Body.String()
-	for _, expected := range []string{"center_url='https://center.example.com'", "command -v \"$required\"", "docker info", "sha256sum", "x86_64|amd64", "supports only Ubuntu 24.04 on amd64", "--proto \"=$curl_protocol\"", "--max-filesize 268435456", "Authorization: Bearer $token", "${center_url%/}/api/v1/agent-binaries/linux/$arch", "x-vastora-sha256:", "failed its SHA-256 integrity check", "failed its version check", "install -m 0755", "agent install --center-url \"$center_url\" --token-file -"} {
+	for _, expected := range []string{"center_url='https://center.example.com'", "IFS= read -r token", "command -v \"$required\"", "docker info", "sha256sum", "x86_64|amd64", "supports only Ubuntu 24.04 on amd64", "--proto \"=$curl_protocol\"", "--max-filesize 268435456", "Authorization: Bearer $token", "${center_url%/}/api/v1/agent-binaries/linux/$arch", "x-vastora-sha256:", "failed its SHA-256 integrity check", "failed its version check", "install -m 0755", "agent install --center-url \"$center_url\" --token-file -"} {
 		if !strings.Contains(script, expected) {
 			t.Fatalf("installer is missing %q:\n%s", expected, script)
 		}
+	}
+	if strings.Contains(script, enrollment.Token) {
+		t.Fatal("authenticated installer embeds its one-time token")
 	}
 	for _, hidden := range []string{"--name", "--roles", "--capabilities"} {
 		if strings.Contains(script, hidden) {
@@ -159,5 +168,10 @@ func TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload(t *testing.T) {
 	command.Stdin = strings.NewReader(script)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("installer is not valid POSIX shell: %v\n%s", err, output)
+	}
+	command = exec.Command("sh", "-n")
+	command.Stdin = strings.NewReader(loader)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("installer loader is not valid POSIX shell: %v\n%s", err, output)
 	}
 }

--- a/web/src/views/NodesView.tsx
+++ b/web/src/views/NodesView.tsx
@@ -21,8 +21,10 @@ import { Switch } from "@/components/ui/switch";
 export { validCenterURL } from "../lib/network";
 
 export function agentInstallCommand({ centerURL, enrollment, installerAvailable }: { centerURL: string; enrollment: AgentEnrollment; installerAvailable: boolean }) {
-  const curlSecurity = centerURL.startsWith("https://") ? "--proto '=https' --tlsv1.2" : "--proto '=http'";
-  if (installerAvailable) return `curl ${curlSecurity} -fsS -H ${shellQuote(`Authorization: Bearer ${enrollment.token}`)} ${shellQuote(`${centerURL.replace(/\/$/, "")}/install/agent.sh`)} | sudo sh`;
+  if (installerAvailable) {
+    const installer = "/tmp/vastora-agent-install.sh";
+    return `curl -fsSL ${shellQuote(`${centerURL.replace(/\/$/, "")}/install/agent.sh`)} -o ${installer} && chmod +x ${installer} && ${installer} ${shellQuote(enrollment.token)}`;
+  }
   return `printf '%s' ${shellQuote(enrollment.token)} | sudo /usr/local/bin/vastora agent install --center-url ${shellQuote(centerURL)} --token-file -`;
 }
 

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -349,16 +349,22 @@ describe("network and app views", () => {
     expect(advanced?.open).toBe(false);
   });
 
-  it("generates a TLS-restricted one-line Agent installer", () => {
+  it("downloads and directly runs the executable Agent installer", () => {
     const command = agentInstallCommand({
       centerURL: "https://center.example.com",
       enrollment: { token: "one-time-token", siteId: "site", expiresAt: "2026-08-18T00:10:00Z" },
       installerAvailable: true
     });
-    expect(command).toContain("curl --proto '=https' --tlsv1.2 -fsS");
+    expect(command).toContain("curl -fsSL");
     expect(command).toContain("https://center.example.com/install/agent.sh");
-    expect(command).toContain("-H 'Authorization: Bearer one-time-token'");
-    expect(command).toContain("| sudo sh");
+    expect(command).toContain("-o /tmp/vastora-agent-install.sh");
+    expect(command).toContain("chmod +x /tmp/vastora-agent-install.sh");
+    expect(command).toContain("/tmp/vastora-agent-install.sh 'one-time-token'");
+    expect(command).not.toContain("sudo");
+    expect(command).not.toContain("| sh");
+    expect(command).not.toContain("Authorization: Bearer");
+    expect(command).not.toContain("--proto");
+    expect(command).not.toContain("--tlsv1.2");
     expect(command).not.toContain("--name");
     expect(command).not.toContain("--roles");
     expect(command).not.toContain("--capabilities");


### PR DESCRIPTION
## Summary
- expose a public Agent installer loader that accepts the one-time token as an argument
- download, chmod, and execute the loader without an outer sudo command
- let the loader request root privileges internally before retrieving the authenticated installer

## Verification
- `go test ./internal/center -run TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload -count=1`
- `cd web && npm test -- views.test.tsx`
- `git diff --check`