### PR TITLE
fix: export public Reality endpoints in subscriptions

### DIFF
--- a/internal/agent/three_xui_clients.go
+++ b/internal/agent/three_xui_clients.go
@@ -275,6 +275,14 @@ func revealThreeXUIClientSubscription(ctx context.Context, baseURL, token string
 	if err != nil || base.Scheme != "https" || base.Hostname() == "" || base.Port() != "" || base.Path != threeXUIRawSubscriptionPath || base.RawQuery != "" || base.Fragment != "" {
 		return "", errors.New("agent: no ready public subscription entry is available")
 	}
+	for _, inbound := range command.Inbounds {
+		if strings.TrimSpace(inbound.ConnectHostname) == "" || strings.TrimSpace(inbound.SNIHostname) == "" {
+			continue
+		}
+		if err := syncThreeXUIRealityHost(ctx, baseURL, token, inbound.ID, inbound.ConnectHostname, inbound.SNIHostname); err != nil {
+			return "", err
+		}
+	}
 	_, err = configureThreeXUIPublicSubscription(ctx, baseURL, token, base.Hostname(), base.String())
 	if err != nil {
 		return "", err

--- a/internal/agent/three_xui_clients_test.go
+++ b/internal/agent/three_xui_clients_test.go
@@ -41,6 +41,7 @@ func TestThreeXUIClientListReturnsOnlySafeMetadata(t *testing.T) {
 func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T) {
 	updatedSubID := ""
 	var updatedSettings map[string]any
+	var syncedHost threeXUIHostGroup
 	var restartPending atomic.Bool
 	var restartCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
@@ -56,6 +57,13 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 				t.Fatal("subscription id was not generated in the full client payload")
 			}
 			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		case "GET /panel/api/hosts/byInbound/9":
+			_, _ = response.Write([]byte(`{"success":true,"obj":[]}`))
+		case "POST /panel/api/hosts/add":
+			if json.NewDecoder(request.Body).Decode(&syncedHost) != nil {
+				t.Fatal("Reality subscription host was not decoded")
+			}
+			_, _ = response.Write([]byte(`{"success":true,"obj":[]}`))
 		case "POST /panel/api/setting/all":
 			if restartPending.Swap(false) {
 				response.WriteHeader(http.StatusServiceUnavailable)
@@ -81,7 +89,7 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 	defer server.Close()
 	store := threeXUIClientTestStore(t, server, "local-token")
 	defer store.Close()
-	inbounds := []ThreeXUIClientInbound{{ID: 9, Name: "inbound-9", ConnectHostname: "reality.example.test"}}
+	inbounds := []ThreeXUIClientInbound{{ID: 9, Name: "inbound-9", ConnectHostname: "reality.example.test", SNIHostname: "www.example.com"}}
 
 	link, err := applyThreeXUIClientCommand(context.Background(), store, ThreeXUIClientCommandTask{Action: "reveal_link", Email: "MacBook", InboundID: 9, Inbounds: inbounds})
 	if err != nil {
@@ -97,6 +105,9 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 	}
 	if subscription.SecretKind != "subscription" || subscription.Secret != "https://subscription.example.test/sub/"+updatedSubID {
 		t.Fatalf("unexpected subscription link: %#v", subscription)
+	}
+	if syncedHost.GroupID != "vastora-public-9" || len(syncedHost.InboundIDs) != 1 || syncedHost.InboundIDs[0] != 9 || len(syncedHost.Hosts) != 1 || syncedHost.Hosts[0] != "reality.example.test" || syncedHost.Port != 443 || syncedHost.SNI != "www.example.com" || syncedHost.Security != "same" {
+		t.Fatalf("public Reality endpoint was not synchronized into subscriptions: %#v", syncedHost)
 	}
 	if updatedSettings["subClashEnable"] != true || updatedSettings["subClashPath"] != "/clash/" || updatedSettings["subClashAutoDetect"] != true || updatedSettings["subClashUserAgentRegex"] != `(?i)(clash|mihomo)` {
 		t.Fatalf("Clash/Mihomo output was not enabled: %#v", updatedSettings)

--- a/internal/agent/three_xui_reality.go
+++ b/internal/agent/three_xui_reality.go
@@ -27,6 +27,22 @@ type threeXUIRealityInbound struct {
 	StreamSettings json.RawMessage `json:"streamSettings"`
 }
 
+type threeXUIHostGroup struct {
+	GroupID           string   `json:"groupId"`
+	InboundIDs        []int    `json:"inboundIds"`
+	Hosts             []string `json:"hosts"`
+	Remark            string   `json:"remark"`
+	ServerDescription string   `json:"serverDescription"`
+	IsDisabled        bool     `json:"isDisabled"`
+	IsHidden          bool     `json:"isHidden"`
+	Tags              []string `json:"tags"`
+	Port              int      `json:"port"`
+	Security          string   `json:"security"`
+	SNI               string   `json:"sni"`
+	Fingerprint       string   `json:"fingerprint"`
+	MihomoIPVersion   string   `json:"mihomoIpVersion"`
+}
+
 type realityScanResult struct {
 	Target      string   `json:"target"`
 	Host        string   `json:"host"`
@@ -56,7 +72,14 @@ func applyRealityCommand(ctx context.Context, store *Store, commandID string, co
 	if existing, ok, err := findRealityInbound(ctx, baseURL, secrets["api_token"], remark); err != nil {
 		return RealityCommandResult{}, err
 	} else if ok {
-		return realityResultFromInbound(existing, command.ConnectHostname, command.Name)
+		result, err := realityResultFromInbound(existing, command.ConnectHostname, command.Name)
+		if err != nil {
+			return RealityCommandResult{}, err
+		}
+		if err := syncThreeXUIRealityHost(ctx, baseURL, secrets["api_token"], result.InboundID, result.ConnectHostname, result.SNIHostname); err != nil {
+			return RealityCommandResult{}, err
+		}
+		return result, nil
 	}
 
 	target, sni, err := selectRealityTarget(ctx, baseURL, secrets["api_token"], command)
@@ -101,7 +124,74 @@ func applyRealityCommand(ctx context.Context, store *Store, commandID string, co
 	if json.Unmarshal(added, &inbound) != nil || inbound.ID < 1 {
 		return RealityCommandResult{}, errors.New("agent: 3x-ui returned an invalid REALITY inbound")
 	}
-	return RealityCommandResult{InboundID: inbound.ID, Name: command.Name, Listen: listen, Port: port, Target: target, SNIHostname: sni, ConnectHostname: command.ConnectHostname, ShareURI: realityShareURI(clientID, command.ConnectHostname, command.Name, sni, keyPair.PublicKey, shortID)}, nil
+	result := RealityCommandResult{InboundID: inbound.ID, Name: command.Name, Listen: listen, Port: port, Target: target, SNIHostname: sni, ConnectHostname: command.ConnectHostname, ShareURI: realityShareURI(clientID, command.ConnectHostname, command.Name, sni, keyPair.PublicKey, shortID)}
+	if err := syncThreeXUIRealityHost(ctx, baseURL, secrets["api_token"], result.InboundID, result.ConnectHostname, result.SNIHostname); err != nil {
+		return RealityCommandResult{}, err
+	}
+	return result, nil
+}
+
+func syncThreeXUIRealityHost(ctx context.Context, baseURL, token string, inboundID int, connectHostname, sniHostname string) error {
+	connectHostname = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(connectHostname), "."))
+	sniHostname = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(sniHostname), "."))
+	if inboundID < 1 || !validThreeXUIShareHostname(connectHostname) || !validThreeXUIShareHostname(sniHostname) {
+		return errors.New("agent: invalid public REALITY subscription endpoint")
+	}
+	groupID := "vastora-public-" + strconv.Itoa(inboundID)
+	desired := threeXUIHostGroup{
+		GroupID: groupID, InboundIDs: []int{inboundID}, Hosts: []string{connectHostname},
+		Remark: "{{INBOUND}}-{{EMAIL}}", ServerDescription: "Managed by Vastora",
+		Tags: []string{"vastora"}, Port: 443, Security: "same", SNI: sniHostname,
+		Fingerprint: "chrome", MihomoIPVersion: "dual",
+	}
+	payload, err := threeXUIAPI(ctx, http.MethodGet, baseURL+"/panel/api/hosts/byInbound/"+strconv.Itoa(inboundID), token, "", nil)
+	if err != nil {
+		return fmt.Errorf("agent: list 3x-ui REALITY subscription hosts: %w", err)
+	}
+	var groups []threeXUIHostGroup
+	if json.Unmarshal(payload, &groups) != nil {
+		return errors.New("agent: 3x-ui returned invalid subscription host data")
+	}
+	endpoint := baseURL + "/panel/api/hosts/add"
+	for _, group := range groups {
+		if group.GroupID != groupID {
+			continue
+		}
+		if threeXUIRealityHostMatches(group, desired) {
+			return nil
+		}
+		endpoint = baseURL + "/panel/api/hosts/update/" + url.PathEscape(groupID)
+		break
+	}
+	if _, err := threeXUIAPI(ctx, http.MethodPost, endpoint, token, "application/json", desired); err != nil {
+		return fmt.Errorf("agent: synchronize 3x-ui REALITY subscription host: %w", err)
+	}
+	return nil
+}
+
+func validThreeXUIShareHostname(value string) bool {
+	if value == "" || len(value) > 253 || strings.ContainsAny(value, "/\\?#@:") {
+		return false
+	}
+	for _, label := range strings.Split(value, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, character := range label {
+			if (character < 'a' || character > 'z') && (character < '0' || character > '9') && character != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func threeXUIRealityHostMatches(actual, desired threeXUIHostGroup) bool {
+	return actual.GroupID == desired.GroupID && len(actual.InboundIDs) == 1 && actual.InboundIDs[0] == desired.InboundIDs[0] &&
+		len(actual.Hosts) == 1 && strings.EqualFold(strings.TrimSuffix(actual.Hosts[0], "."), desired.Hosts[0]) &&
+		actual.Remark == desired.Remark && actual.ServerDescription == desired.ServerDescription && !actual.IsDisabled && !actual.IsHidden &&
+		actual.Port == desired.Port && actual.Security == desired.Security && strings.EqualFold(strings.TrimSuffix(actual.SNI, "."), desired.SNI) &&
+		actual.Fingerprint == desired.Fingerprint && actual.MihomoIPVersion == desired.MihomoIPVersion && len(actual.Tags) == 1 && actual.Tags[0] == "vastora"
 }
 
 func threeXUIClientEmail(name, commandID string) string {

--- a/internal/agent/three_xui_reality_test.go
+++ b/internal/agent/three_xui_reality_test.go
@@ -2,12 +2,54 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 )
+
+func TestSyncThreeXUIRealityHostUpdatesOnlyManagedGroup(t *testing.T) {
+	var updated threeXUIHostGroup
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		switch request.Method + " " + request.URL.Path {
+		case "GET /panel/api/hosts/byInbound/9":
+			_, _ = response.Write([]byte(`{"success":true,"obj":[{"groupId":"user-host","inboundIds":[9],"hosts":["user.example.test"],"remark":"User host","port":8443,"security":"same","sni":"www.example.test"},{"groupId":"vastora-public-9","inboundIds":[9],"hosts":["old.example.test"],"remark":"{{INBOUND}}-{{EMAIL}}","serverDescription":"Managed by Vastora","tags":["vastora"],"port":443,"security":"same","sni":"www.example.test","fingerprint":"chrome","mihomoIpVersion":"dual"}]}`))
+		case "POST /panel/api/hosts/update/vastora-public-9":
+			if json.NewDecoder(request.Body).Decode(&updated) != nil {
+				t.Fatal("managed Reality host update was not decoded")
+			}
+			_, _ = response.Write([]byte(`{"success":true,"obj":[]}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if err := syncThreeXUIRealityHost(context.Background(), server.URL, "token", 9, "reality.example.test", "www.example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if updated.GroupID != "vastora-public-9" || len(updated.InboundIDs) != 1 || updated.InboundIDs[0] != 9 || len(updated.Hosts) != 1 || updated.Hosts[0] != "reality.example.test" || updated.Port != 443 || updated.SNI != "www.example.test" {
+		t.Fatalf("unexpected managed Reality host: %#v", updated)
+	}
+}
+
+func TestSyncThreeXUIRealityHostKeepsMatchingGroup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/panel/api/hosts/byInbound/9" {
+			t.Fatalf("matching host should not be rewritten: %s %s", request.Method, request.URL.Path)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"success":true,"obj":[{"groupId":"vastora-public-9","inboundIds":[9],"hosts":["reality.example.test"],"remark":"{{INBOUND}}-{{EMAIL}}","serverDescription":"Managed by Vastora","tags":["vastora"],"port":443,"security":"same","sni":"www.example.test","fingerprint":"chrome","mihomoIpVersion":"dual"}]}`))
+	}))
+	defer server.Close()
+
+	if err := syncThreeXUIRealityHost(context.Background(), server.URL, "token", 9, "reality.example.test", "www.example.test"); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestSelectRealityTargetUsesNodeLocalFeasibilityAndSkipsUsedSNI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
## Summary
- synchronize each Vastora-managed Reality inbound with a dedicated 3x-ui Host override
- export the ready public hostname on port 443 while preserving the Reality SNI
- repair existing subscriptions when a user copies the adaptive subscription URL
- leave user-managed 3x-ui Host groups untouched and skip unchanged updates

## Validation
- git diff --check
- local test suites intentionally skipped; GitHub CI is the validation gate

## Upstream API
Uses the pinned 3x-ui 3.6.0 /panel/api/hosts endpoints.