### PR TITLE
fix: protect system gateway from stale state

### DIFF
--- a/cmd/vastora/agent_cmd.go
+++ b/cmd/vastora/agent_cmd.go
@@ -244,11 +244,13 @@ func runAgent(arguments []string) error {
 			if err != nil {
 				return err
 			}
+			caddyProvisioner := agent.DockerGatewayProvisioner{Image: *caddyImage, AdminListen: caddyDriver.AdminListen, AdminSocketPath: caddyDriver.AdminSocketPath}
+			caddyDriver.SystemGateway = caddyProvisioner
 			layer4 := agent.DockerLayer4Provisioner{Image: *haproxyImage}
 			managedDriver := &agent.ManagedGatewayDriver{Caddy: caddyDriver, Layer4: layer4}
 			client.GatewayDriver = managedDriver
 			client.GatewayProvisioner = agent.ManagedGatewayProvisioner{
-				Caddy:  agent.DockerGatewayProvisioner{Image: *caddyImage, AdminListen: caddyDriver.AdminListen, AdminSocketPath: caddyDriver.AdminSocketPath},
+				Caddy:  caddyProvisioner,
 				Layer4: layer4,
 				Driver: managedDriver,
 			}

--- a/internal/agent/caddy_driver.go
+++ b/internal/agent/caddy_driver.go
@@ -23,6 +23,7 @@ type CaddyGatewayDriver struct {
 	AdminListen     string
 	AdminSocketPath string
 	HTTPClient      *http.Client
+	SystemGateway   SystemGatewayInspector
 
 	mu           sync.RWMutex
 	state        gateway.DesiredState
@@ -65,6 +66,15 @@ func (driver *CaddyGatewayDriver) ApplyConfiguration(ctx context.Context, desire
 	if err := gateway.ValidateCertificates(certificates); err != nil {
 		return err
 	}
+	if driver.SystemGateway != nil {
+		services, err := driver.SystemGateway.ProtectedSystemServices(ctx)
+		if err != nil {
+			return fmt.Errorf("agent: inspect protected system gateway: %w", err)
+		}
+		if err := validateProtectedSystemRoutes(desired, services); err != nil {
+			return err
+		}
+	}
 	configuration, err := caddyConfiguration(desired.Sorted(), certificates, driver.AdminListen)
 	if err != nil {
 		return err
@@ -91,6 +101,32 @@ func (driver *CaddyGatewayDriver) ApplyConfiguration(ctx context.Context, desire
 	driver.state = desired.Sorted()
 	driver.certificates = append([]gateway.Certificate(nil), certificates...)
 	driver.mu.Unlock()
+	return nil
+}
+
+func validateProtectedSystemRoutes(desired gateway.DesiredState, services []string) error {
+	if len(services) == 0 {
+		return nil
+	}
+	routes := make(map[string]gateway.Route, len(desired.Routes))
+	for _, route := range desired.Routes {
+		routes[route.ID] = route
+	}
+	for _, service := range services {
+		required := []struct {
+			id       string
+			listener string
+		}{
+			{"system-" + service, "public"},
+			{"system-" + service + "-local", "system"},
+		}
+		for _, expected := range required {
+			route, exists := routes[expected.id]
+			if !exists || !route.System || !route.TLSEnabled || route.ListenerKind != expected.listener {
+				return fmt.Errorf("agent: refusing to replace protected system gateway without %s route %q", expected.listener, expected.id)
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/agent/gateway_provisioner.go
+++ b/internal/agent/gateway_provisioner.go
@@ -30,6 +30,10 @@ type GatewayProvisioner interface {
 	Remove(context.Context) error
 }
 
+type SystemGatewayInspector interface {
+	ProtectedSystemServices(context.Context) ([]string, error)
+}
+
 type DockerGatewayProvisioner struct {
 	Socket          string
 	Image           string
@@ -38,6 +42,36 @@ type DockerGatewayProvisioner struct {
 	AdminSocketPath string
 	DataVolume      string
 	ConfigVolume    string
+}
+
+func (provisioner DockerGatewayProvisioner) ProtectedSystemServices(ctx context.Context) ([]string, error) {
+	settings, err := provisioner.settings()
+	if err != nil {
+		return nil, err
+	}
+	docker, err := provisioner.client()
+	if err != nil {
+		return nil, err
+	}
+	defer docker.Close()
+	existing, err := inspectManagedCaddy(ctx, docker, settings.Container)
+	if err != nil || existing == nil {
+		return nil, err
+	}
+	encoded := strings.TrimSpace(existing.Container.Config.Labels[gatewayruntime.SystemServicesLabel])
+	if encoded == "" {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	services := make([]string, 0, 2)
+	for _, value := range strings.Split(encoded, ",") {
+		value = strings.TrimSpace(value)
+		if value != "" && !seen[value] {
+			seen[value] = true
+			services = append(services, value)
+		}
+	}
+	return services, nil
 }
 
 func (provisioner DockerGatewayProvisioner) Ensure(ctx context.Context) error {

--- a/internal/agent/gateway_test.go
+++ b/internal/agent/gateway_test.go
@@ -33,6 +33,12 @@ type fakeLayer4Provisioner struct {
 	removed  int
 }
 
+type staticSystemGatewayInspector []string
+
+func (services staticSystemGatewayInspector) ProtectedSystemServices(context.Context) ([]string, error) {
+	return append([]string(nil), services...), nil
+}
+
 func (provisioner *fakeLayer4Provisioner) Apply(context.Context, gateway.SharedHTTPS) error {
 	return provisioner.applyErr
 }
@@ -402,5 +408,39 @@ func TestGatewayProvisionerSharesUnixAdminSocketWithHost(t *testing.T) {
 	}
 	if _, err := (DockerGatewayProvisioner{AdminSocketPath: "relative.sock"}).settings(); err == nil {
 		t.Fatal("relative Admin socket path was accepted")
+	}
+}
+
+func TestProtectedSystemGatewayRejectsStateWithoutSystemRoutes(t *testing.T) {
+	driver, err := NewCaddyGatewayDriver("http://127.0.0.1:2019")
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver.SystemGateway = staticSystemGatewayInspector{"center", "headscale"}
+	err = driver.ApplyConfiguration(context.Background(), gatewayState(1, 3000), nil)
+	if err == nil || !strings.Contains(err.Error(), `without public route "system-center"`) {
+		t.Fatalf("unsafe stale gateway state was not rejected: %v", err)
+	}
+}
+
+func TestProtectedSystemGatewayAcceptsCompleteSystemRoutes(t *testing.T) {
+	desired := gateway.DesiredState{
+		Revision: 1,
+		Listeners: []gateway.Listener{
+			{Kind: "public", Address: "192.0.2.10", HTTPPort: 80, HTTPSPort: 443},
+			{Kind: "system", Address: "127.0.0.1", HTTPPort: 80, HTTPSPort: 443},
+		},
+	}
+	for _, service := range []struct {
+		name string
+		port int
+	}{{"center", 8080}, {"headscale", 8081}} {
+		desired.Routes = append(desired.Routes,
+			gateway.Route{ID: "system-" + service.name, Hostname: service.name + ".example.test", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: service.port}}, TLSEnabled: true, ListenerKind: "public", System: true},
+			gateway.Route{ID: "system-" + service.name + "-local", Hostname: service.name + ".example.test", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: service.port}}, TLSEnabled: true, ListenerKind: "system", System: true},
+		)
+	}
+	if err := validateProtectedSystemRoutes(desired, []string{"center", "headscale"}); err != nil {
+		t.Fatalf("complete protected system state was rejected: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- detect Deployer-owned Caddy system services dynamically
- reject stale gateway desired state that omits protected Center or Headscale routes
- wire the protection into restore and normal desired-state application

## Validation
- go build ./...
- full tests delegated to CI

## Deployment finding
During the alpha.23 production-node-a upgrade, the previous Agent restored its persisted pre-migration gateway state and replaced the complete Caddy config before its first heartbeat. This guard fails closed before touching Caddy, allowing the Agent to report the stale task and receive the new complete state.