### PR TITLE
fix: reserve private addresses for co-located gateways

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,10 @@ control plane while the host Agent remains the only component that manages
 applications and gateway state. Bundled Headscale runs in its own Docker network
 namespace and publishes only its HTTP control port on host loopback. The host
 Tailscale client therefore owns `tailscale0` without sharing a network namespace
-with the Headscale server process. Center records the bundled infrastructure
+with the Headscale server process. The bundled HTTPS gateway binds only to
+loopback and public addresses that both resolve from its configured hostnames
+and exist on the server, leaving LAN and Tailscale addresses available to the
+co-located Agent gateway. Center records the bundled infrastructure
 specification version and asks the restricted deployment helper to reconcile an
 older installation once after an upgrade; persistent Headscale data and the
 existing encrypted API key are retained.

--- a/internal/center/headscale.go
+++ b/internal/center/headscale.go
@@ -22,7 +22,7 @@ import (
 const (
 	headscaleDNSFile               = "headscale-extra-records.json"
 	builtinHeadscaleRuntimeSetting = "builtin_headscale_runtime"
-	builtinHeadscaleRuntimeVersion = "bridge-loopback-v1"
+	builtinHeadscaleRuntimeVersion = "scoped-center-gateway-v2"
 )
 
 type HeadscaleInput struct {

--- a/internal/deployer/config.go
+++ b/internal/deployer/config.go
@@ -1,15 +1,26 @@
 package deployer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
+
+	"github.com/petauron/vastora/internal/networking"
 )
 
 var dnsLabel = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
+
+type gatewayResolution struct {
+	hostname  string
+	addresses []netip.Addr
+}
 
 func normalizePublicURL(value string) (string, error) {
 	value = strings.TrimRight(strings.TrimSpace(value), "/")
@@ -133,10 +144,76 @@ func renderHeadscalePolicy() []byte {
 `)
 }
 
-func renderCaddyfile(centerURL, centerOrigin, headscaleURL string) []byte {
+func gatewayBindAddresses(ctx context.Context, endpoints ...string) ([]string, error) {
+	candidates, err := networking.Discover(time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("deployer: discover public gateway addresses: %w", err)
+	}
+	resolutions := make([]gatewayResolution, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		parsed, err := url.Parse(endpoint)
+		if err != nil || parsed.Hostname() == "" {
+			return nil, errors.New("deployer: gateway endpoint is invalid")
+		}
+		resolved, err := net.DefaultResolver.LookupNetIP(ctx, "ip", parsed.Hostname())
+		if err != nil {
+			return nil, fmt.Errorf("deployer: resolve gateway hostname %s: %w", parsed.Hostname(), err)
+		}
+		resolutions = append(resolutions, gatewayResolution{hostname: parsed.Hostname(), addresses: resolved})
+	}
+	return selectGatewayBindAddresses(resolutions, candidates)
+}
+
+func selectGatewayBindAddresses(resolutions []gatewayResolution, candidates []networking.Candidate) ([]string, error) {
+	public := make(map[netip.Addr]struct{})
+	for _, candidate := range candidates {
+		if candidate.Kind == networking.KindPublic {
+			if address, err := netip.ParseAddr(candidate.Address); err == nil {
+				public[address.Unmap()] = struct{}{}
+			}
+		}
+	}
+	matched := make(map[netip.Addr]struct{})
+	for _, resolution := range resolutions {
+		hostMatched := false
+		for _, address := range resolution.addresses {
+			address = address.Unmap()
+			if _, exists := public[address]; exists {
+				matched[address] = struct{}{}
+				hostMatched = true
+			}
+		}
+		if !hostMatched {
+			return nil, fmt.Errorf("deployer: gateway hostname %s must resolve directly to a public address assigned to this server", resolution.hostname)
+		}
+	}
+	addresses := make([]netip.Addr, 0, len(matched))
+	for address := range matched {
+		addresses = append(addresses, address)
+	}
+	sort.Slice(addresses, func(left, right int) bool { return addresses[left].Compare(addresses[right]) < 0 })
+	result := []string{"127.0.0.1"}
+	for _, address := range addresses {
+		if address.Is6() {
+			result = append(result, "["+address.String()+"]")
+		} else {
+			result = append(result, address.String())
+		}
+	}
+	return result, nil
+}
+
+func renderCaddyfile(centerURL, centerOrigin, headscaleURL string, bindAddresses []string) []byte {
+	centerHTTP := "http://" + strings.TrimPrefix(centerURL, "https://")
+	headscaleHTTP := "http://" + strings.TrimPrefix(headscaleURL, "https://")
 	return []byte(fmt.Sprintf(`{
 	admin off
 	persist_config off
+	default_bind %s
+}
+
+%s, %s {
+	redir https://{host}{uri} 308
 }
 
 %s {
@@ -146,5 +223,5 @@ func renderCaddyfile(centerURL, centerOrigin, headscaleURL string) []byte {
 %s {
 	reverse_proxy 127.0.0.1:8081
 }
-`, centerURL, centerOrigin, headscaleURL))
+`, strings.Join(bindAddresses, " "), centerHTTP, headscaleHTTP, centerURL, centerOrigin, headscaleURL))
 }

--- a/internal/deployer/config_test.go
+++ b/internal/deployer/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	dockernetwork "github.com/moby/moby/api/types/network"
+	"github.com/petauron/vastora/internal/networking"
 )
 
 func TestBundledServiceURLsUseStandardHTTPS(t *testing.T) {
@@ -48,13 +49,37 @@ func TestGeneratedConfigurationUsesStandardHTTPSAndKeepsSecretsOut(t *testing.T)
 	if !strings.Contains(headscale, "listen_addr: 0.0.0.0:8081") || strings.Contains(headscale, "tls_key_path") || strings.Contains(headscale, "extra_records:") {
 		t.Fatalf("unexpected Headscale configuration:\n%s", headscale)
 	}
-	caddy := string(renderCaddyfile("https://center.example.com", "127.0.0.1:8080", "https://headscale.example.com"))
-	if !strings.Contains(caddy, "https://center.example.com") || !strings.Contains(caddy, "https://headscale.example.com") || strings.Contains(caddy, ":8443") {
+	caddy := string(renderCaddyfile("https://center.example.com", "127.0.0.1:8080", "https://headscale.example.com", []string{"127.0.0.1", "203.0.113.10"}))
+	if !strings.Contains(caddy, "default_bind 127.0.0.1 203.0.113.10") || !strings.Contains(caddy, "http://center.example.com, http://headscale.example.com") || !strings.Contains(caddy, "redir https://{host}{uri} 308") || !strings.Contains(caddy, "https://center.example.com") || !strings.Contains(caddy, "https://headscale.example.com") || strings.Contains(caddy, ":8443") {
 		t.Fatalf("unexpected Caddy configuration:\n%s", caddy)
 	}
 	policy := string(renderHeadscalePolicy())
 	if strings.Contains(policy, "8443") || !strings.Contains(policy, `"ip": ["443"]`) {
 		t.Fatalf("Headscale policy exposes the wrong Center ports:\n%s", policy)
+	}
+}
+
+func TestGatewayBindsOnlyResolvedLocalPublicAddresses(t *testing.T) {
+	resolutions := []gatewayResolution{
+		{hostname: "center.example.com", addresses: []netip.Addr{netip.MustParseAddr("203.0.113.20"), netip.MustParseAddr("198.51.100.5")}},
+		{hostname: "headscale.example.com", addresses: []netip.Addr{netip.MustParseAddr("203.0.113.20"), netip.MustParseAddr("2001:db8::20")}},
+	}
+	candidates := []networking.Candidate{
+		{Address: "203.0.113.20", Kind: networking.KindPublic},
+		{Address: "2001:db8::20", Kind: networking.KindPublic},
+		{Address: "100.64.0.1", Kind: networking.KindHeadscale},
+		{Address: "192.168.1.10", Kind: networking.KindLAN},
+	}
+	addresses, err := selectGatewayBindAddresses(resolutions, candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"127.0.0.1", "203.0.113.20", "[2001:db8::20]"}
+	if strings.Join(addresses, ",") != strings.Join(want, ",") {
+		t.Fatalf("gateway bind addresses = %#v, want %#v", addresses, want)
+	}
+	if _, err := selectGatewayBindAddresses([]gatewayResolution{{hostname: "wrong.example.com", addresses: []netip.Addr{netip.MustParseAddr("198.51.100.5")}}}, candidates); err == nil || !strings.Contains(err.Error(), "must resolve directly") {
+		t.Fatalf("non-local DNS address was accepted: %v", err)
 	}
 }
 

--- a/internal/deployer/headscale.go
+++ b/internal/deployer/headscale.go
@@ -65,6 +65,10 @@ func (installer DockerHeadscaleInstaller) applyHeadscale(ctx context.Context, in
 	if err != nil {
 		return "", "", err
 	}
+	bindAddresses, err := gatewayBindAddresses(ctx, centerURL, headscaleURL)
+	if err != nil {
+		return "", "", err
+	}
 	docker, err := client.New(client.WithHost(settings.Socket))
 	if err != nil {
 		return "", "", fmt.Errorf("deployer: connect Docker: %w", err)
@@ -111,7 +115,7 @@ func (installer DockerHeadscaleInstaller) applyHeadscale(ctx context.Context, in
 			return "", "", err
 		}
 	}
-	if err := settings.replaceGateway(ctx, docker, renderCaddyfile(centerURL, settings.CenterOrigin, headscaleURL)); err != nil {
+	if err := settings.replaceGateway(ctx, docker, renderCaddyfile(centerURL, settings.CenterOrigin, headscaleURL, bindAddresses)); err != nil {
 		return "", "", err
 	}
 	for _, health := range []struct {


### PR DESCRIPTION
## Summary
- bind the bundled Center/Headscale Caddy gateway only to loopback and DNS-confirmed local public addresses
- leave LAN and Tailscale addresses free for an Agent gateway on the same host
- fail closed when a configured gateway hostname does not resolve directly to a public address assigned to the server
- bump the bundled runtime specification so existing installations reconcile once after upgrade

## Validation
- Go unit and race tests
- Staticcheck
- deployment bundle tests
- Caddy 2.11.4 adapted and validated the generated production-node-a configuration
- production-node-a DNS and interface match confirmed for 192.0.2.10