### PR TITLE
fix: synchronize co-located upgrades and tailnet DNS

### DIFF
--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -74,10 +74,13 @@ separator.
 
 Run the same public command to upgrade. It keeps `.env`, replaces only managed
 deployment files, validates and pulls the new immutable image before changing
-anything, then starts Center and waits for health. If the new Center has already
-started, the upgrader never rolls the database or image backward automatically;
-inspect the printed logs and restore Center's pre-migration SQLite backup when a
-manual downgrade is required.
+anything, then starts Center and waits for health. If this host also runs the
+official Vastora Agent service, the upgrader first extracts the matching Agent
+from that pinned image and restarts it before Center can reconcile a newer
+Gateway desired-state schema. If the new Center has already started, the
+upgrader never rolls the database or image backward automatically; inspect the
+printed logs and restore Center's pre-migration SQLite backup when a manual
+downgrade is required.
 
 ## Automated releases
 

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -65,6 +65,8 @@ esac
 temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-center-upgrade.XXXXXX")"
 candidate_env="$temporary_dir/.env"
 backup_dir="$(mktemp -d "${install_dir}.backup.XXXXXX")"
+agent_container=""
+agent_changed=no
 files_changed=no
 center_started=no
 
@@ -83,6 +85,16 @@ restore_files() {
 
 cleanup() {
   status=$?
+  if [ -n "$agent_container" ]; then
+    docker rm -f "$agent_container" >/dev/null 2>&1 || true
+  fi
+  if [ "$status" -ne 0 ] && [ "$agent_changed" = yes ] && [ "$center_started" = no ]; then
+    echo "Upgrade stopped before Center was started; restoring the previous Agent executable." >&2
+    agent_staged="$(mktemp /usr/local/bin/.vastora-rollback.XXXXXX)"
+    install -m 0755 /usr/local/bin/vastora.previous "$agent_staged"
+    mv "$agent_staged" /usr/local/bin/vastora
+    systemctl restart vastora-agent.service || true
+  fi
   if [ "$status" -ne 0 ] && [ "$files_changed" = yes ] && [ "$center_started" = no ]; then
     echo "Upgrade stopped before Center was started; restoring the previous managed files." >&2
     restore_files
@@ -108,6 +120,39 @@ echo "Validating the new deployment with the existing configuration..."
 docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" config --quiet
 echo "Downloading the immutable Center image..."
 docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" pull center deployer
+
+agent_executable="/usr/local/bin/vastora"
+agent_unit="/etc/systemd/system/vastora-agent.service"
+if [ -f "$agent_executable" ] && [ -f "$agent_unit" ] && grep -Fq 'Description=Vastora Agent' "$agent_unit"; then
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "systemctl is required to update the co-located Vastora Agent." >&2
+    exit 1
+  fi
+  echo "Preparing the matching Agent from the immutable Center image..."
+  agent_container="$(docker create "$new_image")"
+  docker cp "$agent_container:/usr/local/bin/vastora" "$temporary_dir/vastora-agent"
+  docker rm -f "$agent_container" >/dev/null
+  agent_container=""
+  chmod 0755 "$temporary_dir/vastora-agent"
+  if [ "$("$temporary_dir/vastora-agent" version)" != "$new_version" ]; then
+    echo "The Center image contains an unexpected Agent version; the upgrade was not started." >&2
+    exit 1
+  fi
+  agent_staged="$(mktemp /usr/local/bin/.vastora-upgrade.XXXXXX)"
+  install -m 0755 "$temporary_dir/vastora-agent" "$agent_staged"
+  install -m 0755 "$agent_executable" "$agent_executable.previous"
+  mv "$agent_staged" "$agent_executable"
+  if ! systemctl restart vastora-agent.service || ! systemctl is-active --quiet vastora-agent.service; then
+    echo "The updated Agent did not start; restoring the previous executable." >&2
+    agent_staged="$(mktemp /usr/local/bin/.vastora-rollback.XXXXXX)"
+    install -m 0755 "$agent_executable.previous" "$agent_staged"
+    mv "$agent_staged" "$agent_executable"
+    systemctl restart vastora-agent.service || true
+    exit 1
+  fi
+  agent_changed=yes
+  echo "Co-located Agent updated to $new_version before Center reconciliation."
+fi
 
 for relative in setup.sh upgrade.sh compose.yaml release.env .env; do
   if [ -f "$install_dir/$relative" ]; then
@@ -144,5 +189,6 @@ until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
 done
 
 files_changed=no
+agent_changed=no
 center_started=no
 echo "Vastora Center was updated successfully${new_version:+ to $new_version}."

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -36,7 +36,7 @@ for required_file in setup.sh upgrade.sh compose.yaml release.env; do
     exit 1
   fi
 done
-for required in awk curl docker install mktemp mv; do
+for required in awk curl docker grep install mktemp mv; do
   if ! command -v "$required" >/dev/null 2>&1; then
     echo "Required command is not installed: $required" >&2
     exit 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,6 +195,11 @@ Built-in Headscale reads stable sorted A/AAAA records from a Center-generated
 `dns.extra_records_path` file. External Headscale installations use manual DNS
 unless that file is managed by the operator.
 
+Bundled Headscale enables tailnet DNS override with fixed Cloudflare upstream
+resolvers. Extra records such as the private Center hostname are therefore
+available through the operating system resolver, while unrelated queries are
+forwarded normally.
+
 ## 3x-ui
 
 3x-ui uses host networking. On first install, Center generates a strong

--- a/internal/center/headscale.go
+++ b/internal/center/headscale.go
@@ -24,7 +24,7 @@ import (
 const (
 	headscaleDNSFile               = "headscale-extra-records.json"
 	builtinHeadscaleRuntimeSetting = "builtin_headscale_runtime"
-	builtinHeadscaleRuntimeVersion = "private-center-v4"
+	builtinHeadscaleRuntimeVersion = "private-center-dns-v5"
 )
 
 type HeadscaleInput struct {

--- a/internal/deployer/config.go
+++ b/internal/deployer/config.go
@@ -99,9 +99,11 @@ database:
 dns:
   magic_dns: true
   base_domain: vastora.internal
-  override_local_dns: false
+  override_local_dns: true
   nameservers:
-    global: []
+    global:
+      - 1.1.1.1
+      - 1.0.0.1
     split: {}
   search_domains: []
   extra_records_path: /var/lib/vastora-shared/headscale-extra-records.json

--- a/internal/deployer/config_test.go
+++ b/internal/deployer/config_test.go
@@ -46,7 +46,7 @@ func TestPortPreflightReportsAConflict(t *testing.T) {
 
 func TestGeneratedConfigurationUsesStandardHTTPSAndKeepsSecretsOut(t *testing.T) {
 	headscale := string(renderHeadscaleConfig("https://headscale.example.com"))
-	if !strings.Contains(headscale, "listen_addr: 0.0.0.0:8081") || strings.Contains(headscale, "tls_key_path") || strings.Contains(headscale, "extra_records:") {
+	if !strings.Contains(headscale, "listen_addr: 0.0.0.0:8081") || !strings.Contains(headscale, "override_local_dns: true") || !strings.Contains(headscale, "      - 1.1.1.1") || strings.Contains(headscale, "tls_key_path") || strings.Contains(headscale, "extra_records:") {
 		t.Fatalf("unexpected Headscale configuration:\n%s", headscale)
 	}
 	caddy := string(renderCaddyfile("https://center.example.com", "127.0.0.1:8080", "https://headscale.example.com", []string{"203.0.113.10"}))

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -32,6 +32,8 @@ grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$temporary_dir/release.env"
 test -x "$temporary_dir/setup.sh"
 test -x "$temporary_dir/upgrade.sh"
 test -f "$temporary_dir/compose.yaml"
+grep -Fq 'docker cp "$agent_container:/usr/local/bin/vastora"' "$temporary_dir/upgrade.sh"
+grep -Fq 'Co-located Agent updated to $new_version before Center reconciliation.' "$temporary_dir/upgrade.sh"
 test ! -e "$temporary_dir/headscale"
 if grep -Eq 'headscale/(config\.yaml|policy\.hujson)' "$project_dir/install.sh"; then
   echo "Public installer still requires removed Headscale configuration files" >&2


### PR DESCRIPTION
## Summary
- make bundled Headscale override tailnet DNS and forward ordinary queries through fixed Cloudflare resolvers, so private Center records reach the operating system resolver
- extract and atomically install the matching Agent from the immutable Center image before starting a newer Center
- restore the previous Agent when an upgrade fails before Center starts
- bump the bundled Headscale runtime revision so existing installations reconcile the DNS change

## Validation
- targeted Center and deployer Go tests passed
- Center installation bundle regression passed
- upgrade shell syntax and diff checks passed
- full validation continues in GitHub CI