### PR TITLE
ci: avoid duplicate release pull request checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04
     permissions:
-      actions: write
+      checks: write
       contents: write
       issues: write
       pull-requests: write
@@ -87,20 +87,38 @@ jobs:
           ref: ${{ steps.release_pr.outputs.head_branch }}
           fetch-depth: 0
 
+      - name: Start release metadata check
+        id: release_metadata_check
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          check_id="$(
+            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs" \
+              -f name='Release metadata' \
+              -f head_sha="$(git rev-parse HEAD)" \
+              -f status='in_progress' \
+              --jq '.id'
+          )"
+          echo "id=$check_id" >> "$GITHUB_OUTPUT"
+
       - name: Validate release pull request metadata
+        id: validate_release_metadata
         if: steps.release.outputs.prs_created == 'true'
         env:
           BASE_SHA: ${{ steps.release_pr.outputs.base_sha }}
         run: scripts/validate-release-metadata.sh "$BASE_SHA"
 
-      - name: Run trusted checks for release pull request
-        if: steps.release.outputs.prs_created == 'true'
+      - name: Finish release metadata check
+        if: always() && steps.release.outputs.prs_created == 'true' && steps.release_metadata_check.outputs.id != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_BRANCH: ${{ steps.release_pr.outputs.head_branch }}
+          CHECK_ID: ${{ steps.release_metadata_check.outputs.id }}
+          CHECK_CONCLUSION: ${{ steps.validate_release_metadata.outcome == 'success' && 'success' || 'failure' }}
         run: |
-          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"
-          gh workflow run codeql.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"
+          gh api --method PATCH "/repos/$GITHUB_REPOSITORY/check-runs/$CHECK_ID" \
+            -f status='completed' \
+            -f conclusion="$CHECK_CONCLUSION" >/dev/null
 
   publish:
     needs: prepare

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -87,13 +87,17 @@ manual downgrade is required.
 ## Automated releases
 
 Merges to `main` update a Release Please pull request from conventional commit
-messages. The trusted release workflow dispatches CI and CodeQL for the
-generated release branch, so GitHub does not require repeated approval of
-bot-authored pull-request runs. Merging that pull request creates a draft
-release, builds and pushes the `linux/amd64` Center image to GHCR, packages the
-installer against the image manifest digest, uploads all three assets, and
-publishes the release only after every step succeeds. Failed builds leave the
-release as a draft. The Cloudflare Worker behind `vastora.petauron.com` selects the newest
+messages. Feature pull requests run the complete CI, CodeQL, security, and
+container checks before their source reaches `main`. The generated release pull
+request changes only `.release-please-manifest.json`, `CHANGELOG.md`, and
+`version.txt`; the trusted release workflow validates that exact allowlist and
+its version metadata, then records a visible `Release metadata` check on the
+pull request. It does not repeat source checks for the already-tested `main`
+commit. Merging that pull request creates a draft release, builds and pushes the
+`linux/amd64` Center image to GHCR, packages the installer against the image
+manifest digest, uploads all three assets, and publishes the release only after
+every step succeeds. Failed builds leave the release as a draft. The Cloudflare
+Worker behind `vastora.petauron.com` selects the newest
 non-draft release containing all three assets, including prereleases, so it does
 not depend on GitHub's stable-only `releases/latest` endpoint.
 

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -13,11 +13,19 @@ require_line() {
   fi
 }
 
-require_line '      actions: write'
-require_line '      - name: Run trusted checks for release pull request'
+require_line '      checks: write'
+require_line '      - name: Start release metadata check'
 require_line '          GH_TOKEN: ${{ github.token }}'
-require_line '          HEAD_BRANCH: ${{ steps.release_pr.outputs.head_branch }}'
-require_line '          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"'
-require_line '          gh workflow run codeql.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_BRANCH"'
+require_line "              -f name='Release metadata'"
+require_line '            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs" \\'
+require_line '        id: validate_release_metadata'
+require_line '      - name: Finish release metadata check'
+require_line '          CHECK_CONCLUSION: ${{ steps.validate_release_metadata.outcome == '\''success'\'' && '\''success'\'' || '\''failure'\'' }}'
+require_line '          gh api --method PATCH "/repos/$GITHUB_REPOSITORY/check-runs/$CHECK_ID" \\'
 
-echo "Release workflow dispatch test passed"
+if printf '%s\n' "$prepare_job" | grep -Fq 'gh workflow run'; then
+  echo 'Release metadata pull requests must not duplicate source workflows' >&2
+  exit 1
+fi
+
+echo "Release metadata check workflow test passed"

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -17,11 +17,11 @@ require_line '      checks: write'
 require_line '      - name: Start release metadata check'
 require_line '          GH_TOKEN: ${{ github.token }}'
 require_line "              -f name='Release metadata'"
-require_line '            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs" \\'
+require_line '            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs"'
 require_line '        id: validate_release_metadata'
 require_line '      - name: Finish release metadata check'
 require_line '          CHECK_CONCLUSION: ${{ steps.validate_release_metadata.outcome == '\''success'\'' && '\''success'\'' || '\''failure'\'' }}'
-require_line '          gh api --method PATCH "/repos/$GITHUB_REPOSITORY/check-runs/$CHECK_ID" \\'
+require_line '          gh api --method PATCH "/repos/$GITHUB_REPOSITORY/check-runs/$CHECK_ID"'
 
 if printf '%s\n' "$prepare_job" | grep -Fq 'gh workflow run'; then
   echo 'Release metadata pull requests must not duplicate source workflows' >&2


### PR DESCRIPTION
## Summary
- replace detached full CI and CodeQL reruns on generated release PRs with a visible Release metadata check
- keep fail-closed validation of the exact generated-file allowlist and version metadata
- document that source CI remains mandatory on feature PRs

## Validation
- GitHub CI only, per project workflow
- local static checks: git diff --check and shell syntax