### PR TITLE
fix: verify private services through gateway addresses

### DIFF
--- a/internal/center/publication_verification.go
+++ b/internal/center/publication_verification.go
@@ -44,9 +44,19 @@ func (s *Store) VerifyPublication(ctx context.Context, id string) (PublicationVi
 	if routeStatus != "" && routeStatus != "ready" {
 		return s.recordPublicationVerification(ctx, id, "gateway configuration is not ready")
 	}
-	addresses, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, publication.Hostname)
-	if lookupErr != nil || len(addresses) == 0 {
-		return s.recordPublicationVerification(ctx, id, "DNS record has not propagated")
+	verificationAddress, privateEntry, targetErr := privatePublicationVerificationAddress(publication)
+	if targetErr != nil {
+		return s.recordPublicationVerification(ctx, id, targetErr.Error())
+	}
+	addresses := []net.IPAddr{}
+	if privateEntry {
+		addresses = append(addresses, net.IPAddr{IP: net.ParseIP(verificationAddress)})
+	} else {
+		var lookupErr error
+		addresses, lookupErr = net.DefaultResolver.LookupIPAddr(ctx, publication.Hostname)
+		if lookupErr != nil || len(addresses) == 0 {
+			return s.recordPublicationVerification(ctx, id, "DNS record has not propagated")
+		}
 	}
 	if publication.Kind != publicationCloudflare && publication.DNSRecord != nil {
 		matched := false
@@ -72,7 +82,11 @@ func (s *Store) VerifyPublication(ctx context.Context, id string) (PublicationVi
 		if publication.Kind == publicationShared443 {
 			port = "443"
 		}
-		connection, dialErr := (&net.Dialer{Timeout: 8 * time.Second}).DialContext(ctx, "tcp", net.JoinHostPort(publication.Hostname, port))
+		host := publication.Hostname
+		if verificationAddress != "" {
+			host = verificationAddress
+		}
+		connection, dialErr := (&net.Dialer{Timeout: 8 * time.Second}).DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 		if dialErr != nil {
 			return s.recordPublicationVerification(ctx, id, "public port is not reachable")
 		}
@@ -88,7 +102,8 @@ func (s *Store) VerifyPublication(ctx context.Context, id string) (PublicationVi
 	if err != nil {
 		return PublicationView{}, err
 	}
-	client := &http.Client{Timeout: 12 * time.Second}
+	client, closeClient := publicationVerificationHTTPClient(verificationAddress)
+	defer closeClient()
 	response, requestErr := client.Do(request)
 	if requestErr != nil {
 		return s.recordPublicationVerification(ctx, id, "service health check has not passed: "+requestErr.Error())
@@ -99,6 +114,35 @@ func (s *Store) VerifyPublication(ctx context.Context, id string) (PublicationVi
 		return s.recordPublicationVerification(ctx, id, "service returned "+response.Status)
 	}
 	return s.markPublicationReady(ctx, id)
+}
+
+func privatePublicationVerificationAddress(publication PublicationView) (string, bool, error) {
+	if publication.Kind != publicationLAN && publication.Kind != publicationHeadscale {
+		return "", false, nil
+	}
+	if publication.DNSRecord == nil || net.ParseIP(publication.DNSRecord.Value) == nil {
+		return "", true, errors.New("gateway entry address is not ready")
+	}
+	return net.ParseIP(publication.DNSRecord.Value).String(), true, nil
+}
+
+func publicationVerificationHTTPClient(address string) (*http.Client, func()) {
+	client := &http.Client{Timeout: 12 * time.Second}
+	if address == "" {
+		return client, func() {}
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	dialer := &net.Dialer{Timeout: 8 * time.Second}
+	transport.DialContext = func(ctx context.Context, network, target string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(target)
+		if err != nil {
+			return nil, err
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(address, port))
+	}
+	client.Transport = transport
+	return client, transport.CloseIdleConnections
 }
 
 func (s *Store) recordPublicationVerification(ctx context.Context, id, message string) (PublicationView, error) {

--- a/internal/center/publication_verification_test.go
+++ b/internal/center/publication_verification_test.go
@@ -1,0 +1,49 @@
+package center
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPrivatePublicationVerificationUsesConfirmedGatewayAddress(t *testing.T) {
+	var receivedHost string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		receivedHost = request.Host
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	serverAddress := strings.TrimPrefix(server.URL, "http://")
+	gatewayAddress, port, err := net.SplitHostPort(serverAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, closeClient := publicationVerificationHTTPClient(gatewayAddress)
+	defer closeClient()
+	response, err := client.Get("http://private-service.example.test:" + port + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusNoContent || receivedHost != "private-service.example.test:"+port {
+		t.Fatalf("status=%d host=%q", response.StatusCode, receivedHost)
+	}
+}
+
+func TestPrivatePublicationVerificationTargetFailsClosed(t *testing.T) {
+	publication := PublicationView{Kind: publicationHeadscale, DNSRecord: &DNSRecordInstruction{Value: "100.64.0.10"}}
+	address, privateEntry, err := privatePublicationVerificationAddress(publication)
+	if err != nil || !privateEntry || address != "100.64.0.10" {
+		t.Fatalf("address=%q private=%t err=%v", address, privateEntry, err)
+	}
+	publication.DNSRecord = nil
+	if _, privateEntry, err = privatePublicationVerificationAddress(publication); err == nil || !privateEntry {
+		t.Fatalf("missing private entry address was accepted: private=%t err=%v", privateEntry, err)
+	}
+	if address, privateEntry, err = privatePublicationVerificationAddress(PublicationView{Kind: publicationPublic}); err != nil || privateEntry || address != "" {
+		t.Fatalf("public publication unexpectedly received a private target: address=%q private=%t err=%v", address, privateEntry, err)
+	}
+}


### PR DESCRIPTION
## Outcome

- verify LAN and Headscale publications through the confirmed Gateway address while preserving HTTP Host and TLS SNI
- avoid depending on the Center host DNS for managed private records
- keep public and Cloudflare verification on normal DNS resolution

## Validation

- [ ] `make check` (delegated to CI)
- [ ] `make security-check` (delegated to CI)
- [x] Tests cover private address dialing, Host preservation, and fail-closed behavior.
- [x] Go binary builds locally.

## Security review

- [x] No secret, private host, account, or runtime data is added.
- [x] The target comes from Center-confirmed Gateway state and preserves the Center-Agent trust boundary.