### PR TITLE
fix: support Mihomo Reality clients

### DIFF
--- a/internal/agent/three_xui_clients.go
+++ b/internal/agent/three_xui_clients.go
@@ -230,13 +230,9 @@ func revealThreeXUIClientLink(ctx context.Context, baseURL, token string, comman
 	if !ok || strings.TrimSpace(inboundRef.ConnectHostname) == "" {
 		return "", errors.New("agent: this client has no ready public REALITY entry")
 	}
-	payload, err := threeXUIAPI(ctx, http.MethodGet, baseURL+"/panel/api/inbounds/get/"+strconv.Itoa(inboundRef.ID), token, "", nil)
+	inbound, err := ensureThreeXUIRealityClientVersion(ctx, baseURL, token, inboundRef.ID)
 	if err != nil {
-		return "", fmt.Errorf("agent: get 3x-ui REALITY inbound: %w", err)
-	}
-	var inbound threeXUIRealityInbound
-	if json.Unmarshal(payload, &inbound) != nil || inbound.ID != inboundRef.ID {
-		return "", errors.New("agent: 3x-ui returned invalid REALITY inbound data")
+		return "", err
 	}
 	return realityClientLinkFromInbound(inbound, inboundRef.ConnectHostname, command.Email)
 }
@@ -278,6 +274,9 @@ func revealThreeXUIClientSubscription(ctx context.Context, baseURL, token string
 	for _, inbound := range command.Inbounds {
 		if strings.TrimSpace(inbound.ConnectHostname) == "" || strings.TrimSpace(inbound.SNIHostname) == "" {
 			continue
+		}
+		if _, err := ensureThreeXUIRealityClientVersion(ctx, baseURL, token, inbound.ID); err != nil {
+			return "", err
 		}
 		if err := syncThreeXUIRealityHost(ctx, baseURL, token, inbound.ID, inbound.ConnectHostname, inbound.SNIHostname); err != nil {
 			return "", err

--- a/internal/agent/three_xui_clients_test.go
+++ b/internal/agent/three_xui_clients_test.go
@@ -42,6 +42,8 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 	updatedSubID := ""
 	var updatedSettings map[string]any
 	var syncedHost threeXUIHostGroup
+	var clientVersionUpdated atomic.Bool
+	var clientVersionUpdateCount atomic.Int32
 	var restartPending atomic.Bool
 	var restartCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
@@ -50,7 +52,24 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 		case "GET /panel/api/clients/get/MacBook":
 			_, _ = response.Write([]byte(`{"success":true,"obj":{"client":{"email":"MacBook","id":"11111111-2222-4333-8444-555555555555","subId":"","flow":"xtls-rprx-vision","enable":true},"inboundIds":[9]}}`))
 		case "GET /panel/api/inbounds/get/9":
-			_, _ = response.Write([]byte(`{"success":true,"obj":{"id":9,"settings":{"clients":[{"id":"11111111-2222-4333-8444-555555555555","email":"MacBook","flow":"xtls-rprx-vision"}]},"streamSettings":{"security":"reality","realitySettings":{"serverNames":["www.example.com"],"shortIds":["deadbeef"],"settings":{"publicKey":"public-key"}}}}}`))
+			minClientVersion := ""
+			if clientVersionUpdated.Load() {
+				minClientVersion = threeXUIMihomoMinClientVersion
+			}
+			_, _ = response.Write([]byte(`{"success":true,"obj":{"id":9,"enable":true,"remark":"inbound-9","protocol":"vless","listen":"100.64.0.1","port":39871,"total":0,"expiryTime":0,"settings":{"clients":[{"id":"11111111-2222-4333-8444-555555555555","email":"MacBook","flow":"xtls-rprx-vision"}]},"streamSettings":{"network":"tcp","security":"reality","realitySettings":{"serverNames":["www.example.com"],"shortIds":["deadbeef"],"minClientVer":"` + minClientVersion + `","settings":{"publicKey":"public-key"}}},"sniffing":{"enabled":true}}}`))
+		case "POST /panel/api/inbounds/update/9":
+			var payload map[string]any
+			if json.NewDecoder(request.Body).Decode(&payload) != nil {
+				t.Fatal("compatible Reality inbound update was not decoded")
+			}
+			streamSettings, _ := payload["streamSettings"].(map[string]any)
+			realitySettings, _ := streamSettings["realitySettings"].(map[string]any)
+			if realitySettings["minClientVer"] != threeXUIMihomoMinClientVersion {
+				t.Fatalf("minimum Reality client version = %#v", realitySettings["minClientVer"])
+			}
+			clientVersionUpdateCount.Add(1)
+			clientVersionUpdated.Store(true)
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
 		case "POST /panel/api/clients/update/MacBook":
 			var payload map[string]json.RawMessage
 			if json.NewDecoder(request.Body).Decode(&payload) != nil || json.Unmarshal(payload["subId"], &updatedSubID) != nil || updatedSubID == "" {
@@ -114,6 +133,9 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 	}
 	if restartCount.Load() != 1 {
 		t.Fatalf("3x-ui restart count = %d, want 1", restartCount.Load())
+	}
+	if clientVersionUpdateCount.Load() != 1 {
+		t.Fatalf("Reality compatibility update count = %d, want 1", clientVersionUpdateCount.Load())
 	}
 }
 

--- a/internal/agent/three_xui_reality.go
+++ b/internal/agent/three_xui_reality.go
@@ -50,6 +50,8 @@ type realityScanResult struct {
 	ServerNames []string `json:"serverNames"`
 }
 
+const threeXUIMihomoMinClientVersion = "1.8.2"
+
 func applyRealityCommand(ctx context.Context, store *Store, commandID string, command RealityCommandTask) (RealityCommandResult, error) {
 	installation, err := store.AppliedInstallation(ctx, threeXUIKey)
 	if err != nil {
@@ -72,6 +74,10 @@ func applyRealityCommand(ctx context.Context, store *Store, commandID string, co
 	if existing, ok, err := findRealityInbound(ctx, baseURL, secrets["api_token"], remark); err != nil {
 		return RealityCommandResult{}, err
 	} else if ok {
+		existing, err = ensureThreeXUIRealityClientVersion(ctx, baseURL, secrets["api_token"], existing.ID)
+		if err != nil {
+			return RealityCommandResult{}, err
+		}
 		result, err := realityResultFromInbound(existing, command.ConnectHostname, command.Name)
 		if err != nil {
 			return RealityCommandResult{}, err
@@ -113,7 +119,7 @@ func applyRealityCommand(ctx context.Context, store *Store, commandID string, co
 	payload := map[string]any{
 		"enable": true, "remark": remark, "listen": listen, "port": port, "protocol": "vless", "expiryTime": 0, "total": 0,
 		"settings":       map[string]any{"clients": []map[string]any{{"id": clientID, "email": threeXUIClientEmail(command.Name, commandID), "flow": "xtls-rprx-vision", "limitIp": 0, "totalGB": 0, "expiryTime": 0, "enable": true}}, "decryption": "none", "encryption": "none", "fallbacks": []any{}},
-		"streamSettings": map[string]any{"network": "tcp", "tcpSettings": map[string]any{"header": map[string]string{"type": "none"}}, "security": "reality", "realitySettings": map[string]any{"show": false, "xver": 0, "target": target, "serverNames": []string{sni}, "privateKey": keyPair.PrivateKey, "minClientVer": "", "maxClientVer": "", "maxTimediff": 0, "shortIds": []string{shortID}, "settings": map[string]any{"publicKey": keyPair.PublicKey, "fingerprint": "chrome", "serverName": "", "spiderX": "/"}}},
+		"streamSettings": threeXUIRealityStreamSettings(target, sni, keyPair.PrivateKey, keyPair.PublicKey, shortID),
 		"sniffing":       map[string]any{"enabled": true, "destOverride": []string{"http", "tls", "quic"}, "metadataOnly": false, "routeOnly": false},
 	}
 	added, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/inbounds/add", secrets["api_token"], "application/json", payload)
@@ -129,6 +135,56 @@ func applyRealityCommand(ctx context.Context, store *Store, commandID string, co
 		return RealityCommandResult{}, err
 	}
 	return result, nil
+}
+
+func threeXUIRealityStreamSettings(target, sni, privateKey, publicKey, shortID string) map[string]any {
+	return map[string]any{
+		"network":     "tcp",
+		"tcpSettings": map[string]any{"header": map[string]string{"type": "none"}},
+		"security":    "reality",
+		"realitySettings": map[string]any{
+			"show": false, "xver": 0, "target": target, "serverNames": []string{sni},
+			"privateKey": privateKey, "minClientVer": threeXUIMihomoMinClientVersion,
+			"maxClientVer": "", "maxTimediff": 0, "shortIds": []string{shortID},
+			"settings": map[string]any{"publicKey": publicKey, "fingerprint": "chrome", "serverName": "", "spiderX": "/"},
+		},
+	}
+}
+
+func ensureThreeXUIRealityClientVersion(ctx context.Context, baseURL, token string, inboundID int) (threeXUIRealityInbound, error) {
+	payload, err := threeXUIAPI(ctx, http.MethodGet, baseURL+"/panel/api/inbounds/get/"+strconv.Itoa(inboundID), token, "", nil)
+	if err != nil {
+		return threeXUIRealityInbound{}, fmt.Errorf("agent: get 3x-ui REALITY inbound: %w", err)
+	}
+	var inbound threeXUIRealityInbound
+	var update map[string]any
+	if json.Unmarshal(payload, &inbound) != nil || json.Unmarshal(payload, &update) != nil || inbound.ID != inboundID {
+		return threeXUIRealityInbound{}, errors.New("agent: 3x-ui returned invalid REALITY inbound data")
+	}
+	streamSettings, ok := update["streamSettings"].(map[string]any)
+	if !ok || streamSettings["security"] != "reality" || update["protocol"] != "vless" {
+		return threeXUIRealityInbound{}, errors.New("agent: selected inbound is not VLESS REALITY")
+	}
+	realitySettings, ok := streamSettings["realitySettings"].(map[string]any)
+	if !ok {
+		return threeXUIRealityInbound{}, errors.New("agent: selected REALITY inbound is incomplete")
+	}
+	if realitySettings["minClientVer"] == threeXUIMihomoMinClientVersion {
+		return inbound, nil
+	}
+	realitySettings["minClientVer"] = threeXUIMihomoMinClientVersion
+	delete(update, "id")
+	delete(update, "clientStats")
+	delete(update, "fallbackParent")
+	if _, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/inbounds/update/"+strconv.Itoa(inboundID), token, "application/json", update); err != nil {
+		return threeXUIRealityInbound{}, fmt.Errorf("agent: enable Mihomo compatibility for 3x-ui REALITY inbound: %w", err)
+	}
+	encodedStreamSettings, err := json.Marshal(streamSettings)
+	if err != nil {
+		return threeXUIRealityInbound{}, err
+	}
+	inbound.StreamSettings = encodedStreamSettings
+	return inbound, nil
 }
 
 func syncThreeXUIRealityHost(ctx context.Context, baseURL, token string, inboundID int, connectHostname, sniHostname string) error {

--- a/internal/agent/three_xui_reality_test.go
+++ b/internal/agent/three_xui_reality_test.go
@@ -10,6 +10,64 @@ import (
 	"testing"
 )
 
+func TestThreeXUIRealityStreamSettingsUsesMihomoCompatibleVersion(t *testing.T) {
+	stream := threeXUIRealityStreamSettings("www.example.test:443", "www.example.test", "private-key", "public-key", "deadbeef")
+	reality, ok := stream["realitySettings"].(map[string]any)
+	if !ok || reality["minClientVer"] != threeXUIMihomoMinClientVersion {
+		t.Fatalf("REALITY minimum client version = %#v", reality["minClientVer"])
+	}
+}
+
+func TestEnsureThreeXUIRealityClientVersionRepairsOnceAndPreservesPayload(t *testing.T) {
+	compatible := false
+	updates := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		switch request.Method + " " + request.URL.Path {
+		case "GET /panel/api/inbounds/get/9":
+			minClientVersion := ""
+			if compatible {
+				minClientVersion = threeXUIMihomoMinClientVersion
+			}
+			_, _ = response.Write([]byte(`{"success":true,"obj":{"id":9,"enable":true,"remark":"keep-me","protocol":"vless","listen":"100.64.0.1","port":39871,"settings":{"clients":[{"id":"client-id","email":"MacBook"}]},"streamSettings":{"network":"tcp","security":"reality","realitySettings":{"target":"www.example.test:443","serverNames":["www.example.test"],"privateKey":"private-key","minClientVer":"` + minClientVersion + `","maxClientVer":"keep-max","shortIds":["deadbeef"],"settings":{"publicKey":"public-key"}}},"sniffing":{"enabled":true},"clientStats":[{"email":"MacBook"}],"customField":"preserve-me"}}`))
+		case "POST /panel/api/inbounds/update/9":
+			updates++
+			var payload map[string]any
+			if json.NewDecoder(request.Body).Decode(&payload) != nil {
+				t.Fatal("updated inbound payload was not decoded")
+			}
+			streamSettings, _ := payload["streamSettings"].(map[string]any)
+			realitySettings, _ := streamSettings["realitySettings"].(map[string]any)
+			if realitySettings["minClientVer"] != threeXUIMihomoMinClientVersion || realitySettings["maxClientVer"] != "keep-max" || payload["remark"] != "keep-me" || payload["customField"] != "preserve-me" || payload["id"] != nil || payload["clientStats"] != nil {
+				t.Fatalf("unexpected compatible inbound update: %#v", payload)
+			}
+			compatible = true
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	for range 2 {
+		inbound, err := ensureThreeXUIRealityClientVersion(context.Background(), server.URL, "token", 9)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var stream struct {
+			Reality struct {
+				MinClientVersion string `json:"minClientVer"`
+			} `json:"realitySettings"`
+		}
+		if json.Unmarshal(inbound.StreamSettings, &stream) != nil || stream.Reality.MinClientVersion != threeXUIMihomoMinClientVersion {
+			t.Fatalf("returned minimum client version = %q", stream.Reality.MinClientVersion)
+		}
+	}
+	if updates != 1 {
+		t.Fatalf("compatible inbound updates = %d, want 1", updates)
+	}
+}
+
 func TestSyncThreeXUIRealityHostUpdatesOnlyManagedGroup(t *testing.T) {
 	var updated threeXUIHostGroup
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
## Summary
- set the generated 3x-ui Reality minimum client version to 1.8.2 for Mihomo compatibility
- repair existing Vastora-managed Reality inbounds when links or subscriptions are revealed or commands are retried
- preserve the rest of the 3x-ui inbound payload and avoid redundant updates

## Testing
- added Go tests for new inbound defaults, one-time repair, payload preservation, and subscription reveal integration
- full test execution is delegated to GitHub CI as requested