### PR TITLE
fix: restore co-located gateways after upgrades

### DIFF
--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -77,10 +77,12 @@ deployment files, validates and pulls the new immutable image before changing
 anything, then starts Center and waits for health. If this host also runs the
 official Vastora Agent service, the upgrader first extracts the matching Agent
 from that pinned image and restarts it before Center can reconcile a newer
-Gateway desired-state schema. If the new Center has already started, the
-upgrader never rolls the database or image backward automatically; inspect the
-printed logs and restore Center's pre-migration SQLite backup when a manual
-downgrade is required.
+Gateway desired-state schema. It then waits for Center and built-in Headscale
+startup readiness and restarts the Agent again, restoring any shared HTTPS
+gateway from encrypted local desired state. If the new Center has already
+started, the upgrader never rolls the database or image backward automatically;
+inspect the printed logs and restore Center's pre-migration SQLite backup when a
+manual downgrade is required.
 
 ## Automated releases
 

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -69,6 +69,10 @@ agent_container=""
 agent_changed=no
 files_changed=no
 center_started=no
+layer4_was_running=no
+if [ "$(docker inspect -f '{{.State.Running}}' vastora-gateway-haproxy 2>/dev/null || true)" = "true" ]; then
+  layer4_was_running=yes
+fi
 
 restore_files() {
   for relative in setup.sh upgrade.sh compose.yaml release.env .env; do
@@ -187,6 +191,46 @@ until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
   fi
   sleep 2
 done
+
+attempt=0
+until curl -fsS "http://127.0.0.1:$bootstrap_port/readyz" >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 240 ]; then
+    echo "The updated Center did not finish startup reconciliation." >&2
+    echo "Inspect: cd '$install_dir' && docker compose logs center deployer" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+if [ "$agent_changed" = yes ]; then
+  echo "Restarting the co-located Agent after Center reconciliation..."
+  if ! systemctl restart vastora-agent.service || ! systemctl is-active --quiet vastora-agent.service; then
+    echo "The co-located Agent did not restart after Center reconciliation." >&2
+    exit 1
+  fi
+  attempt=0
+  until curl -fsS http://127.0.0.1:8090/healthz >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 30 ]; then
+      echo "The co-located Agent did not become healthy after Center reconciliation." >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  if [ "$layer4_was_running" = yes ]; then
+    attempt=0
+    until [ "$(docker inspect -f '{{.State.Running}}' vastora-gateway-haproxy 2>/dev/null || true)" = "true" ]; do
+      attempt=$((attempt + 1))
+      if [ "$attempt" -ge 30 ]; then
+        echo "The co-located Agent did not restore the shared HTTPS gateway." >&2
+        exit 1
+      fi
+      sleep 1
+    done
+  fi
+  echo "Co-located Agent reconciled successfully after Center startup."
+fi
 
 files_changed=no
 agent_changed=no

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,11 @@ specification version and asks the restricted deployment helper to reconcile an
 older installation once after an upgrade; persistent Headscale data and the
 existing encrypted API key are retained.
 
+Center exposes separate liveness and startup-readiness probes. The official
+upgrader waits for built-in Headscale reconciliation before restarting a
+co-located Agent, allowing the Agent to restore Caddy and HAProxy state without
+depending on the private Center route during the gateway handoff.
+
 ## Address discovery and confirmation
 
 Agent enumerates addresses assigned to local interfaces and reports

--- a/internal/agent/caddy_driver.go
+++ b/internal/agent/caddy_driver.go
@@ -40,7 +40,7 @@ func NewCaddyGatewayDriver(adminURL string) (*CaddyGatewayDriver, error) {
 			return nil, errors.New("agent: Caddy Admin API Unix socket path must be absolute")
 		}
 		socketPath := parsed.Path
