### PR TITLE
fix: synchronize 3x-ui clients across nodes

### DIFF
--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -144,6 +144,7 @@ type ThreeXUIClientCommandTask struct {
 	Email               string                  `json:"email,omitempty"`
 	NewEmail            string                  `json:"newEmail,omitempty"`
 	InboundID           int                     `json:"inboundId,omitempty"`
+	InboundIDs          []int                   `json:"inboundIds,omitempty"`
 	Enabled             bool                    `json:"enabled"`
 	TotalBytes          int64                   `json:"totalBytes"`
 	ExpiryTime          int64                   `json:"expiryTime"`

--- a/internal/agent/three_xui_clients.go
+++ b/internal/agent/three_xui_clients.go
@@ -48,8 +48,8 @@ func applyThreeXUIClientCommand(ctx context.Context, store *Store, command Three
 	switch command.Action {
 	case "list":
 	case "create":
-		if !clientInboundAvailable(command.Inbounds, command.InboundID) {
-			return result, errors.New("agent: selected 3x-ui inbound is unavailable")
+		if !clientInboundsAvailable(command.Inbounds, command.InboundIDs) {
+			return result, errors.New("agent: selected 3x-ui nodes are unavailable")
 		}
 		clientID, err := randomUUID()
 		if err != nil {
@@ -65,7 +65,7 @@ func applyThreeXUIClientCommand(ctx context.Context, store *Store, command Three
 				"totalGB": command.TotalBytes, "expiryTime": command.ExpiryTime, "limitIp": command.LimitIP,
 				"tgId": 0, "enable": command.Enabled,
 			},
-			"inboundIds": []int{command.InboundID},
+			"inboundIds": command.InboundIDs,
 		}
 		if _, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/clients/add", token, "application/json", payload); err != nil {
 			return result, fmt.Errorf("agent: create 3x-ui client: %w", err)
@@ -76,6 +76,9 @@ func applyThreeXUIClientCommand(ctx context.Context, store *Store, command Three
 			return result, err
 		}
 		if command.Action == "update" {
+			if !clientInboundsAvailable(command.Inbounds, command.InboundIDs) {
+				return result, errors.New("agent: selected 3x-ui nodes are unavailable")
+			}
 			setClientJSONField(detail.Client, "email", command.NewEmail)
 			setClientJSONField(detail.Client, "totalGB", command.TotalBytes)
 			setClientJSONField(detail.Client, "expiryTime", command.ExpiryTime)
@@ -85,6 +88,11 @@ func applyThreeXUIClientCommand(ctx context.Context, store *Store, command Three
 		}
 		if _, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/clients/update/"+url.PathEscape(command.Email), token, "application/json", detail.Client); err != nil {
 			return result, fmt.Errorf("agent: update 3x-ui client: %w", err)
+		}
+		if command.Action == "update" {
+			if err := syncThreeXUIClientInbounds(ctx, baseURL, token, command.NewEmail, detail.InboundIDs, command.InboundIDs); err != nil {
+				return result, err
+			}
 		}
 	case "delete":
 		if _, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/clients/del/"+url.PathEscape(command.Email), token, "application/json", map[string]any{}); err != nil {
@@ -198,13 +206,55 @@ func clientJSONText(client map[string]json.RawMessage, key string) string {
 	return strings.TrimSpace(value)
 }
 
-func clientInboundAvailable(inbounds []ThreeXUIClientInbound, id int) bool {
+func clientInboundsAvailable(inbounds []ThreeXUIClientInbound, ids []int) bool {
+	if len(ids) == 0 {
+		return false
+	}
+	available := make(map[int]bool, len(inbounds))
 	for _, inbound := range inbounds {
-		if inbound.ID == id {
-			return true
+		available[inbound.ID] = true
+	}
+	seen := make(map[int]bool, len(ids))
+	for _, id := range ids {
+		if id < 1 || !available[id] || seen[id] {
+			return false
+		}
+		seen[id] = true
+	}
+	return true
+}
+
+func syncThreeXUIClientInbounds(ctx context.Context, baseURL, token, email string, current, desired []int) error {
+	currentSet := make(map[int]bool, len(current))
+	desiredSet := make(map[int]bool, len(desired))
+	for _, inboundID := range current {
+		currentSet[inboundID] = true
+	}
+	for _, inboundID := range desired {
+		desiredSet[inboundID] = true
+	}
+	attach, detach := []int{}, []int{}
+	for _, inboundID := range desired {
+		if !currentSet[inboundID] {
+			attach = append(attach, inboundID)
 		}
 	}
-	return false
+	for _, inboundID := range current {
+		if !desiredSet[inboundID] {
+			detach = append(detach, inboundID)
+		}
+	}
+	if len(attach) != 0 {
+		if _, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/clients/"+url.PathEscape(email)+"/attach", token, "application/json", map[string]any{"inboundIds": attach}); err != nil {
+			return fmt.Errorf("agent: attach 3x-ui client to selected nodes: %w", err)
+		}
+	}
+	if len(detach) != 0 {
+		if _, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/clients/"+url.PathEscape(email)+"/detach", token, "application/json", map[string]any{"inboundIds": detach}); err != nil {
+			return fmt.Errorf("agent: detach 3x-ui client from unselected nodes: %w", err)
+		}
+	}
+	return nil
 }
 
 func clientInbound(inbounds []ThreeXUIClientInbound, ids []int, requested int) (ThreeXUIClientInbound, bool) {

--- a/internal/agent/three_xui_clients_test.go
+++ b/internal/agent/three_xui_clients_test.go
@@ -141,6 +141,7 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 
 func TestThreeXUIClientCreateAndUpdateUseFirstClassClientAPI(t *testing.T) {
 	createdID, createdSubID := "", ""
+	attached, detached := []int{}, []int{}
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		response.Header().Set("Content-Type", "application/json")
 		switch request.Method + " " + request.URL.Path {
@@ -149,12 +150,12 @@ func TestThreeXUIClientCreateAndUpdateUseFirstClassClientAPI(t *testing.T) {
 				Client     map[string]json.RawMessage `json:"client"`
 				InboundIDs []int                      `json:"inboundIds"`
 			}
-			if json.NewDecoder(request.Body).Decode(&payload) != nil || json.Unmarshal(payload.Client["id"], &createdID) != nil || json.Unmarshal(payload.Client["subId"], &createdSubID) != nil || createdID == "" || createdSubID == "" || len(payload.InboundIDs) != 1 || payload.InboundIDs[0] != 9 {
+			if json.NewDecoder(request.Body).Decode(&payload) != nil || json.Unmarshal(payload.Client["id"], &createdID) != nil || json.Unmarshal(payload.Client["subId"], &createdSubID) != nil || createdID == "" || createdSubID == "" || len(payload.InboundIDs) != 2 || payload.InboundIDs[0] != 9 || payload.InboundIDs[1] != 10 {
 				t.Fatal("create did not use generated first-class client credentials")
 			}
 			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
 		case "GET /panel/api/clients/get/Phone":
-			_, _ = response.Write([]byte(`{"success":true,"obj":{"client":{"email":"Phone","id":"preserved-uuid","subId":"preserved-sub-id","comment":"keep-me","enable":true,"totalGB":0,"expiryTime":0,"limitIp":0},"inboundIds":[9]}}`))
+			_, _ = response.Write([]byte(`{"success":true,"obj":{"client":{"email":"Phone","id":"preserved-uuid","subId":"preserved-sub-id","comment":"keep-me","enable":true,"totalGB":0,"expiryTime":0,"limitIp":0},"inboundIds":[9,10]}}`))
 		case "POST /panel/api/clients/update/Phone":
 			var payload map[string]json.RawMessage
 			var email, id, subID, comment string
@@ -162,6 +163,24 @@ func TestThreeXUIClientCreateAndUpdateUseFirstClassClientAPI(t *testing.T) {
 			if json.NewDecoder(request.Body).Decode(&payload) != nil || json.Unmarshal(payload["email"], &email) != nil || json.Unmarshal(payload["id"], &id) != nil || json.Unmarshal(payload["subId"], &subID) != nil || json.Unmarshal(payload["comment"], &comment) != nil || json.Unmarshal(payload["totalGB"], &total) != nil || email != "Phone 2" || id != "preserved-uuid" || subID != "preserved-sub-id" || comment != "keep-me" || total != 20*gibibyteForTest {
 				t.Fatal("update did not preserve the complete 3x-ui client payload")
 			}
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		case "POST /panel/api/clients/Phone 2/attach":
+			var payload struct {
+				InboundIDs []int `json:"inboundIds"`
+			}
+			if json.NewDecoder(request.Body).Decode(&payload) != nil {
+				t.Fatal("attach payload was not decoded")
+			}
+			attached = payload.InboundIDs
+			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
+		case "POST /panel/api/clients/Phone 2/detach":
+			var payload struct {
+				InboundIDs []int `json:"inboundIds"`
+			}
+			if json.NewDecoder(request.Body).Decode(&payload) != nil {
+				t.Fatal("detach payload was not decoded")
+			}
+			detached = payload.InboundIDs
 			_, _ = response.Write([]byte(`{"success":true,"obj":{}}`))
 		case "GET /panel/api/clients/list/paged":
 			_, _ = response.Write([]byte(`{"success":true,"obj":{"items":[],"total":0}}`))
@@ -172,12 +191,15 @@ func TestThreeXUIClientCreateAndUpdateUseFirstClassClientAPI(t *testing.T) {
 	defer server.Close()
 	store := threeXUIClientTestStore(t, server, "local-token")
 	defer store.Close()
-	inbounds := []ThreeXUIClientInbound{{ID: 9, Name: "inbound-9"}}
-	if _, err := applyThreeXUIClientCommand(context.Background(), store, ThreeXUIClientCommandTask{Action: "create", NewEmail: "Phone", InboundID: 9, Enabled: true, Inbounds: inbounds}); err != nil {
+	inbounds := []ThreeXUIClientInbound{{ID: 9, Name: "inbound-9"}, {ID: 10, Name: "inbound-10"}, {ID: 11, Name: "inbound-11"}}
+	if _, err := applyThreeXUIClientCommand(context.Background(), store, ThreeXUIClientCommandTask{Action: "create", NewEmail: "Phone", InboundIDs: []int{9, 10}, Enabled: true, Inbounds: inbounds}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := applyThreeXUIClientCommand(context.Background(), store, ThreeXUIClientCommandTask{Action: "update", Email: "Phone", NewEmail: "Phone 2", TotalBytes: 20 * gibibyteForTest, Inbounds: inbounds}); err != nil {
+	if _, err := applyThreeXUIClientCommand(context.Background(), store, ThreeXUIClientCommandTask{Action: "update", Email: "Phone", NewEmail: "Phone 2", InboundIDs: []int{10, 11}, TotalBytes: 20 * gibibyteForTest, Inbounds: inbounds}); err != nil {
 		t.Fatal(err)
+	}
+	if len(attached) != 1 || attached[0] != 11 || len(detached) != 1 || detached[0] != 9 {
+		t.Fatalf("attachment changes = attach %#v, detach %#v", attached, detached)
 	}
 }
 

--- a/internal/agent/three_xui_reality.go
+++ b/internal/agent/three_xui_reality.go
@@ -85,6 +85,9 @@ func applyRealityCommand(ctx context.Context, store *Store, commandID string, co
 		if err := syncThreeXUIRealityHost(ctx, baseURL, masterToken, result.InboundID, result.ConnectHostname, result.SNIHostname); err != nil {
 			return RealityCommandResult{}, err
 		}
+		if err := attachAllThreeXUIClientsToInbound(ctx, baseURL, masterToken, result.InboundID); err != nil {
+			return RealityCommandResult{}, err
+		}
 		return result, nil
 	}
 
@@ -137,7 +140,46 @@ func applyRealityCommand(ctx context.Context, store *Store, commandID string, co
 	if err := syncThreeXUIRealityHost(ctx, baseURL, masterToken, result.InboundID, result.ConnectHostname, result.SNIHostname); err != nil {
 		return RealityCommandResult{}, err
 	}
+	if err := attachAllThreeXUIClientsToInbound(ctx, baseURL, masterToken, result.InboundID); err != nil {
+		return RealityCommandResult{}, err
+	}
 	return result, nil
+}
+
+func attachAllThreeXUIClientsToInbound(ctx context.Context, baseURL, token string, inboundID int) error {
+	clients, err := listThreeXUIClients(ctx, baseURL, token)
+	if err != nil {
+		return fmt.Errorf("agent: list clients for automatic node synchronization: %w", err)
+	}
+	emails := make([]string, 0, len(clients))
+	for _, client := range clients {
+		if !containsInt(client.InboundIDs, inboundID) {
+			emails = append(emails, client.Email)
+		}
+	}
+	if len(emails) == 0 {
+		return nil
+	}
+	payload, err := threeXUIAPI(ctx, http.MethodPost, baseURL+"/panel/api/clients/bulkAttach", token, "application/json", map[string]any{"emails": emails, "inboundIds": []int{inboundID}})
+	if err != nil {
+		return fmt.Errorf("agent: attach existing clients to the new REALITY node: %w", err)
+	}
+	var result struct {
+		Errors []json.RawMessage `json:"errors"`
+	}
+	if json.Unmarshal(payload, &result) != nil || len(result.Errors) != 0 {
+		return errors.New("agent: 3x-ui could not attach every existing client to the new REALITY node")
+	}
+	return nil
+}
+
+func containsInt(values []int, expected int) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func threeXUIRealityStreamSettings(target, sni, privateKey, publicKey, shortID string) map[string]any {

--- a/internal/agent/three_xui_reality_test.go
+++ b/internal/agent/three_xui_reality_test.go
@@ -109,6 +109,38 @@ func TestSyncThreeXUIRealityHostKeepsMatchingGroup(t *testing.T) {
 	}
 }
 
+func TestAttachAllThreeXUIClientsToInboundKeepsClientIdentity(t *testing.T) {
+	var emails []string
+	var inboundIDs []int
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		switch request.Method + " " + request.URL.Path {
+		case "GET /panel/api/clients/list/paged":
+			_, _ = response.Write([]byte(`{"success":true,"obj":{"items":[{"email":"MacBook","inboundIds":[7]},{"email":"Router","inboundIds":[7,9]}],"total":2}}`))
+		case "POST /panel/api/clients/bulkAttach":
+			var payload struct {
+				Emails     []string `json:"emails"`
+				InboundIDs []int    `json:"inboundIds"`
+			}
+			if json.NewDecoder(request.Body).Decode(&payload) != nil {
+				t.Fatal("bulk attachment payload was not decoded")
+			}
+			emails, inboundIDs = payload.Emails, payload.InboundIDs
+			_, _ = response.Write([]byte(`{"success":true,"obj":{"attached":["MacBook"],"skipped":[],"errors":[]}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if err := attachAllThreeXUIClientsToInbound(context.Background(), server.URL, "token", 9); err != nil {
+		t.Fatal(err)
+	}
+	if len(emails) != 1 || emails[0] != "MacBook" || len(inboundIDs) != 1 || inboundIDs[0] != 9 {
+		t.Fatalf("automatic attachment = emails %#v, inbounds %#v", emails, inboundIDs)
+	}
+}
+
 func TestSelectRealityTargetUsesNodeLocalFeasibilityAndSkipsUsedSNI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost || request.URL.Path != "/panel/api/server/scanRealityTargets" || request.Header.Get("Authorization") != "Bearer token" {

--- a/internal/center/application_commands.go
+++ b/internal/center/application_commands.go
@@ -82,6 +82,7 @@ type ThreeXUIClientCommandInput struct {
 	Email         string `json:"email,omitempty"`
 	NewEmail      string `json:"newEmail,omitempty"`
 	InboundID     int    `json:"inboundId,omitempty"`
+	InboundIDs    []int  `json:"inboundIds,omitempty"`
 	Enabled       bool   `json:"enabled"`
 	TotalBytes    int64  `json:"totalBytes"`
 	ExpiryTime    int64  `json:"expiryTime"`
@@ -103,6 +104,7 @@ type ThreeXUIClientCommandTask struct {
 	Email               string                  `json:"email,omitempty"`
 	NewEmail            string                  `json:"newEmail,omitempty"`
 	InboundID           int                     `json:"inboundId,omitempty"`
+	InboundIDs          []int                   `json:"inboundIds,omitempty"`
 	Enabled             bool                    `json:"enabled"`
 	TotalBytes          int64                   `json:"totalBytes"`
 	ExpiryTime          int64                   `json:"expiryTime"`

--- a/internal/center/deployment_tasks.go
+++ b/internal/center/deployment_tasks.go
@@ -232,12 +232,12 @@ func (s *Store) CompleteTask(ctx context.Context, agentID, credential, taskID st
 		return err
 	}
 	defer tx.Rollback()
-	var applicationID, operation, currentState string
+	var applicationID, appKey, role, operation, currentState string
 	var attempt int64
 	var manifestJSON, configJSON []byte
 	var serviceAddress string
-	if err := tx.QueryRowContext(ctx, `SELECT d.application_id, d.operation, d.state, d.manifest_json, d.config_json, COALESCE(p.service_address, ''), d.attempt
-		FROM deployments d LEFT JOIN agent_network_profiles p ON p.agent_id = d.agent_id WHERE d.id = ? AND d.agent_id = ?`, taskID, agentID).Scan(&applicationID, &operation, &currentState, &manifestJSON, &configJSON, &serviceAddress, &attempt); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT d.application_id, a.app_key, a.role, d.operation, d.state, d.manifest_json, d.config_json, COALESCE(p.service_address, ''), d.attempt
+		FROM deployments d JOIN applications a ON a.id = d.application_id LEFT JOIN agent_network_profiles p ON p.agent_id = d.agent_id WHERE d.id = ? AND d.agent_id = ?`, taskID, agentID).Scan(&applicationID, &appKey, &role, &operation, &currentState, &manifestJSON, &configJSON, &serviceAddress, &attempt); err != nil {
 		return errors.New("center: task not found")
 	}
 	if currentState == "succeeded" || currentState == "failed" {
@@ -261,7 +261,7 @@ func (s *Store) CompleteTask(ctx context.Context, agentID, credential, taskID st
 			if json.Unmarshal(manifestJSON, &manifest) != nil || catalog.ValidateApp(manifest) != nil {
 				return errors.New("center: stored deployment manifest is invalid")
 			}
-			if err := validateApplicationResult(manifest, configJSON, serviceAddress, taskResult); err != nil {
+			if err := validateApplicationResult(manifest, appKey, role, configJSON, serviceAddress, taskResult); err != nil {
 				state = "failed"
 				taskError = err.Error()
 				succeeded = false
@@ -287,10 +287,6 @@ func (s *Store) CompleteTask(ctx context.Context, agentID, credential, taskID st
 					err = s.queueThreeXUINodeReconcile(ctx, tx, taskID, applicationID, now)
 				}
 				if err != nil && operation != "uninstall" {
-					var role string
-					if roleErr := tx.QueryRowContext(ctx, `SELECT role FROM applications WHERE id = ?`, applicationID).Scan(&role); roleErr != nil {
-						return roleErr
-					}
 					if role == threeXUIRoleWorker {
 						if _, syncErr := tx.ExecContext(ctx, `UPDATE three_x_ui_nodes SET status = 'failed', last_error = ?, updated_at = ? WHERE worker_application_id = ?`, err.Error(), now.Format(time.RFC3339Nano), applicationID); syncErr != nil {
 							return syncErr

--- a/internal/center/deployment_validation.go
+++ b/internal/center/deployment_validation.go
@@ -7,8 +7,15 @@ import (
 	"github.com/petauron/vastora/internal/catalog"
 )
 
-func validateApplicationResult(manifest catalog.AppManifest, configJSON []byte, serviceAddress string, result ApplicationTaskResult) error {
-	if len(result.Services) != len(manifest.Services) {
+func validateApplicationResult(manifest catalog.AppManifest, appKey, role string, configJSON []byte, serviceAddress string, result ApplicationTaskResult) error {
+	services := make(map[string]catalog.Service, len(manifest.Services))
+	for _, service := range manifest.Services {
+		if appKey == threeXUIAppKey && role == threeXUIRoleWorker && service.Name == "subscription" {
+			continue
+		}
+		services[service.Name] = service
+	}
+	if len(result.Services) != len(services) {
 		return errors.New("center: Agent service result does not match the signed manifest")
 	}
 	var config map[string]json.RawMessage
@@ -17,8 +24,8 @@ func validateApplicationResult(manifest catalog.AppManifest, configJSON []byte, 
 	}
 	seen := make(map[string]bool, len(result.Services))
 	for _, reported := range result.Services {
-		declared, err := selectedCatalogService(manifest, reported.Name)
-		if err != nil || seen[reported.Name] || reported.Protocol != declared.Protocol || reported.ContainerPort != declared.ContainerPort {
+		declared, expected := services[reported.Name]
+		if !expected || seen[reported.Name] || reported.Protocol != declared.Protocol || reported.ContainerPort != declared.ContainerPort {
 			return errors.New("center: Agent service result does not match the signed manifest")
 		}
 		seen[reported.Name] = true

--- a/internal/center/deployment_validation_test.go
+++ b/internal/center/deployment_validation_test.go
@@ -1,0 +1,31 @@
+package center
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/petauron/vastora/internal/catalog"
+)
+
+func TestValidateApplicationResultUsesThreeXUIWorkerServices(t *testing.T) {
+	manifest := catalog.AppManifest{ID: "3x-ui", Services: []catalog.Service{
+		{Name: "panel", Protocol: "http", ContainerPort: 2053, DefaultHostPort: 2053, HostPortField: "panel_port"},
+		{Name: "subscription", Protocol: "http", ContainerPort: 2096, DefaultHostPort: 2096},
+	}}
+	config := json.RawMessage(`{"panel_port":2053}`)
+	panel := ApplicationServiceResult{Name: "panel", Protocol: "http", ContainerPort: 2053, HostPort: 2053, Address: "100.64.0.3"}
+
+	if err := validateApplicationResult(manifest, threeXUIAppKey, threeXUIRoleWorker, config, "100.64.0.3", ApplicationTaskResult{Services: []ApplicationServiceResult{panel}}); err != nil {
+		t.Fatalf("worker panel result was rejected: %v", err)
+	}
+
+	subscription := ApplicationServiceResult{Name: "subscription", Protocol: "http", ContainerPort: 2096, HostPort: 2096, Address: "100.64.0.3"}
+	if err := validateApplicationResult(manifest, threeXUIAppKey, threeXUIRoleWorker, config, "100.64.0.3", ApplicationTaskResult{Services: []ApplicationServiceResult{subscription}}); err == nil || !strings.Contains(err.Error(), "signed manifest") {
+		t.Fatalf("worker subscription result error = %v", err)
+	}
+
+	if err := validateApplicationResult(manifest, threeXUIAppKey, threeXUIRoleMaster, config, "100.64.0.3", ApplicationTaskResult{Services: []ApplicationServiceResult{panel}}); err == nil || !strings.Contains(err.Error(), "signed manifest") {
+		t.Fatalf("controller incomplete result error = %v", err)
+	}
+}

--- a/internal/center/orchestration.go
+++ b/internal/center/orchestration.go
@@ -85,15 +85,6 @@ func (s *Store) prepareApplication(ctx context.Context, tx *sql.Tx, request Depl
 	return applicationID, nil
 }
 
-func selectedCatalogService(manifest catalog.AppManifest, name string) (catalog.Service, error) {
-	for _, service := range manifest.Services {
-		if service.Name == name {
-			return service, nil
-		}
-	}
-	return catalog.Service{}, fmt.Errorf("center: catalog service %q not found", name)
-}
-
 func (s *Store) completeApplication(ctx context.Context, tx *sql.Tx, deploymentID, applicationID, operation string, result ApplicationTaskResult, now time.Time, cleanups *[]publicationCleanup) error {
 	if operation == "uninstall" {
 		values, err := s.applicationPublicationCleanups(ctx, tx, applicationID)

--- a/internal/center/three_x_ui_topology_test.go
+++ b/internal/center/three_x_ui_topology_test.go
@@ -112,11 +112,14 @@ func TestThreeXUISiteControllerAndVLESSNodeLifecycle(t *testing.T) {
 
 func completeThreeXUIDeployment(t *testing.T, store *Store, node AgentCredential, task *AgentTask, address, apiToken string) {
 	t.Helper()
+	services := []ApplicationServiceResult{
+		{Name: "panel", Protocol: "http", ContainerPort: 2053, HostPort: 2053, Address: address},
+	}
+	if task.ApplicationRole != threeXUIRoleWorker {
+		services = append(services, ApplicationServiceResult{Name: "subscription", Protocol: "http", ContainerPort: 2096, HostPort: 2096, Address: address})
+	}
 	result, _ := json.Marshal(ApplicationTaskResult{
-		Services: []ApplicationServiceResult{
-			{Name: "panel", Protocol: "http", ContainerPort: 2053, HostPort: 2053, Address: address},
-			{Name: "subscription", Protocol: "http", ContainerPort: 2096, HostPort: 2096, Address: address},
-		},
+		Services:         services,
 		GeneratedSecrets: map[string]string{"api_token": apiToken},
 	})
 	if err := store.CompleteTask(context.Background(), node.ID, node.Credential, task.ID, task.Attempt, true, "", result); err != nil {

--- a/internal/center/three_xui_clients.go
+++ b/internal/center/three_xui_clients.go
@@ -24,6 +24,12 @@ func normalizeThreeXUIClientCommandInput(input ThreeXUIClientCommandInput) (Thre
 	input.Action = strings.TrimSpace(input.Action)
 	input.Email = strings.TrimSpace(input.Email)
 	input.NewEmail = strings.TrimSpace(input.NewEmail)
+	for _, inboundID := range input.InboundIDs {
+		if inboundID < 1 {
+			return input, errors.New("center: selected REALITY node is invalid")
+		}
+	}
+	input.InboundIDs = normalizedThreeXUIInboundIDs(input.InboundIDs)
 	if input.ApplicationID == "" || !threeXUIClientActions[input.Action] {
 		return input, errors.New("center: application and a valid 3x-ui client operation are required")
 	}
@@ -32,12 +38,12 @@ func normalizeThreeXUIClientCommandInput(input ThreeXUIClientCommandInput) (Thre
 	}
 	switch input.Action {
 	case "create":
-		if !validThreeXUIClientName(input.NewEmail) || input.InboundID < 1 {
-			return input, errors.New("center: client name and REALITY inbound are required")
+		if !validThreeXUIClientName(input.NewEmail) || len(input.InboundIDs) == 0 {
+			return input, errors.New("center: client name and at least one REALITY node are required")
 		}
 	case "update":
-		if !validThreeXUIClientName(input.Email) || !validThreeXUIClientName(input.NewEmail) {
-			return input, errors.New("center: current and new client names are required")
+		if !validThreeXUIClientName(input.Email) || !validThreeXUIClientName(input.NewEmail) || len(input.InboundIDs) == 0 {
+			return input, errors.New("center: client name and at least one REALITY node are required")
 		}
 	case "set_enabled", "delete", "reset_traffic", "reveal_subscription":
 		if !validThreeXUIClientName(input.Email) {
@@ -49,6 +55,20 @@ func normalizeThreeXUIClientCommandInput(input ThreeXUIClientCommandInput) (Thre
 		}
 	}
 	return input, nil
+}
+
+func normalizedThreeXUIInboundIDs(values []int) []int {
+	seen := make(map[int]bool, len(values))
+	result := make([]int, 0, len(values))
+	for _, value := range values {
+		if value < 1 || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	sort.Ints(result)
+	return result
 }
 
 func validThreeXUIClientName(value string) bool {
@@ -97,13 +117,19 @@ func (s *Store) CreateThreeXUIClientCommand(ctx context.Context, input ThreeXUIC
 	if input.InboundID > 0 && !threeXUIClientInboundExists(inbounds, input.InboundID) {
 		return ApplicationCommandView{}, errors.New("center: selected REALITY inbound is unavailable")
 	}
+	for _, inboundID := range input.InboundIDs {
+		if !threeXUIClientInboundExists(inbounds, inboundID) {
+			return ApplicationCommandView{}, errors.New("center: selected REALITY node is unavailable")
+		}
+	}
 	subscriptionBaseURI, err := threeXUISubscriptionBaseURI(ctx, tx, input.ApplicationID)
 	if err != nil {
 		return ApplicationCommandView{}, err
 	}
 	task := ThreeXUIClientCommandTask{
 		Action: input.Action, Email: input.Email, NewEmail: input.NewEmail, InboundID: input.InboundID,
-		Enabled: input.Enabled, TotalBytes: input.TotalBytes, ExpiryTime: input.ExpiryTime, LimitIP: input.LimitIP,
+		InboundIDs: input.InboundIDs,
+		Enabled:    input.Enabled, TotalBytes: input.TotalBytes, ExpiryTime: input.ExpiryTime, LimitIP: input.LimitIP,
 		Inbounds: inbounds, SubscriptionBaseURI: subscriptionBaseURI,
 	}
 	encoded, _ := json.Marshal(task)

--- a/internal/center/three_xui_clients_test.go
+++ b/internal/center/three_xui_clients_test.go
@@ -97,3 +97,38 @@ func TestThreeXUIClientCommandsKeepLinksOneTimeAndMetadataSafe(t *testing.T) {
 		t.Fatalf("revealed subscription = %q err=%v", consumed, err)
 	}
 }
+
+func TestThreeXUIClientCommandSelectsMultipleSiteNodes(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	node := enrollOrchestrationNode(t, store, "controller", NodeCapabilities{Docker: true}, []networking.Candidate{{Address: "10.0.0.80", Interface: "eth0", Family: "ipv4", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.80", LANAddress: "10.0.0.80", EnabledKinds: []string{networking.KindLAN}})
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	siteID := testSiteID(t, store)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO applications(id, name, node_id, site_id, app_key, image, status, runtime, role, created_at, updated_at) VALUES('three-x-ui-controller', '3x-ui', ?, ?, ?, '', 'running', 'docker', 'master', ?, ?)`, node.ID, siteID, threeXUIAppKey, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO services(id, application_id, site_id, name, protocol, container_port, host_port, endpoint, source, app_protocol, management, observed_listen, status, created_at, updated_at)
+		VALUES('reality-9', 'three-x-ui-controller', ?, 'inbound-9', 'tcp', 30009, 30009, '10.0.0.80:30009', 'observed', 'vless/tcp/reality', 0, '10.0.0.80', 'ready', ?, ?),
+		('reality-10', 'three-x-ui-controller', ?, 'inbound-10', 'tcp', 30010, 30010, '10.0.0.80:30010', 'observed', 'vless/tcp/reality', 0, '10.0.0.80', 'ready', ?, ?)`, siteID, now, now, siteID, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	command, err := store.CreateThreeXUIClientCommand(ctx, ThreeXUIClientCommandInput{ApplicationID: "three-x-ui-controller", Action: "create", NewEmail: "Router", InboundIDs: []int{10, 9, 10}, Enabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := claimTask(t, store, node)
+	if task.ClientCommand == nil || len(task.ClientCommand.InboundIDs) != 2 || task.ClientCommand.InboundIDs[0] != 9 || task.ClientCommand.InboundIDs[1] != 10 {
+		t.Fatalf("multi-node client task = %#v", task.ClientCommand)
+	}
+	metadata := []ThreeXUIClientView{{Email: "Router", Enabled: true, InboundIDs: []int{9, 10}, HasSubscription: true}}
+	result, _ := json.Marshal(ApplicationTaskResult{ClientCommand: &ThreeXUIClientCommandResult{Clients: metadata, ClientsObserved: true, Inbounds: task.ClientCommand.Inbounds}})
+	if err := store.CompleteTask(ctx, node.ID, node.Credential, task.ID, task.Attempt, true, "", result); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.ApplicationCommand(ctx, command.ID)
+	if err != nil || completed.State != "succeeded" || len(completed.Clients) != 1 || len(completed.Clients[0].InboundIDs) != 2 {
+		t.Fatalf("multi-node client result = %#v err=%v", completed, err)
+	}
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -146,7 +146,7 @@ export type ApplicationCommandKind = "3xui.reality.create" | "3xui.subscription.
 export type ThreeXUIClientInbound = { id: number; name: string; applicationId?: string; nodeId?: string; nodeName?: string; connectHostname?: string; sniHostname?: string };
 export type ThreeXUIClient = { email: string; enabled: boolean; totalBytes: number; usedBytes: number; expiryTime: number; limitIp: number; inboundIds: number[]; hasSubscription: boolean };
 export type ThreeXUIClientAction = "list" | "create" | "update" | "set_enabled" | "delete" | "reset_traffic" | "reveal_link" | "reveal_subscription";
-export type ThreeXUIClientCommandInput = { applicationId: string; action: ThreeXUIClientAction; email?: string; newEmail?: string; inboundId?: number; enabled?: boolean; totalBytes?: number; expiryTime?: number; limitIp?: number };
+export type ThreeXUIClientCommandInput = { applicationId: string; action: ThreeXUIClientAction; email?: string; newEmail?: string; inboundId?: number; inboundIds?: number[]; enabled?: boolean; totalBytes?: number; expiryTime?: number; limitIp?: number };
 export type ApplicationCommand = { id: string; applicationId: string; gatewayNodeId: string; kind: ApplicationCommandKind; state: "pending" | "running" | "succeeded" | "failed"; hostname: string; dnsProvider: "manual" | "cloudflare"; target?: string; sniHostname?: string; publicationId?: string; action?: ThreeXUIClientAction; clients?: ThreeXUIClient[]; clientsObserved?: boolean; inbounds?: ThreeXUIClientInbound[]; subscriptionAvailable?: boolean; error?: string; resultAvailable: boolean; createdAt: string; updatedAt: string };
 
 export type Deployment = {

--- a/web/src/views/ThreeXUIClientsSheet.tsx
+++ b/web/src/views/ThreeXUIClientsSheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
-import { CopyIcon, ExternalLinkIcon, LinkIcon, PencilIcon, PlusIcon, RefreshCwIcon, RotateCcwIcon, Trash2Icon, UsersIcon } from "lucide-react";
+import { CheckIcon, CopyIcon, ExternalLinkIcon, LinkIcon, PencilIcon, PlusIcon, RefreshCwIcon, RotateCcwIcon, ServerIcon, Trash2Icon, UsersIcon } from "lucide-react";
 import { api } from "../api";
 import type { Application, ApplicationCommand, ThreeXUIClient, ThreeXUIClientCommandInput, ThreeXUIClientInbound } from "../types";
 import type { Language } from "../translations";
@@ -10,7 +10,6 @@ import { Button } from "@/components/ui/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { NativeSelect } from "@/components/ui/native-select";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
@@ -75,7 +74,7 @@ export function ThreeXUIClientsSheet({ application, advancedURL, language, onClo
     setNotice("");
     try {
       await runCommand(input);
-      if (input.action !== "list" && input.action !== "reveal_link" && input.action !== "reveal_subscription") setNotice(copy(language, "更改已同步到 3x-ui。", "The change was synced to 3x-ui."));
+      if (input.action !== "list" && input.action !== "reveal_link" && input.action !== "reveal_subscription") setNotice(copy(language, "更改已同步到所选节点。", "The change was synced to the selected nodes."));
     } catch (operationError) {
       setError(readableError(language, operationError));
       throw operationError;
@@ -126,10 +125,10 @@ export function ThreeXUIClientsSheet({ application, advancedURL, language, onClo
           <div className="grid gap-3">
             {visibleClients.map((client) => {
               const publishedInbound = inbounds.find((inbound) => inbound.connectHostname && client.inboundIds.includes(inbound.id));
-              const inboundNames = inbounds.filter((inbound) => client.inboundIds.includes(inbound.id)).map((inbound) => inbound.nodeName ? `${inbound.nodeName} · ${inbound.name}` : inbound.name);
+              const inboundNames = inbounds.filter((inbound) => client.inboundIds.includes(inbound.id)).map((inbound) => inbound.nodeName || inbound.name);
               return <div className="rounded-2xl border bg-card p-4" key={client.email}>
                 <div className="flex flex-wrap items-start gap-3">
-                  <div className="min-w-0 flex-1"><div className="flex flex-wrap items-center gap-2"><h3 className="truncate font-medium">{client.email}</h3><Badge variant={client.enabled ? "secondary" : "outline"}>{client.enabled ? copy(language, "已启用", "Enabled") : copy(language, "已停用", "Disabled")}</Badge></div><p className="mt-1 text-xs text-muted-foreground">{inboundNames.length ? inboundNames.join(" · ") : copy(language, "未连接入站", "No inbound attached")}</p></div>
+                  <div className="min-w-0 flex-1"><div className="flex flex-wrap items-center gap-2"><h3 className="truncate font-medium">{client.email}</h3><Badge variant={client.enabled ? "secondary" : "outline"}>{client.enabled ? copy(language, "已启用", "Enabled") : copy(language, "已停用", "Disabled")}</Badge></div><p className="mt-1 text-xs text-muted-foreground">{inboundNames.length ? copy(language, `已接入 ${inboundNames.length} 个节点：${inboundNames.join("、")}`, `Connected to ${inboundNames.length} node(s): ${inboundNames.join(", ")}`) : copy(language, "未连接节点", "No node attached")}</p></div>
                   <Switch aria-label={copy(language, `启用 ${client.email}`, `Enable ${client.email}`)} checked={client.enabled} disabled={busy} onCheckedChange={(enabled) => void run({ action: "set_enabled", email: client.email, enabled }).catch(() => undefined)} />
                 </div>
                 <div className="mt-4 grid gap-3 text-xs sm:grid-cols-3"><Metric label={copy(language, "已用流量", "Traffic used")} value={`${formatBytes(client.usedBytes)}${client.totalBytes ? ` / ${formatBytes(client.totalBytes)}` : ""}`} /><Metric label={copy(language, "有效期", "Expires")} value={formatExpiry(client.expiryTime, language)} /><Metric label={copy(language, "设备数限制", "IP limit")} value={client.limitIp ? String(client.limitIp) : copy(language, "不限", "Unlimited")} /></div>
@@ -151,23 +150,77 @@ export function ThreeXUIClientsSheet({ application, advancedURL, language, onClo
 function ClientEditor({ busy, editor, inbounds, language, onCancel, onSave }: { busy: boolean; editor: NonNullable<Editor>; inbounds: ThreeXUIClientInbound[]; language: Language; onCancel: () => void; onSave: (input: Omit<ThreeXUIClientCommandInput, "applicationId">) => Promise<void> }) {
   const client = editor.client;
   const [name, setName] = useState(client?.email ?? "");
-  const [inboundID, setInboundID] = useState(client?.inboundIds[0] ?? inbounds[0]?.id ?? 0);
+  const [inboundIDs, setInboundIDs] = useState<number[]>(() => client ? client.inboundIds.filter((id) => inbounds.some((inbound) => inbound.id === id)) : inbounds.map((inbound) => inbound.id));
   const [quota, setQuota] = useState(client?.totalBytes ? String(Math.round(client.totalBytes / gibibyte * 100) / 100) : "");
   const [expiry, setExpiry] = useState(client?.expiryTime ? localDateValue(client.expiryTime) : "");
   const [limitIP, setLimitIP] = useState(client?.limitIp ? String(client.limitIp) : "");
   const [enabled, setEnabled] = useState(client?.enabled ?? true);
   const [error, setError] = useState("");
   const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault(); setError("");
+    event.preventDefault();
+    setError("");
     const totalBytes = quota ? Math.round(Number(quota) * gibibyte) : 0;
     const expiryTime = expiry ? new Date(`${expiry}T23:59:59`).getTime() : 0;
     const limit = limitIP ? Number(limitIP) : 0;
-    if (!name.trim() || !Number.isFinite(totalBytes) || totalBytes < 0 || !Number.isInteger(limit) || limit < 0) { setError(copy(language, "请检查名称、流量和设备数。", "Check the name, quota, and IP limit.")); return; }
+    if (!name.trim() || !Number.isFinite(totalBytes) || totalBytes < 0 || !Number.isInteger(limit) || limit < 0) {
+      setError(copy(language, "请检查名称、流量和设备数。", "Check the name, quota, and IP limit."));
+      return;
+    }
     try {
-      await onSave(client ? { action: "update", email: client.email, newEmail: name.trim(), totalBytes, expiryTime, limitIp: limit } : { action: "create", newEmail: name.trim(), inboundId: inboundID, enabled, totalBytes, expiryTime, limitIp: limit });
-    } catch (saveError) { setError(readableError(language, saveError)); }
+      await onSave(client ? { action: "update", email: client.email, newEmail: name.trim(), inboundIds: inboundIDs, totalBytes, expiryTime, limitIp: limit } : { action: "create", newEmail: name.trim(), inboundIds: inboundIDs, enabled, totalBytes, expiryTime, limitIp: limit });
+    } catch (saveError) {
+      setError(readableError(language, saveError));
+    }
   };
-  return <form className="flex min-h-0 flex-1 flex-col" onSubmit={(event) => void submit(event)}><div className="flex-1 overflow-y-auto px-4"><FieldGroup><Field><FieldLabel htmlFor="three-xui-client-name">{copy(language, "名称", "Name")}</FieldLabel><Input autoFocus id="three-xui-client-name" maxLength={64} onChange={(event) => setName(event.target.value)} placeholder={copy(language, "例如：我的 MacBook", "For example: My MacBook")} required value={name} /><FieldDescription>{copy(language, "这是设备名称，不需要填写真实邮箱。", "This is a device label, not a real email address.")}</FieldDescription></Field><Field><FieldLabel htmlFor="three-xui-client-inbound">{copy(language, "使用的节点和入站", "Node and inbound")}</FieldLabel><NativeSelect disabled={Boolean(client)} id="three-xui-client-inbound" onChange={(event) => setInboundID(Number(event.target.value))} required value={inboundID}>{inbounds.map((inbound) => <option key={inbound.id} value={inbound.id}>{inbound.nodeName ? `${inbound.nodeName} · ` : ""}{inbound.name}{inbound.connectHostname ? ` · ${inbound.connectHostname}` : ""}</option>)}</NativeSelect>{client ? <FieldDescription>{copy(language, "更改客户端所属入站属于高级操作，请在 3x-ui 中完成。", "Changing inbound attachments is an advanced task handled in 3x-ui.")}</FieldDescription> : null}</Field><Field><FieldLabel htmlFor="three-xui-client-quota">{copy(language, "流量上限（GB）", "Traffic limit (GB)")}</FieldLabel><Input id="three-xui-client-quota" min="0" onChange={(event) => setQuota(event.target.value)} placeholder={copy(language, "留空表示不限", "Leave empty for unlimited")} step="0.1" type="number" value={quota} /></Field><Field><FieldLabel htmlFor="three-xui-client-expiry">{copy(language, "到期日期", "Expiry date")}</FieldLabel><Input id="three-xui-client-expiry" min={new Date().toISOString().slice(0, 10)} onChange={(event) => setExpiry(event.target.value)} type="date" value={expiry} /><FieldDescription>{copy(language, "留空表示永不过期。", "Leave empty to never expire.")}</FieldDescription></Field><Field><FieldLabel htmlFor="three-xui-client-limit-ip">{copy(language, "同时使用的设备数", "Simultaneous devices")}</FieldLabel><Input id="three-xui-client-limit-ip" min="0" onChange={(event) => setLimitIP(event.target.value)} placeholder={copy(language, "留空表示不限", "Leave empty for unlimited")} step="1" type="number" value={limitIP} /></Field>{!client ? <Field orientation="horizontal"><div className="flex flex-1 flex-col gap-1"><FieldLabel htmlFor="three-xui-client-enabled">{copy(language, "创建后立即启用", "Enable after creation")}</FieldLabel><FieldDescription>{copy(language, "关闭时会保存客户端，但暂时不能连接。", "When off, the client is saved but cannot connect yet.")}</FieldDescription></div><Switch checked={enabled} id="three-xui-client-enabled" onCheckedChange={setEnabled} /></Field> : null}{error ? <FieldError role="alert">{error}</FieldError> : null}</FieldGroup></div><SheetFooter><Button disabled={busy} onClick={onCancel} type="button" variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy || !name.trim() || (!client && !inboundID)} type="submit">{busy ? <Spinner data-icon="inline-start" /> : null}{client ? copy(language, "保存修改", "Save changes") : copy(language, "添加客户端", "Add client")}</Button></SheetFooter></form>;
+  return <form className="flex min-h-0 flex-1 flex-col" onSubmit={(event) => void submit(event)}>
+    <div className="flex-1 overflow-y-auto px-4">
+      <FieldGroup>
+        <Field>
+          <FieldLabel htmlFor="three-xui-client-name">{copy(language, "名称", "Name")}</FieldLabel>
+          <Input autoFocus id="three-xui-client-name" maxLength={64} onChange={(event) => setName(event.target.value)} placeholder={copy(language, "例如：我的 MacBook", "For example: My MacBook")} required value={name} />
+          <FieldDescription>{copy(language, "这是设备名称，不需要填写真实邮箱。", "This is a device label, not a real email address.")}</FieldDescription>
+        </Field>
+        <ClientNodePicker busy={busy} inbounds={inbounds} language={language} onChange={setInboundIDs} selected={inboundIDs} />
+        <Field>
+          <FieldLabel htmlFor="three-xui-client-quota">{copy(language, "流量上限（GB）", "Traffic limit (GB)")}</FieldLabel>
+          <Input id="three-xui-client-quota" min="0" onChange={(event) => setQuota(event.target.value)} placeholder={copy(language, "留空表示不限", "Leave empty for unlimited")} step="0.1" type="number" value={quota} />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="three-xui-client-expiry">{copy(language, "到期日期", "Expiry date")}</FieldLabel>
+          <Input id="three-xui-client-expiry" min={new Date().toISOString().slice(0, 10)} onChange={(event) => setExpiry(event.target.value)} type="date" value={expiry} />
+          <FieldDescription>{copy(language, "留空表示永不过期。", "Leave empty to never expire.")}</FieldDescription>
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="three-xui-client-limit-ip">{copy(language, "同时使用的设备数", "Simultaneous devices")}</FieldLabel>
+          <Input id="three-xui-client-limit-ip" min="0" onChange={(event) => setLimitIP(event.target.value)} placeholder={copy(language, "留空表示不限", "Leave empty for unlimited")} step="1" type="number" value={limitIP} />
+        </Field>
+        {!client ? <Field orientation="horizontal"><div className="flex flex-1 flex-col gap-1"><FieldLabel htmlFor="three-xui-client-enabled">{copy(language, "创建后立即启用", "Enable after creation")}</FieldLabel><FieldDescription>{copy(language, "关闭时会保存客户端，但暂时不能连接。", "When off, the client is saved but cannot connect yet.")}</FieldDescription></div><Switch checked={enabled} id="three-xui-client-enabled" onCheckedChange={setEnabled} /></Field> : null}
+        {error ? <FieldError role="alert">{error}</FieldError> : null}
+      </FieldGroup>
+    </div>
+    <SheetFooter><Button disabled={busy} onClick={onCancel} type="button" variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy || !name.trim() || inboundIDs.length === 0} type="submit">{busy ? <Spinner data-icon="inline-start" /> : null}{client ? copy(language, "保存修改", "Save changes") : copy(language, "添加客户端", "Add client")}</Button></SheetFooter>
+  </form>;
+}
+
+function ClientNodePicker({ busy, inbounds, language, onChange, selected }: { busy: boolean; inbounds: ThreeXUIClientInbound[]; language: Language; onChange: (ids: number[]) => void; selected: number[] }) {
+  const toggle = (id: number) => onChange(selected.includes(id) ? selected.filter((value) => value !== id) : [...selected, id]);
+  return <fieldset className="grid gap-3">
+    <legend className="text-sm font-medium">{copy(language, "使用哪些节点", "Nodes to use")}</legend>
+    <div className="flex items-start justify-between gap-3">
+      <p className="text-sm text-muted-foreground">{copy(language, "默认使用全部节点；以后添加的新入站也会自动同步现有客户端。", "All nodes are selected by default. New inbounds also receive existing clients automatically.")}</p>
+      <Button disabled={busy || selected.length === inbounds.length} onClick={() => onChange(inbounds.map((inbound) => inbound.id))} size="sm" type="button" variant="ghost">{copy(language, "全选", "Select all")}</Button>
+    </div>
+    <div className="grid gap-2 sm:grid-cols-2">
+      {inbounds.map((inbound) => {
+        const checked = selected.includes(inbound.id);
+        return <button aria-checked={checked} className={`flex min-h-14 items-center gap-3 rounded-xl border p-3 text-left transition-colors ${checked ? "border-primary bg-primary/5" : "bg-card hover:bg-accent"}`} disabled={busy} key={inbound.id} onClick={() => toggle(inbound.id)} role="checkbox" type="button">
+          <span className={`flex size-9 shrink-0 items-center justify-center rounded-full ${checked ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"}`}>{checked ? <CheckIcon className="size-4" /> : <ServerIcon className="size-4" />}</span>
+          <span className="min-w-0 flex-1"><span className="block truncate text-sm font-medium">{inbound.nodeName || inbound.name}</span><span className="mt-0.5 block truncate text-xs text-muted-foreground">{inbound.connectHostname || inbound.name}</span></span>
+        </button>;
+      })}
+    </div>
+    <p aria-live="polite" className="text-xs text-muted-foreground">{copy(language, `已选择 ${selected.length} / ${inbounds.length} 个节点`, `${selected.length} of ${inbounds.length} nodes selected`)}</p>
+  </fieldset>;
 }
 
 function Metric({ label, value }: { label: string; value: string }) { return <div><p className="text-muted-foreground">{label}</p><p className="mt-1 font-medium tabular-nums">{value}</p></div>; }

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -300,7 +300,7 @@ describe("network and app views", () => {
 
   it("manages 3x-ui clients and reveals links without opening the panel", async () => {
     const data = realityDashboard();
-    const baseCommand: ApplicationCommand = { id: "client-command-list", applicationId: "three-x-ui", gatewayNodeId: "agent", kind: "3xui.clients.manage", state: "succeeded", hostname: "", dnsProvider: "manual", action: "list", clients: [{ email: "MacBook", enabled: true, totalBytes: 10 * 1024 ** 3, usedBytes: 1024, expiryTime: 0, limitIp: 2, inboundIds: [9], hasSubscription: true }], clientsObserved: true, inbounds: [{ id: 9, name: "inbound-9", nodeName: "edge-worker", connectHostname: "reality.example.test" }], subscriptionAvailable: true, resultAvailable: false, createdAt: "2026-08-22T00:00:00Z", updatedAt: "2026-08-22T00:00:01Z" };
+    const baseCommand: ApplicationCommand = { id: "client-command-list", applicationId: "three-x-ui", gatewayNodeId: "agent", kind: "3xui.clients.manage", state: "succeeded", hostname: "", dnsProvider: "manual", action: "list", clients: [{ email: "MacBook", enabled: true, totalBytes: 10 * 1024 ** 3, usedBytes: 1024, expiryTime: 0, limitIp: 2, inboundIds: [9], hasSubscription: true }], clientsObserved: true, inbounds: [{ id: 9, name: "inbound-9", nodeName: "edge-worker", connectHostname: "reality.example.test" }, { id: 10, name: "inbound-10", nodeName: "oracle-worker", connectHostname: "reality.oracle.example.test" }], subscriptionAvailable: true, resultAvailable: false, createdAt: "2026-08-22T00:00:00Z", updatedAt: "2026-08-22T00:00:01Z" };
     const create = vi.spyOn(api, "createThreeXUIClientCommand").mockImplementation(async (input) => input.action.startsWith("reveal_") ? { ...baseCommand, id: `client-command-${input.action}`, action: input.action, resultAvailable: true } : baseCommand);
     const reveal = vi.spyOn(api, "revealApplicationCommand").mockImplementation(async (id) => ({ shareUri: id.includes("subscription") ? "https://subscription.example.test/sub/client-id" : "vless://one-time-client-link" }));
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -313,8 +313,20 @@ describe("network and app views", () => {
     });
     expect(create).toHaveBeenCalledWith({ applicationId: "three-x-ui", action: "list" });
     expect(document.body.textContent).toContain("MacBook");
-    expect(document.body.textContent).toContain("edge-worker · inbound-9");
+    expect(document.body.textContent).toContain("已接入 1 个节点：edge-worker");
     expect(document.body.textContent).toContain("日常管理");
+    act(() => [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("编辑") || button.querySelector(".sr-only")?.textContent === "编辑")?.click());
+    const nodeChoices = [...document.querySelectorAll<HTMLElement>('[role="checkbox"]')];
+    expect(nodeChoices).toHaveLength(2);
+    expect(nodeChoices[0].getAttribute("aria-checked")).toBe("true");
+    expect(nodeChoices[1].getAttribute("aria-checked")).toBe("false");
+    act(() => nodeChoices[1].click());
+    await act(async () => {
+      [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("保存修改"))?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(create).toHaveBeenCalledWith({ applicationId: "three-x-ui", action: "update", email: "MacBook", newEmail: "MacBook", inboundIds: [9, 10], totalBytes: 10 * 1024 ** 3, expiryTime: 0, limitIp: 2 });
     await act(async () => {
       [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("复制 VLESS"))?.click();
       await Promise.resolve();


### PR DESCRIPTION
## Summary
- validate 3x-ui worker installation results against the role-specific service set
- attach existing clients automatically when a new REALITY inbound is created
- let operators create and edit clients across multiple site nodes from Vastora
- add regression coverage for worker installation, client attachment, and the node picker

## Verification
- local tests intentionally not run; GitHub CI is the requested verification path
- `git diff --check` passed