### PR TITLE
fix: use triggering commit for release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,15 +71,12 @@ jobs:
         id: release_pr
         if: steps.release.outputs.prs_created == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
           head_branch="$(printf '%s' "$RELEASE_PR" | jq -er '.headBranchName')"
-          pull_number="$(printf '%s' "$RELEASE_PR" | jq -er '.number')"
-          base_sha="$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pull_number" --jq '.base.sha')"
           {
             echo "head_branch=$head_branch"
-            echo "base_sha=$base_sha"
+            echo "base_sha=$GITHUB_SHA"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check out release pull request


### PR DESCRIPTION
## Summary
- use the immutable main commit that triggered the Release workflow as the metadata diff base
- avoid GitHub's transient stale PR base SHA when Release Please updates an existing release PR

## Validation
- actionlint
- release metadata validator test
- confirmed release PR #58 currently changes only manifest, changelog, and version.txt