### PR TITLE
fix: link release metadata check to workflow logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
               -f name='Release metadata' \
               -f head_sha="$(git rev-parse HEAD)" \
               -f status='in_progress' \
+              -f details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
               --jq '.id'
           )"
           echo "id=$check_id" >> "$GITHUB_OUTPUT"

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -18,6 +18,7 @@ require_line '      - name: Start release metadata check'
 require_line '          GH_TOKEN: ${{ github.token }}'
 require_line "              -f name='Release metadata'"
 require_line '            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs"'
+require_line '              -f details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"'
 require_line '        id: validate_release_metadata'
 require_line '      - name: Finish release metadata check'
 require_line '          CHECK_CONCLUSION: ${{ steps.validate_release_metadata.outcome == '\''success'\'' && '\''success'\'' || '\''failure'\'' }}'


### PR DESCRIPTION
## Summary
- link the generated Release metadata check directly to its trusted Actions run
- provide a release-eligible workflow fix so the optimized alpha.36 path can be verified end to end

## Validation
- GitHub CI only, per project workflow
- local static checks: git diff --check and shell syntax