-		transport := &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		transport := &http.Transport{DisableKeepAlives: true, DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 		}}
 		return &CaddyGatewayDriver{

--- a/internal/agent/gateway_test.go
+++ b/internal/agent/gateway_test.go
@@ -375,6 +375,10 @@ func TestCaddyDriverAcceptsOnlyPrivateAdminEndpoints(t *testing.T) {
 	if driver.AdminListen != "unix//run/vastora/caddy-admin.sock" || driver.AdminSocketPath != "/run/vastora/caddy-admin.sock" || driver.AdminURL != "http://localhost" {
 		t.Fatalf("unexpected Unix Admin API configuration: %#v", driver)
 	}
+	transport, ok := driver.HTTPClient.Transport.(*http.Transport)
+	if !ok || !transport.DisableKeepAlives {
+		t.Fatal("Unix Admin API must reconnect after the managed Caddy container is replaced")
+	}
 	for _, endpoint := range []string{"http://127.0.0.1:2019", "http://[::1]:2019"} {
 		if _, err := NewCaddyGatewayDriver(endpoint); err != nil {
 			t.Fatalf("private endpoint %q was rejected: %v", endpoint, err)

--- a/internal/center/headscale_deployer_test.go
+++ b/internal/center/headscale_deployer_test.go
@@ -106,8 +106,14 @@ func TestReconcileBuiltinHeadscaleAppliesAnOlderRuntimeOnce(t *testing.T) {
 	}
 	installer := &fakeBuiltinHeadscaleInstaller{}
 	server := NewServer(store, "", false).WithHeadscaleInstaller(installer)
+	if server.startupReady.Load() {
+		t.Fatal("Center became ready before built-in Headscale startup reconciliation")
+	}
 	if err := server.ReconcileBuiltinHeadscale(ctx); err != nil {
 		t.Fatal(err)
+	}
+	if !server.startupReady.Load() {
+		t.Fatal("Center did not become ready after built-in Headscale startup reconciliation")
 	}
 	if installer.reconcileInput.CenterURL != "https://center.example.com" || installer.reconcileInput.HeadscaleURL != "https://headscale.example.com" {
 		t.Fatalf("unexpected reconciliation input: %#v", installer.reconcileInput)

--- a/internal/center/server.go
+++ b/internal/center/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/petauron/vastora/internal/deployapi"
@@ -25,15 +26,19 @@ type Server struct {
 	secureCookies        bool
 	officialCatalog      []byte
 	headscaleInstaller   deployapi.HeadscaleInstaller
+	startupReady         atomic.Bool
 }
 
 func (s *Server) WithHeadscaleInstaller(installer deployapi.HeadscaleInstaller) *Server {
 	s.headscaleInstaller = installer
+	s.startupReady.Store(false)
 	return s
 }
 
 func NewServer(store *Store, staticDir string, secureCookies bool) *Server {
-	return &Server{store: store, staticDir: staticDir, secureCookies: secureCookies}
+	server := &Server{store: store, staticDir: staticDir, secureCookies: secureCookies}
+	server.startupReady.Store(true)
+	return server
 }
 
 func (s *Server) WithOfficialCatalog(payload []byte) *Server {
@@ -54,6 +59,7 @@ func (s *Server) WithSetupAgentConnectURL(value string) *Server {
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", s.handleHealth)
+	mux.HandleFunc("GET /readyz", s.handleReady)
 	mux.HandleFunc("GET /install/agent.sh", s.handleAgentInstallScript)
 	mux.HandleFunc("GET /api/v1/agent-binaries/{os}/{arch}", s.handleAgentBinary)
 	mux.HandleFunc("GET /api/v1/agents/{id}/binary/{os}/{arch}", s.handleAgentUpdateBinary)
@@ -115,6 +121,14 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) handleHealth(writer http.ResponseWriter, _ *http.Request) {
 	writeJSON(writer, http.StatusOK, map[string]string{"status": "ok", "version": Version})
+}
+
+func (s *Server) handleReady(writer http.ResponseWriter, _ *http.Request) {
+	if !s.startupReady.Load() {
+		writeJSON(writer, http.StatusServiceUnavailable, map[string]string{"status": "reconciling", "version": Version})
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]string{"status": "ready", "version": Version})
 }
 
 func (s *Server) requireAuth(mutation bool, handler http.HandlerFunc) http.HandlerFunc {

--- a/internal/center/server_integrations.go
+++ b/internal/center/server_integrations.go
@@ -138,7 +138,12 @@ func (s *Server) configureHeadscale(ctx context.Context, input HeadscaleInput, c
 
 // ReconcileBuiltinHeadscale applies the current fixed runtime specification to
 // an existing bundled installation without rotating its stored API key.
-func (s *Server) ReconcileBuiltinHeadscale(ctx context.Context) error {
+func (s *Server) ReconcileBuiltinHeadscale(ctx context.Context) (err error) {
+	defer func() {
+		if err == nil {
+			s.startupReady.Store(true)
+		}
+	}()
 	if s.headscaleInstaller == nil {
 		return nil
 	}

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -34,6 +34,8 @@ test -x "$temporary_dir/upgrade.sh"
 test -f "$temporary_dir/compose.yaml"
 grep -Fq 'docker cp "$agent_container:/usr/local/bin/vastora"' "$temporary_dir/upgrade.sh"
 grep -Fq 'Co-located Agent updated to $new_version before Center reconciliation.' "$temporary_dir/upgrade.sh"
+grep -Fq 'http://127.0.0.1:$bootstrap_port/readyz' "$temporary_dir/upgrade.sh"
+grep -Fq 'Co-located Agent reconciled successfully after Center startup.' "$temporary_dir/upgrade.sh"
 test ! -e "$temporary_dir/headscale"
 if grep -Eq 'headscale/(config\.yaml|policy\.hujson)' "$project_dir/install.sh"; then
   echo "Public installer still requires removed Headscale configuration files" >&2


### PR DESCRIPTION
## Summary
- expose startup readiness until built-in Headscale reconciliation completes
- reconnect to the Caddy Unix admin socket after container replacement
- restart the co-located Agent after readiness and verify shared HTTPS recovery

## Verification
- `GOCACHE=/tmp/vastora-gocache GOTOOLCHAIN=go1.26.6 go test ./internal/agent ./internal/center`
- `sh -n deploy/center/upgrade.sh`
- `scripts/test-center-install.sh`
- `git diff --check`