### PR TITLE
fix: accept in-process 3x-ui reloads

### DIFF
--- a/internal/agent/docker_executor_3xui.go
+++ b/internal/agent/docker_executor_3xui.go
@@ -165,7 +165,7 @@ func configureThreeXUISubscription(ctx context.Context, address string, panelPor
 	if _, err := threeXUIRequest(ctx, http.MethodPost, baseURL+"/panel/api/setting/update", apiToken, settings); err != nil {
 		return fmt.Errorf("agent: update 3x-ui subscription settings: %w", err)
 	}
-	if err := restartThreeXUIPanel(ctx, baseURL, apiToken); err != nil {
+	if err := restartThreeXUIPanel(ctx, baseURL, apiToken, threeXUIRestartSettleTime); err != nil {
 		return err
 	}
 	return waitForEndpoint(ctx, address, 2096)

--- a/internal/agent/three_xui_subscription.go
+++ b/internal/agent/three_xui_subscription.go
@@ -18,6 +18,7 @@ const (
 	threeXUIRawSubscriptionPath   = "/sub/"
 	threeXUIClashSubscriptionPath = "/clash/"
 	threeXUIClashUserAgentRegex   = `(?i)(clash|mihomo)`
+	threeXUIRestartSettleTime     = 4 * time.Second
 )
 
 func applySubscriptionCommand(ctx context.Context, store *Store, command SubscriptionCommandTask) (SubscriptionCommandResult, error) {
@@ -82,14 +83,14 @@ func configureThreeXUIPublicSubscription(ctx context.Context, endpoint, token, d
 		if _, err := threeXUIRequest(ctx, http.MethodPost, endpoint+"/panel/api/setting/update", token, settings); err != nil {
 			return "", fmt.Errorf("agent: update 3x-ui public subscription formats: %w", err)
 		}
-		if err := restartThreeXUIPanel(ctx, endpoint, token); err != nil {
+		if err := restartThreeXUIPanel(ctx, endpoint, token, threeXUIRestartSettleTime); err != nil {
 			return "", err
 		}
 	}
 	return clashURI.String(), nil
 }
 
-func restartThreeXUIPanel(ctx context.Context, endpoint, token string) error {
+func restartThreeXUIPanel(ctx context.Context, endpoint, token string, settleTime time.Duration) error {
 	if _, err := threeXUIRequest(ctx, http.MethodPost, endpoint+"/panel/api/setting/restartPanel", token, map[string]any{}); err != nil {
 		return fmt.Errorf("agent: restart 3x-ui after subscription update: %w", err)
 	}
@@ -97,6 +98,7 @@ func restartThreeXUIPanel(ctx context.Context, endpoint, token string) error {
 	defer cancel()
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
+	restartStarted := time.Now()
 	sawUnavailable := false
 	for {
 		probeContext, probeCancel := context.WithTimeout(restartContext, time.Second)
@@ -104,7 +106,7 @@ func restartThreeXUIPanel(ctx context.Context, endpoint, token string) error {
 		probeCancel()
 		if probeErr != nil {
 			sawUnavailable = true
-		} else if sawUnavailable {
+		} else if sawUnavailable || time.Since(restartStarted) >= settleTime {
 			return nil
 		}
 		select {

--- a/internal/agent/three_xui_subscription_test.go
+++ b/internal/agent/three_xui_subscription_test.go
@@ -9,7 +9,31 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 )
+
+func TestRestartThreeXUIPanelAcceptsInProcessReload(t *testing.T) {
+	var restartCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/panel/api/setting/restartPanel":
+			restartCount.Add(1)
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		case "/panel/api/setting/all":
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	if err := restartThreeXUIPanel(context.Background(), server.URL, "local-api-token", 10*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if restartCount.Load() != 1 {
+		t.Fatalf("3x-ui restart count = %d, want 1", restartCount.Load())
+	}
+}
 
 func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) {
 	var updated map[string]any


### PR DESCRIPTION
## Summary
- accept both observable restarts and 3x-ui in-process subscription reloads
- wait through the documented restart grace period before treating an uninterrupted API as ready
- cover the no-downtime reload path in the Agent tests

## Live evidence
- alpha.27 successfully reloaded both /clash/ and User-Agent auto-detection
- the task stayed pending only because the reload downtime was shorter than the Agent polling interval

## Validation
- full validation is delegated to GitHub CI as requested; no local test suite was run