### PR TITLE
fix: reload 3x-ui subscription routes

### DIFF
--- a/internal/agent/docker_executor_3xui.go
+++ b/internal/agent/docker_executor_3xui.go
@@ -161,8 +161,12 @@ func configureThreeXUISubscription(ctx context.Context, address string, panelPor
 	settings["subClashEnable"] = true
 	settings["subClashPath"] = threeXUIClashSubscriptionPath
 	settings["subClashAutoDetect"] = true
+	settings["subClashUserAgentRegex"] = threeXUIClashUserAgentRegex
 	if _, err := threeXUIRequest(ctx, http.MethodPost, baseURL+"/panel/api/setting/update", apiToken, settings); err != nil {
 		return fmt.Errorf("agent: update 3x-ui subscription settings: %w", err)
+	}
+	if err := restartThreeXUIPanel(ctx, baseURL, apiToken); err != nil {
+		return err
 	}
 	return waitForEndpoint(ctx, address, 2096)
 }

--- a/internal/agent/three_xui_clients_test.go
+++ b/internal/agent/three_xui_clients_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -40,6 +41,8 @@ func TestThreeXUIClientListReturnsOnlySafeMetadata(t *testing.T) {
 func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T) {
 	updatedSubID := ""
 	var updatedSettings map[string]any
+	var restartPending atomic.Bool
+	var restartCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		response.Header().Set("Content-Type", "application/json")
 		switch request.Method + " " + request.URL.Path {
@@ -54,11 +57,20 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 			}
 			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
 		case "POST /panel/api/setting/all":
+			if restartPending.Swap(false) {
+				response.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = response.Write([]byte(`{"success":false}`))
+				return
+			}
 			_, _ = response.Write([]byte(`{"success":true,"obj":{"subEnable":true,"subPath":"/sub/","subClashEnable":false}}`))
 		case "POST /panel/api/setting/update":
 			if json.NewDecoder(request.Body).Decode(&updatedSettings) != nil {
 				t.Fatal("Clash subscription settings were not decoded")
 			}
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		case "POST /panel/api/setting/restartPanel":
+			restartCount.Add(1)
+			restartPending.Store(true)
 			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
 		case "GET /panel/api/clients/list/paged":
 			_, _ = response.Write([]byte(`{"success":true,"obj":{"items":[],"total":0}}`))
@@ -93,8 +105,11 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 	if clashSubscription.SecretKind != "clash_subscription" || clashSubscription.Secret != "https://subscription.example.test/clash/"+updatedSubID {
 		t.Fatalf("unexpected Clash subscription link: %#v", clashSubscription)
 	}
-	if updatedSettings["subClashEnable"] != true || updatedSettings["subClashPath"] != "/clash/" || updatedSettings["subClashAutoDetect"] != true {
+	if updatedSettings["subClashEnable"] != true || updatedSettings["subClashPath"] != "/clash/" || updatedSettings["subClashAutoDetect"] != true || updatedSettings["subClashUserAgentRegex"] != `(?i)(clash|mihomo)` {
 		t.Fatalf("Clash/Mihomo output was not enabled: %#v", updatedSettings)
+	}
+	if restartCount.Load() != 2 {
+		t.Fatalf("3x-ui restart count = %d, want 2", restartCount.Load())
 	}
 }
 

--- a/internal/agent/three_xui_subscription.go
+++ b/internal/agent/three_xui_subscription.go
@@ -11,11 +11,13 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
 	threeXUIRawSubscriptionPath   = "/sub/"
 	threeXUIClashSubscriptionPath = "/clash/"
+	threeXUIClashUserAgentRegex   = `(?i)(clash|mihomo)`
 )
 
 func applySubscriptionCommand(ctx context.Context, store *Store, command SubscriptionCommandTask) (SubscriptionCommandResult, error) {
@@ -59,14 +61,15 @@ func configureThreeXUIPublicSubscription(ctx context.Context, endpoint, token, d
 		return "", fmt.Errorf("agent: read 3x-ui subscription settings: %w", err)
 	}
 	desired := map[string]any{
-		"subEnable":          true,
-		"subPath":            threeXUIRawSubscriptionPath,
-		"subDomain":          domain,
-		"subURI":             parsed.String(),
-		"subClashEnable":     true,
-		"subClashPath":       threeXUIClashSubscriptionPath,
-		"subClashURI":        clashURI.String(),
-		"subClashAutoDetect": true,
+		"subEnable":              true,
+		"subPath":                threeXUIRawSubscriptionPath,
+		"subDomain":              domain,
+		"subURI":                 parsed.String(),
+		"subClashEnable":         true,
+		"subClashPath":           threeXUIClashSubscriptionPath,
+		"subClashURI":            clashURI.String(),
+		"subClashAutoDetect":     true,
+		"subClashUserAgentRegex": threeXUIClashUserAgentRegex,
 	}
 	changed := false
 	for key, value := range desired {
@@ -79,6 +82,35 @@ func configureThreeXUIPublicSubscription(ctx context.Context, endpoint, token, d
 		if _, err := threeXUIRequest(ctx, http.MethodPost, endpoint+"/panel/api/setting/update", token, settings); err != nil {
 			return "", fmt.Errorf("agent: update 3x-ui public subscription formats: %w", err)
 		}
+		if err := restartThreeXUIPanel(ctx, endpoint, token); err != nil {
+			return "", err
+		}
 	}
 	return clashURI.String(), nil
+}
+
+func restartThreeXUIPanel(ctx context.Context, endpoint, token string) error {
+	if _, err := threeXUIRequest(ctx, http.MethodPost, endpoint+"/panel/api/setting/restartPanel", token, map[string]any{}); err != nil {
+		return fmt.Errorf("agent: restart 3x-ui after subscription update: %w", err)
+	}
+	restartContext, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	sawUnavailable := false
+	for {
+		probeContext, probeCancel := context.WithTimeout(restartContext, time.Second)
+		_, probeErr := threeXUIRequest(probeContext, http.MethodPost, endpoint+"/panel/api/setting/all", token, map[string]any{})
+		probeCancel()
+		if probeErr != nil {
+			sawUnavailable = true
+		} else if sawUnavailable {
+			return nil
+		}
+		select {
+		case <-restartContext.Done():
+			return fmt.Errorf("agent: wait for 3x-ui subscription reload: %w", restartContext.Err())
+		case <-ticker.C:
+		}
+	}
 }

--- a/internal/agent/three_xui_subscription_test.go
+++ b/internal/agent/three_xui_subscription_test.go
@@ -7,11 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
 )
 
 func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) {
 	var updated map[string]any
+	var restartPending atomic.Bool
+	var restartCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.Header.Get("Authorization") != "Bearer local-api-token" {
 			t.Fatalf("missing API token: %q", request.Header.Get("Authorization"))
@@ -19,11 +22,20 @@ func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) 
 		response.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/panel/api/setting/all":
+			if restartPending.Swap(false) {
+				response.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = response.Write([]byte(`{"success":false}`))
+				return
+			}
 			_, _ = response.Write([]byte(`{"success":true,"obj":{"subListen":"100.64.0.10","subPort":2096,"subPath":"/sub/","subClashEnable":false}}`))
 		case "/panel/api/setting/update":
 			if err := json.NewDecoder(request.Body).Decode(&updated); err != nil {
 				t.Fatal(err)
 			}
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		case "/panel/api/setting/restartPanel":
+			restartCount.Add(1)
+			restartPending.Store(true)
 			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
 		default:
 			http.NotFound(response, request)
@@ -69,8 +81,11 @@ func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) 
 	if updated["subEnable"] != true || updated["subPath"] != "/sub/" {
 		t.Fatalf("public subscription endpoint was not enabled: %#v", updated)
 	}
