### PR TITLE
fix: dispatch trusted release checks automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -91,6 +92,15 @@ jobs:
         env:
           BASE_SHA: ${{ steps.release_pr.outputs.base_sha }}
         run: scripts/validate-release-metadata.sh "$BASE_SHA"
+
+      - name: Run trusted checks for release pull request
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ steps.release_pr.outputs.head_branch }}
+        run: |
+          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"
+          gh workflow run codeql.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"
 
   publish:
     needs: prepare

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ deployment-check:
 	sh -n scripts/validate-release-metadata.sh
 	sh -n scripts/test-center-install.sh
 	sh -n scripts/test-release-metadata.sh
+	sh -n scripts/test-release-workflow.sh
 	node scripts/test-installer-worker.mjs
 	./install.sh --help >/dev/null
 	deploy/center/setup.sh --help >/dev/null
@@ -39,6 +40,7 @@ deployment-check:
 	scripts/package-center-install.sh --help >/dev/null
 	scripts/test-center-install.sh
 	scripts/test-release-metadata.sh
+	scripts/test-release-workflow.sh
 
 security-check:
 	gitleaks detect --no-git --redact --source .

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -87,11 +87,13 @@ manual downgrade is required.
 ## Automated releases
 
 Merges to `main` update a Release Please pull request from conventional commit
-messages. Merging that pull request creates a draft release, builds and pushes
-the `linux/amd64` Center image to GHCR, packages the installer
-against the image manifest digest, uploads all three assets, and publishes the
-release only after every step succeeds. Failed builds leave the release as a
-draft. The Cloudflare Worker behind `vastora.petauron.com` selects the newest
+messages. The trusted release workflow dispatches CI and CodeQL for the
+generated release branch, so GitHub does not require repeated approval of
+bot-authored pull-request runs. Merging that pull request creates a draft
+release, builds and pushes the `linux/amd64` Center image to GHCR, packages the
+installer against the image manifest digest, uploads all three assets, and
+publishes the release only after every step succeeds. Failed builds leave the
+release as a draft. The Cloudflare Worker behind `vastora.petauron.com` selects the newest
 non-draft release containing all three assets, including prereleases, so it does
 not depend on GitHub's stable-only `releases/latest` endpoint.
 

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
+workflow="$project_dir/.github/workflows/release.yml"
+prepare_job="$(sed -n '/^  prepare:/,/^  publish:/p' "$workflow")"
+
+require_line() {
+  if ! printf '%s\n' "$prepare_job" | grep -Fq "$1"; then
+    echo "Release workflow is missing: $1" >&2
+    exit 1
+  fi
+}
+
+require_line '      actions: write'
+require_line '      - name: Run trusted checks for release pull request'
+require_line '          GH_TOKEN: ${{ github.token }}'
+require_line '          HEAD_BRANCH: ${{ steps.release_pr.outputs.head_branch }}'
+require_line '          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"'
+require_line '          gh workflow run codeql.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"'
+
+echo "Release workflow dispatch test passed"


### PR DESCRIPTION
## Summary
- restore the minimal `actions: write` permission used by Release Please
- dispatch CI and CodeQL against every generated release branch
- add a deployment regression test so automatic dispatch cannot disappear silently again

## Verification
- `scripts/test-release-workflow.sh`
- `make deployment-check`
- `git diff --check`