### PR TITLE
feat: deliver agent tasks instantly

### DIFF
--- a/cmd/vastora/agent_cmd.go
+++ b/cmd/vastora/agent_cmd.go
@@ -261,6 +261,9 @@ func runAgent(arguments []string) error {
 		go client.RunHeartbeats(context.Background(), store, *heartbeatInterval, func(err error) {
 			fmt.Fprintln(os.Stderr, "agent heartbeat:", err)
 		})
+		go client.RunTasks(context.Background(), store, func(err error) {
+			fmt.Fprintln(os.Stderr, "agent task channel:", err)
+		})
 		fmt.Printf("Agent health listener on %s\n", *listen)
 		return http.ListenAndServe(*listen, store.Handler())
 	default:

--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -137,6 +137,7 @@ type SubscriptionCommandResult struct {
 type ThreeXUIClientInbound struct {
 	ID              int    `json:"id"`
 	Name            string `json:"name"`
+	DisplayName     string `json:"displayName,omitempty"`
 	ApplicationID   string `json:"applicationId"`
 	NodeID          string `json:"nodeId"`
 	NodeName        string `json:"nodeName"`
@@ -367,125 +368,6 @@ func (c Client) RunHeartbeats(ctx context.Context, store *Store, interval time.D
 		if observeErr != nil && report != nil {
 			report(observeErr)
 		}
-		if err != nil {
-			if report != nil {
-				report(err)
-			}
-			return
-		}
-		task, err := c.claimNextTask(requestContext, store)
-		if err != nil {
-			if report != nil {
-				report(err)
-			}
-			return
-		}
-		if task == nil {
-			return
-		}
-		var result ApplicationTaskResult
-		switch task.Kind {
-		case "application.apply":
-			if c.Executor == nil || !c.Capabilities.Docker {
-				err = errors.New("agent: Docker capability is not configured")
-			} else {
-				result, err = c.Executor.Deploy(requestContext, *task)
-			}
-		case "application.command":
-			commands := 0
-			if task.ApplicationCommand != nil {
-				commands++
-			}
-			if task.SubscriptionCommand != nil {
-				commands++
-			}
-			if task.ClientCommand != nil {
-				commands++
-			}
-			if task.NodeCommand != nil {
-				commands++
-			}
-			if task.ControllerCommand != nil {
-				commands++
-			}
-			if !c.Capabilities.Docker || commands != 1 {
-				err = errors.New("agent: application command received without Docker capability")
-			} else if task.ApplicationCommand != nil {
-				var commandResult RealityCommandResult
-				commandResult, err = applyRealityCommand(requestContext, store, task.ID, *task.ApplicationCommand)
-				if err == nil {
-					result.ApplicationCommand = &commandResult
-				}
-			} else if task.SubscriptionCommand != nil {
-				var commandResult SubscriptionCommandResult
-				commandResult, err = applySubscriptionCommand(requestContext, store, *task.SubscriptionCommand)
-				if err == nil {
-					result.SubscriptionCommand = &commandResult
-				}
-			} else if task.ClientCommand != nil {
-				var commandResult ThreeXUIClientCommandResult
-				commandResult, err = applyThreeXUIClientCommand(requestContext, store, *task.ClientCommand)
-				if err == nil {
-					result.ClientCommand = &commandResult
-				}
-			} else if task.NodeCommand != nil {
-				var commandResult ThreeXUINodeCommandResult
-				commandResult, err = applyThreeXUINodeCommand(requestContext, store, *task.NodeCommand)
-				if err == nil {
-					result.NodeCommand = &commandResult
-				}
-			} else {
-				var commandResult ThreeXUIControllerCommandResult
-				commandResult, err = c.applyThreeXUIControllerCommand(requestContext, store, *task.ControllerCommand)
-				if err == nil {
-					result.ControllerCommand = &commandResult
-				}
-			}
-		case "gateway.routes.apply":
-			if task.GatewayState == nil || !c.Capabilities.Gateway {
-				err = errors.New("agent: gateway task received without gateway capability")
-			} else {
-				err = applyGatewayDesiredState(requestContext, store, c.GatewayDriver, *task.GatewayState, task.GatewayCertificates)
-			}
-		case "gateway.component.apply":
-			if c.GatewayProvisioner == nil || !c.Capabilities.Gateway {
-				err = errors.New("agent: gateway provisioning capability is not configured")
-			} else if task.Operation == "running" {
-				err = c.GatewayProvisioner.Ensure(requestContext)
-				if err == nil {
-					err = waitForGateway(requestContext, c.GatewayDriver)
-				}
-			} else if task.Operation == "stopped" {
-				err = c.GatewayProvisioner.Remove(requestContext)
-				if err == nil {
-					err = store.ClearGatewayState(requestContext)
-				}
-			} else {
-				err = errors.New("agent: invalid gateway component operation")
-			}
-		case "tunnel.state.apply":
-			if c.TunnelProvisioner == nil || !c.Capabilities.Tunnel || task.TunnelState == nil {
-				err = errors.New("agent: tunnel task received without tunnel capability")
-			} else {
-				err = c.TunnelProvisioner.Apply(requestContext, *task.TunnelState)
-			}
-		default:
-			err = errors.New("agent: unsupported task kind")
-		}
-		if err == nil && task.Kind == "application.apply" && task.Operation != "uninstall" {
-			if len(result.GeneratedSecrets) != 0 {
-				task.Secrets, err = mergeGeneratedSecrets(task.Secrets, result.GeneratedSecrets)
-			}
-		}
-		if err == nil && task.Kind == "application.apply" && task.Operation != "uninstall" {
-			_, err = store.RecordApplied(requestContext, AppliedInstallation{InstanceID: task.ID, AppKey: task.AppKey, Version: task.Manifest.Version, Config: task.Config, Secrets: task.Secrets, ServiceAddress: task.ServiceAddress})
-		}
-		if err == nil && task.Kind == "application.apply" && task.Operation == "uninstall" {
-			err = store.RemoveApplied(requestContext, task.AppKey)
-		}
-		if completeErr := c.completeTask(requestContext, store, task.ID, task.Attempt, result, err); completeErr != nil && report != nil {
-			report(completeErr)
-		}
 		if err != nil && report != nil {
 			report(err)
 		}
@@ -500,6 +382,144 @@ func (c Client) RunHeartbeats(ctx context.Context, store *Store, interval time.D
 		case <-ticker.C:
 			send()
 		}
+	}
+}
+
+func (c Client) RunTasks(ctx context.Context, store *Store, report func(error)) {
+	for {
+		claimContext, cancel := context.WithTimeout(ctx, 15*time.Second)
+		task, err := c.claimNextTask(claimContext, store, 10*time.Second)
+		cancel()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if report != nil {
+				report(err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+		if task == nil {
+			continue
+		}
+		requestContext, requestCancel := context.WithTimeout(ctx, 5*time.Minute)
+		c.processTask(requestContext, store, *task, report)
+		requestCancel()
+	}
+}
+
+func (c Client) processTask(ctx context.Context, store *Store, task DeploymentTask, report func(error)) {
+	var result ApplicationTaskResult
+	var err error
+	switch task.Kind {
+	case "application.apply":
+		if c.Executor == nil || !c.Capabilities.Docker {
+			err = errors.New("agent: Docker capability is not configured")
+		} else {
+			result, err = c.Executor.Deploy(ctx, task)
+		}
+	case "application.command":
+		commands := 0
+		if task.ApplicationCommand != nil {
+			commands++
+		}
+		if task.SubscriptionCommand != nil {
+			commands++
+		}
+		if task.ClientCommand != nil {
+			commands++
+		}
+		if task.NodeCommand != nil {
+			commands++
+		}
+		if task.ControllerCommand != nil {
+			commands++
+		}
+		if !c.Capabilities.Docker || commands != 1 {
+			err = errors.New("agent: application command received without Docker capability")
+		} else if task.ApplicationCommand != nil {
+			var commandResult RealityCommandResult
+			commandResult, err = applyRealityCommand(ctx, store, task.ID, *task.ApplicationCommand)
+			if err == nil {
+				result.ApplicationCommand = &commandResult
+			}
+		} else if task.SubscriptionCommand != nil {
+			var commandResult SubscriptionCommandResult
+			commandResult, err = applySubscriptionCommand(ctx, store, *task.SubscriptionCommand)
+			if err == nil {
+				result.SubscriptionCommand = &commandResult
+			}
+		} else if task.ClientCommand != nil {
+			var commandResult ThreeXUIClientCommandResult
+			commandResult, err = applyThreeXUIClientCommand(ctx, store, *task.ClientCommand)
+			if err == nil {
+				result.ClientCommand = &commandResult
+			}
+		} else if task.NodeCommand != nil {
+			var commandResult ThreeXUINodeCommandResult
+			commandResult, err = applyThreeXUINodeCommand(ctx, store, *task.NodeCommand)
+			if err == nil {
+				result.NodeCommand = &commandResult
+			}
+		} else {
+			var commandResult ThreeXUIControllerCommandResult
+			commandResult, err = c.applyThreeXUIControllerCommand(ctx, store, *task.ControllerCommand)
+			if err == nil {
+				result.ControllerCommand = &commandResult
+			}
+		}
+	case "gateway.routes.apply":
+		if task.GatewayState == nil || !c.Capabilities.Gateway {
+			err = errors.New("agent: gateway task received without gateway capability")
+		} else {
+			err = applyGatewayDesiredState(ctx, store, c.GatewayDriver, *task.GatewayState, task.GatewayCertificates)
+		}
+	case "gateway.component.apply":
+		if c.GatewayProvisioner == nil || !c.Capabilities.Gateway {
+			err = errors.New("agent: gateway provisioning capability is not configured")
+		} else if task.Operation == "running" {
+			err = c.GatewayProvisioner.Ensure(ctx)
+			if err == nil {
+				err = waitForGateway(ctx, c.GatewayDriver)
+			}
+		} else if task.Operation == "stopped" {
+			err = c.GatewayProvisioner.Remove(ctx)
+			if err == nil {
+				err = store.ClearGatewayState(ctx)
+			}
+		} else {
+			err = errors.New("agent: invalid gateway component operation")
+		}
+	case "tunnel.state.apply":
+		if c.TunnelProvisioner == nil || !c.Capabilities.Tunnel || task.TunnelState == nil {
+			err = errors.New("agent: tunnel task received without tunnel capability")
+		} else {
+			err = c.TunnelProvisioner.Apply(ctx, *task.TunnelState)
+		}
+	default:
+		err = errors.New("agent: unsupported task kind")
+	}
+	if err == nil && task.Kind == "application.apply" && task.Operation != "uninstall" {
+		if len(result.GeneratedSecrets) != 0 {
+			task.Secrets, err = mergeGeneratedSecrets(task.Secrets, result.GeneratedSecrets)
+		}
+	}
+	if err == nil && task.Kind == "application.apply" && task.Operation != "uninstall" {
+		_, err = store.RecordApplied(ctx, AppliedInstallation{InstanceID: task.ID, AppKey: task.AppKey, Version: task.Manifest.Version, Config: task.Config, Secrets: task.Secrets, ServiceAddress: task.ServiceAddress})
+	}
+	if err == nil && task.Kind == "application.apply" && task.Operation == "uninstall" {
+		err = store.RemoveApplied(ctx, task.AppKey)
+	}
+	if completeErr := c.completeTask(ctx, store, task.ID, task.Attempt, result, err); completeErr != nil && report != nil {
+		report(completeErr)
+	}
+	if err != nil && report != nil {
+		report(err)
 	}
 }
 
@@ -534,7 +554,7 @@ func waitForGateway(ctx context.Context, driver GatewayDriver) error {
 	}
 }
 
-func (c Client) claimNextTask(ctx context.Context, store *Store) (*DeploymentTask, error) {
+func (c Client) claimNextTask(ctx context.Context, store *Store, wait time.Duration) (*DeploymentTask, error) {
 	connection, err := store.Connection(ctx)
 	if err != nil {
 		return nil, err
@@ -542,7 +562,8 @@ func (c Client) claimNextTask(ctx context.Context, store *Store) (*DeploymentTas
 	var response struct {
 		Task *DeploymentTask `json:"task"`
 	}
-	if err := c.get(ctx, connection.CenterURL+"/api/v1/agents/"+url.PathEscape(connection.AgentID)+"/tasks/next", connection.Credential, &response); err != nil {
+	endpoint := connection.CenterURL + "/api/v1/agents/" + url.PathEscape(connection.AgentID) + "/tasks/next?wait=" + url.QueryEscape(wait.String())
+	if err := c.get(ctx, endpoint, connection.Credential, &response); err != nil {
 		return nil, err
 	}
 	return response.Task, nil

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +58,21 @@ func TestObserveThreeXUISynchronizesEnabledInboundsWithoutChangingThem(t *testin
 	}
 }
 
+func TestThreeXUIClientInboundDisplayNameSurvivesAgentRoundTrip(t *testing.T) {
+	var task ThreeXUIClientCommandTask
+	if err := json.Unmarshal([]byte(`{"action":"list","inbounds":[{"id":7,"name":"inbound-7","displayName":"美国CloudLead","applicationId":"app-1","nodeId":"node-1","nodeName":"CloudLead"}]}`), &task); err != nil {
+		t.Fatal(err)
+	}
+	result := ThreeXUIClientCommandResult{Inbounds: task.Inbounds}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(payload), `"displayName":"美国CloudLead"`) {
+		t.Fatalf("display name was lost from Agent result: %s", payload)
+	}
+}
+
 func TestHeartbeatsRestoreGatewayStateOnlyAtStartup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -102,6 +118,29 @@ func TestHeartbeatsRestoreGatewayStateOnlyAtStartup(t *testing.T) {
 	}
 	if len(driver.applied) != 1 || driver.applied[0].Revision != 3 {
 		t.Fatalf("persisted gateway state was restored %d times: %#v", len(driver.applied), driver.applied)
+	}
+}
+
+func TestTaskClaimUsesBoundedLongPoll(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/agents/agent-1/tasks/next" || request.URL.Query().Get("wait") != "10s" {
+			t.Fatalf("unexpected task claim request: %s", request.URL.String())
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"task":null}`))
+	}))
+	defer server.Close()
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "agent-1", Name: "test", CenterURL: server.URL, Credential: "credential"}); err != nil {
+		t.Fatal(err)
+	}
+	task, err := (Client{}).claimNextTask(context.Background(), store, 10*time.Second)
+	if err != nil || task != nil {
+		t.Fatalf("unexpected task claim result: task=%#v err=%v", task, err)
 	}
 }
 

--- a/internal/center/application_command_events.go
+++ b/internal/center/application_command_events.go
@@ -1,0 +1,71 @@
+package center
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func (s *Server) handleApplicationCommandEvents(writer http.ResponseWriter, request *http.Request) {
+	flusher, ok := writer.(http.Flusher)
+	if !ok {
+		writeError(writer, http.StatusInternalServerError, errors.New("center: streaming is unavailable"))
+		return
+	}
+	commandID := request.PathValue("id")
+	if _, err := s.store.ApplicationCommand(request.Context(), commandID); err != nil {
+		writeError(writer, http.StatusNotFound, err)
+		return
+	}
+	writer.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	writer.Header().Set("Cache-Control", "no-store")
+	writer.Header().Set("X-Accel-Buffering", "no")
+	fallback := time.NewTicker(time.Second)
+	defer fallback.Stop()
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+	var previous []byte
+	for {
+		key := "task:" + commandID
+		changed := s.store.taskChanges.subscribe(key)
+		command, err := s.store.ApplicationCommand(request.Context(), commandID)
+		if err != nil {
+			s.store.taskChanges.unsubscribe(key, changed)
+			return
+		}
+		payload, err := json.Marshal(command)
+		if err != nil {
+			s.store.taskChanges.unsubscribe(key, changed)
+			return
+		}
+		if !bytes.Equal(previous, payload) {
+			if _, err := fmt.Fprintf(writer, "data: %s\n\n", payload); err != nil {
+				s.store.taskChanges.unsubscribe(key, changed)
+				return
+			}
+			flusher.Flush()
+			previous = payload
+		}
+		if command.State == "succeeded" || command.State == "failed" {
+			s.store.taskChanges.unsubscribe(key, changed)
+			return
+		}
+		select {
+		case <-request.Context().Done():
+			s.store.taskChanges.unsubscribe(key, changed)
+			return
+		case <-changed:
+		case <-fallback.C:
+			s.store.taskChanges.unsubscribe(key, changed)
+		case <-keepalive.C:
+			s.store.taskChanges.unsubscribe(key, changed)
+			if _, err := fmt.Fprint(writer, ": keepalive\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/center/change_notifier.go
+++ b/internal/center/change_notifier.go
@@ -1,0 +1,56 @@
+package center
+
+import "sync"
+
+// changeNotifier provides process-local wakeups while SQLite remains the
+// durable source of truth. Callers always query after subscribing and recheck
+// again when their bounded request is renewed.
+type changeNotifier struct {
+	mu      sync.Mutex
+	waiters map[string]map[chan struct{}]struct{}
+}
+
+func (n *changeNotifier) subscribe(key string) <-chan struct{} {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.waiters == nil {
+		n.waiters = make(map[string]map[chan struct{}]struct{})
+	}
+	if n.waiters[key] == nil {
+		n.waiters[key] = make(map[chan struct{}]struct{})
+	}
+	waiter := make(chan struct{})
+	n.waiters[key][waiter] = struct{}{}
+	return waiter
+}
+
+func (n *changeNotifier) unsubscribe(key string, waiter <-chan struct{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	waiters := n.waiters[key]
+	for candidate := range waiters {
+		if candidate == waiter {
+			delete(waiters, candidate)
+			break
+		}
+	}
+	if len(waiters) == 0 {
+		delete(n.waiters, key)
+	}
+}
+
+func (n *changeNotifier) notify(key string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.waiters == nil {
+		return
+	}
+	waiters, exists := n.waiters[key]
+	if !exists {
+		return
+	}
+	delete(n.waiters, key)
+	for waiter := range waiters {
+		close(waiter)
+	}
+}

--- a/internal/center/change_notifier_test.go
+++ b/internal/center/change_notifier_test.go
@@ -1,0 +1,20 @@
+package center
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChangeNotifierWakesEverySubscriber(t *testing.T) {
+	var notifier changeNotifier
+	first := notifier.subscribe("agent:one")
+	second := notifier.subscribe("agent:one")
+	notifier.notify("agent:one")
+	for index, waiter := range []<-chan struct{}{first, second} {
+		select {
+		case <-waiter:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("subscriber %d was not notified", index)
+		}
+	}
+}

--- a/internal/center/deployment_tasks.go
+++ b/internal/center/deployment_tasks.go
@@ -203,6 +203,35 @@ func (s *Store) ClaimNextTask(ctx context.Context, agentID, credential string) (
 	return &task, nil
 }
 
+func (s *Store) WaitAndClaimNextTask(ctx context.Context, agentID, credential string, wait time.Duration) (*AgentTask, error) {
+	if wait <= 0 {
+		return s.ClaimNextTask(ctx, agentID, credential)
+	}
+	if wait > 30*time.Second {
+		wait = 30 * time.Second
+	}
+	deadline := time.NewTimer(wait)
+	defer deadline.Stop()
+	for {
+		key := "agent:" + agentID
+		changed := s.taskChanges.subscribe(key)
+		task, err := s.ClaimNextTask(ctx, agentID, credential)
+		if err != nil || task != nil {
+			s.taskChanges.unsubscribe(key, changed)
+			return task, err
+		}
+		select {
+		case <-ctx.Done():
+			s.taskChanges.unsubscribe(key, changed)
+			return nil, ctx.Err()
+		case <-deadline.C:
+			s.taskChanges.unsubscribe(key, changed)
+			return nil, nil
+		case <-changed:
+		}
+	}
+}
+
 func (s *Store) CompleteTask(ctx context.Context, agentID, credential, taskID string, expectedAttempt int64, succeeded bool, taskError string, rawResult json.RawMessage) error {
 	if err := s.authenticateAgent(ctx, agentID, credential); err != nil {
 		return err

--- a/internal/center/server.go
+++ b/internal/center/server.go
@@ -90,6 +90,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/v1/application-commands/subscription", s.requireAuth(true, s.handleCreateSubscriptionCommand))
 	mux.HandleFunc("POST /api/v1/application-commands/clients", s.requireAuth(true, s.handleCreateThreeXUIClientCommand))
 	mux.HandleFunc("GET /api/v1/application-commands/{id}", s.requireAuth(false, s.handleApplicationCommand))
+	mux.HandleFunc("GET /api/v1/application-commands/{id}/events", s.requireAuth(false, s.handleApplicationCommandEvents))
 	mux.HandleFunc("POST /api/v1/application-commands/{id}/reveal", s.requireAuth(true, s.handleRevealApplicationCommand))
 	mux.HandleFunc("GET /api/v1/services", s.requireAuth(false, s.handleListServices))
 	mux.HandleFunc("GET /api/v1/publications", s.requireAuth(false, s.handleListPublications))

--- a/internal/center/server_agent.go
+++ b/internal/center/server_agent.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/petauron/vastora/internal/networking"
 )
@@ -169,7 +170,15 @@ func (s *Server) handleClaimTask(writer http.ResponseWriter, request *http.Reque
 		writeError(writer, http.StatusUnauthorized, err)
 		return
 	}
-	task, err := s.store.ClaimNextTask(request.Context(), request.PathValue("id"), credential)
+	wait := time.Duration(0)
+	if value := strings.TrimSpace(request.URL.Query().Get("wait")); value != "" {
+		wait, err = time.ParseDuration(value)
+		if err != nil || wait < 0 || wait > 30*time.Second {
+			writeError(writer, http.StatusBadRequest, errors.New("center: task wait must be between 0 and 30 seconds"))
+			return
+		}
+	}
+	task, err := s.store.WaitAndClaimNextTask(request.Context(), request.PathValue("id"), credential, wait)
 	if err != nil {
 		writeError(writer, http.StatusUnauthorized, err)
 		return

--- a/internal/center/store.go
+++ b/internal/center/store.go
@@ -31,6 +31,7 @@ type Store struct {
 	certificateMu             sync.Mutex
 	siteCertificateMu         sync.Mutex
 	publicationCleanupMu      sync.Mutex
+	taskChanges               changeNotifier
 	now                       func() time.Time
 	discoverNetworkCandidates func(time.Time) ([]networking.Candidate, error)
 	lookupPublicRegion        func(context.Context, string) (string, error)

--- a/internal/center/task_lifecycle_test.go
+++ b/internal/center/task_lifecycle_test.go
@@ -57,6 +57,58 @@ func TestExpiredTaskIsRetriedAndStaleResultIsRejected(t *testing.T) {
 	}
 }
 
+func TestTaskLongPollWakesWhenACommandIsQueued(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	node := enrollOrchestrationNode(t, store, "long-poll", NodeCapabilities{Docker: true}, []networking.Candidate{{Address: "10.0.0.90", Interface: "eth0", Family: "ipv4", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.90", LANAddress: "10.0.0.90", EnabledKinds: []string{networking.KindLAN}})
+	siteID := testSiteID(t, store)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO applications(id, name, node_id, site_id, app_key, image, status, runtime, role, created_at, updated_at)
+		VALUES('long-poll-controller', '3x-ui', ?, ?, ?, '', 'running', 'docker', 'master', ?, ?)`, node.ID, siteID, threeXUIAppKey, now, now); err != nil {
+		t.Fatal(err)
+	}
+	result := make(chan *AgentTask, 1)
+	errors := make(chan error, 1)
+	go func() {
+		task, err := store.WaitAndClaimNextTask(ctx, node.ID, node.Credential, 5*time.Second)
+		if err != nil {
+			errors <- err
+			return
+		}
+		result <- task
+	}()
+	time.Sleep(50 * time.Millisecond)
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commandID := "application-command-long-poll"
+	input, _ := json.Marshal(ThreeXUIClientCommandTask{Action: "list", Inbounds: []ThreeXUIClientInbound{}})
+	if _, err := tx.ExecContext(ctx, `INSERT INTO application_commands(id, application_id, agent_id, gateway_node_id, kind, input_json, state, created_at, updated_at)
+		VALUES(?, 'long-poll-controller', ?, ?, ?, ?, 'pending', ?, ?)`, commandID, node.ID, node.ID, clientCommandKind, input, now, now); err != nil {
+		tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := store.recordTaskEvent(ctx, tx, commandID, node.ID, "application.command", 1, "queued", "test command queued"); err != nil {
+		tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-errors:
+		t.Fatal(err)
+	case task := <-result:
+		if task == nil || task.ID != commandID || task.ClientCommand == nil || task.ClientCommand.Action != "list" {
+			t.Fatalf("unexpected long-polled task: %#v", task)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("queued task did not wake the Agent long poll")
+	}
+}
+
 func TestDeploymentLifecyclePreventsDuplicateInstallAndControlsDataDeletion(t *testing.T) {
 	store := openOrchestrationStore(t)
 	defer store.Close()

--- a/internal/center/tasks.go
+++ b/internal/center/tasks.go
@@ -36,6 +36,10 @@ func (s *Store) recordTaskEvent(ctx context.Context, tx *sql.Tx, taskID, agentID
 		message = message[:1024]
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO task_events(id, task_id, agent_id, kind, revision, event, message, created_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?)`, id, taskID, agentID, kind, revision, event, message, s.now().UTC().Format(time.RFC3339Nano))
+	if err == nil {
+		s.taskChanges.notify("agent:" + agentID)
+		s.taskChanges.notify("task:" + taskID)
+	}
 	return err
 }
 

--- a/web/src/hooks/use-application-command-executor.ts
+++ b/web/src/hooks/use-application-command-executor.ts
@@ -1,22 +1,37 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { api } from "../api";
 import type { ApplicationCommand } from "../types";
 
 type StartCommand = () => Promise<ApplicationCommand>;
 type AdoptCommand = (command: ApplicationCommand) => void;
 
-function waitForNextPoll(signal: AbortSignal) {
-  return new Promise<void>((resolve) => {
-    const finish = () => {
+function waitForCommand(commandId: string, signal: AbortSignal, adopt: AdoptCommand): Promise<ApplicationCommand | null> {
+  return new Promise((resolve, reject) => {
+    const source = new EventSource(`/api/v1/application-commands/${encodeURIComponent(commandId)}/events`, { withCredentials: true });
+    let settled = false;
+    let timeout = 0;
+    let abort = () => {};
+    const finish = (settle: () => void) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
       signal.removeEventListener("abort", abort);
-      resolve();
+      source.close();
+      settle();
     };
-    const abort = () => {
-      window.clearTimeout(timer);
-      finish();
-    };
-    const timer = window.setTimeout(finish, 1000);
+    abort = () => finish(() => resolve(null));
+    timeout = window.setTimeout(() => finish(() => reject(new Error("The node did not respond in time"))), 120_000);
     signal.addEventListener("abort", abort, { once: true });
+    source.onmessage = (event) => {
+      try {
+        const command = JSON.parse(event.data) as ApplicationCommand;
+        adopt(command);
+        if (command.state !== "pending" && command.state !== "running") {
+          finish(() => resolve(command));
+        }
+      } catch {
+        finish(() => reject(new Error("Center returned an invalid command event")));
+      }
+    };
   });
 }
 
@@ -40,23 +55,13 @@ export function useApplicationCommandExecutor(scopeKey?: string) {
     activeController.current = controller;
     setRunning(true);
     try {
-      let command = await start();
+      const command = await start();
       if (controller.signal.aborted) return null;
       adopt(command);
-      for (let attempt = 0; command.state === "pending" || command.state === "running"; attempt += 1) {
-        if (attempt >= 120) throw new Error("The node did not respond in time");
-        await waitForNextPoll(controller.signal);
-        if (controller.signal.aborted) return null;
-        try {
-          command = await api.applicationCommand(command.id);
-        } catch (error) {
-          if (attempt === 119) throw error;
-          continue;
-        }
-        if (controller.signal.aborted) return null;
-        adopt(command);
+      if (command.state !== "pending" && command.state !== "running") {
+        return command;
       }
-      return command;
+      return await waitForCommand(command.id, controller.signal, adopt);
     } finally {
       if (activeController.current === controller) {
         activeController.current = null;

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -26,6 +26,7 @@ afterEach(() => {
   document.body.replaceChildren();
   window.sessionStorage.clear();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   vi.useRealTimers();
 });
 
@@ -57,6 +58,19 @@ function render(element: ReactNode) {
   root = createRoot(container);
   act(() => root?.render(element));
   return container;
+}
+
+function mockCommandEvent(command: ApplicationCommand) {
+  class CommandEventSource {
+    onmessage: ((event: MessageEvent<string>) => void) | null = null;
+
+    constructor(readonly url: string, readonly init?: EventSourceInit) {
+      queueMicrotask(() => this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(command) })));
+    }
+
+    close() {}
+  }
+  vi.stubGlobal("EventSource", CommandEventSource);
 }
 
 describe("network and app views", () => {
@@ -303,7 +317,7 @@ describe("network and app views", () => {
 		const pending: ApplicationCommand = { id: "rename-command", applicationId: "three-x-ui", gatewayNodeId: "agent", kind: "3xui.reality.rename", state: "pending", hostname: "", dnsProvider: "manual", action: "rename", regionCode: "US", displayName: "🇺🇸 美国Oracle", inboundId: 9, resultAvailable: false, createdAt: "2026-08-23T00:00:00Z", updatedAt: "2026-08-23T00:00:00Z" };
 		vi.spyOn(api, "regions").mockResolvedValue({ regions: [{ code: "US", nameZh: "美国", prefix: "🇺🇸 美国" }] });
 		const rename = vi.spyOn(api, "renameRealityCommand").mockResolvedValue(pending);
-		vi.spyOn(api, "applicationCommand").mockResolvedValue({ ...pending, state: "succeeded", updatedAt: "2026-08-23T00:00:01Z" });
+		mockCommandEvent({ ...pending, state: "succeeded", updatedAt: "2026-08-23T00:00:01Z" });
 		const mutate = vi.fn(async (operation: () => Promise<unknown>) => { await operation(); });
 		const container = render(<AppsView data={data} language="zh-CN" mutate={mutate} />);
 		expect(container.textContent).toContain("🇺🇸 美国Old name");
@@ -451,6 +465,7 @@ describe("network and app views", () => {
 		vi.spyOn(api, "agentRegionSuggestion").mockResolvedValue({ agentId: "agent", publicAddress: "203.0.113.10", regionCode: "US", prefix: "🇺🇸 美国", source: "country.is" });
 		const pending: ApplicationCommand = { id: "create-reality", applicationId: "three-x-ui", gatewayNodeId: "agent", kind: "3xui.reality.create", state: "pending", hostname: "reality.home-server.home.vastora.example.com", dnsProvider: "manual", action: "create", regionCode: "US", displayName: "🇺🇸 美国Oracle", resultAvailable: false, createdAt: "2026-08-23T00:00:00Z", updatedAt: "2026-08-23T00:00:00Z" };
 		const create = vi.spyOn(api, "createRealityCommand").mockResolvedValue(pending);
+		mockCommandEvent(pending);
 		const container = render(<AppsView data={data} language="zh-CN" mutate={async () => undefined} />);
 		await act(async () => {
 			[...container.querySelectorAll("button")].find((button) => button.textContent?.includes("创建 VLESS"))?.click();


### PR DESCRIPTION
## Summary
- separate durable Agent task delivery from the 15-second telemetry heartbeat using authenticated long polling
- stream application command snapshots to the browser with SSE instead of one-second polling
- preserve 3x-ui inbound display names across the Agent boundary so valid client operations are not rejected

## Validation
- added focused Agent, Center long-poll, notifier, and manifest round-trip tests
- full Go, web, deployment, and security validation runs in pull-request CI

## Security
- Agents remain outbound-only and task claims retain existing credentials, leases, and audit events
- SSE is same-origin, session-authenticated, snapshot-based, and carries no command secrets