-	if updated["subClashEnable"] != true || updated["subClashPath"] != "/clash/" || updated["subClashURI"] != "https://subscribe.example.com/clash/" || updated["subClashAutoDetect"] != true {
+	if updated["subClashEnable"] != true || updated["subClashPath"] != "/clash/" || updated["subClashURI"] != "https://subscribe.example.com/clash/" || updated["subClashAutoDetect"] != true || updated["subClashUserAgentRegex"] != `(?i)(clash|mihomo)` {
 		t.Fatalf("Clash/Mihomo subscription endpoint was not enabled: %#v", updated)
+	}
+	if restartCount.Load() != 1 {
+		t.Fatalf("3x-ui restart count = %d, want 1", restartCount.Load())
 	}
 	if updated["subListen"] != "100.64.0.10" || updated["subPath"] != "/sub/" {
 		t.Fatalf("existing private subscription settings were changed: %#v", updated)


### PR DESCRIPTION
## Summary
- reload 3x-ui after subscription route settings change using its supported restart API
- wait for the panel to cycle down and return before completing the task
- set the Clash/Mihomo user-agent regex explicitly because an existing installation may store it as blank

## Validation
- this follow-up comes from live alpha.26 verification: settings persisted, but /clash remained 404 until process reload
- full validation is delegated to GitHub CI as requested; no local test suite was run