### PR TITLE
fix: normalize 3x-ui subscription node names

### DIFF
--- a/internal/agent/docker_executor_3xui.go
+++ b/internal/agent/docker_executor_3xui.go
@@ -175,13 +175,11 @@ func configureThreeXUISubscription(ctx context.Context, address string, panelPor
 	if err != nil {
 		return fmt.Errorf("agent: read 3x-ui subscription settings: %w", err)
 	}
+	for key, value := range threeXUIManagedSubscriptionSettings() {
+		settings[key] = value
+	}
 	settings["subListen"] = address
 	settings["subPort"] = 2096
-	settings["subPath"] = threeXUIRawSubscriptionPath
-	settings["subClashEnable"] = true
-	settings["subClashPath"] = threeXUIClashSubscriptionPath
-	settings["subClashAutoDetect"] = true
-	settings["subClashUserAgentRegex"] = threeXUIClashUserAgentRegex
 	if _, err := threeXUIRequest(ctx, http.MethodPost, baseURL+"/panel/api/setting/update", apiToken, settings); err != nil {
 		return fmt.Errorf("agent: update 3x-ui subscription settings: %w", err)
 	}

--- a/internal/agent/three_xui_clients_test.go
+++ b/internal/agent/three_xui_clients_test.go
@@ -103,7 +103,7 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 				_, _ = response.Write([]byte(`{"success":false}`))
 				return
 			}
-			_, _ = response.Write([]byte(`{"success":true,"obj":{"subEnable":true,"subPath":"/sub/","subClashEnable":false}}`))
+			_, _ = response.Write([]byte(`{"success":true,"obj":{"subEnable":true,"subPath":"/sub/","subClashEnable":false,"remarkTemplate":"{{INBOUND}}-{{EMAIL}}"}}`))
 		case "POST /panel/api/setting/update":
 			if json.NewDecoder(request.Body).Decode(&updatedSettings) != nil {
 				t.Fatal("Clash subscription settings were not decoded")
@@ -144,6 +144,9 @@ func TestThreeXUIClientRevealsPublishedRealityAndSubscriptionLinks(t *testing.T)
 	}
 	if updatedSettings["subClashEnable"] != true || updatedSettings["subClashPath"] != "/clash/" || updatedSettings["subClashAutoDetect"] != true || updatedSettings["subClashUserAgentRegex"] != `(?i)(clash|mihomo)` {
 		t.Fatalf("Clash/Mihomo output was not enabled: %#v", updatedSettings)
+	}
+	if updatedSettings["remarkTemplate"] != "{{INBOUND}}" {
+		t.Fatalf("subscription node names still include client identity: %#v", updatedSettings["remarkTemplate"])
 	}
 	if restartCount.Load() != 1 {
 		t.Fatalf("3x-ui restart count = %d, want 1", restartCount.Load())

--- a/internal/agent/three_xui_reality.go
+++ b/internal/agent/three_xui_reality.go
@@ -417,7 +417,7 @@ func syncThreeXUIRealityHost(ctx context.Context, baseURL, token string, inbound
 	groupID := "vastora-public-" + strconv.Itoa(inboundID)
 	desired := threeXUIHostGroup{
 		GroupID: groupID, InboundIDs: []int{inboundID}, Hosts: []string{connectHostname},
-		Remark: "{{INBOUND}}", ServerDescription: "Managed by Vastora",
+		Remark: threeXUISubscriptionRemarkTemplate, ServerDescription: "Managed by Vastora",
 		Tags: []string{"vastora"}, Port: 443, Security: "same", SNI: sniHostname,
 		Fingerprint: "chrome", MihomoIPVersion: "dual",
 	}

--- a/internal/agent/three_xui_subscription.go
+++ b/internal/agent/three_xui_subscription.go
@@ -15,11 +15,24 @@ import (
 )
 
 const (
-	threeXUIRawSubscriptionPath   = "/sub/"
-	threeXUIClashSubscriptionPath = "/clash/"
-	threeXUIClashUserAgentRegex   = `(?i)(clash|mihomo)`
-	threeXUIRestartSettleTime     = 4 * time.Second
+	threeXUIRawSubscriptionPath        = "/sub/"
+	threeXUIClashSubscriptionPath      = "/clash/"
+	threeXUIClashUserAgentRegex        = `(?i)(clash|mihomo)`
+	threeXUISubscriptionRemarkTemplate = "{{INBOUND}}"
+	threeXUIRestartSettleTime          = 4 * time.Second
 )
+
+func threeXUIManagedSubscriptionSettings() map[string]any {
+	return map[string]any{
+		"subEnable":              true,
+		"subPath":                threeXUIRawSubscriptionPath,
+		"subClashEnable":         true,
+		"subClashPath":           threeXUIClashSubscriptionPath,
+		"subClashAutoDetect":     true,
+		"subClashUserAgentRegex": threeXUIClashUserAgentRegex,
+		"remarkTemplate":         threeXUISubscriptionRemarkTemplate,
+	}
+}
 
 func applySubscriptionCommand(ctx context.Context, store *Store, command SubscriptionCommandTask) (SubscriptionCommandResult, error) {
 	domain := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(command.Domain), "."))
@@ -61,17 +74,10 @@ func configureThreeXUIPublicSubscription(ctx context.Context, endpoint, token, d
 	if err != nil {
 		return "", fmt.Errorf("agent: read 3x-ui subscription settings: %w", err)
 	}
-	desired := map[string]any{
-		"subEnable":              true,
-		"subPath":                threeXUIRawSubscriptionPath,
-		"subDomain":              domain,
-		"subURI":                 parsed.String(),
-		"subClashEnable":         true,
-		"subClashPath":           threeXUIClashSubscriptionPath,
-		"subClashURI":            clashURI.String(),
-		"subClashAutoDetect":     true,
-		"subClashUserAgentRegex": threeXUIClashUserAgentRegex,
-	}
+	desired := threeXUIManagedSubscriptionSettings()
+	desired["subDomain"] = domain
+	desired["subURI"] = parsed.String()
+	desired["subClashURI"] = clashURI.String()
 	changed := false
 	for key, value := range desired {
 		if !reflect.DeepEqual(settings[key], value) {

--- a/internal/agent/three_xui_subscription_test.go
+++ b/internal/agent/three_xui_subscription_test.go
@@ -35,6 +35,16 @@ func TestRestartThreeXUIPanelAcceptsInProcessReload(t *testing.T) {
 	}
 }
 
+func TestManagedThreeXUISubscriptionSettingsUseInboundOnlyRemark(t *testing.T) {
+	settings := threeXUIManagedSubscriptionSettings()
+	if settings["remarkTemplate"] != "{{INBOUND}}" {
+		t.Fatalf("managed subscription remark template = %#v", settings["remarkTemplate"])
+	}
+	if settings["subEnable"] != true {
+		t.Fatalf("managed subscription endpoint is not enabled: %#v", settings["subEnable"])
+	}
+}
+
 func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) {
 	var updated map[string]any
 	var restartPending atomic.Bool
@@ -51,7 +61,7 @@ func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) 
 				_, _ = response.Write([]byte(`{"success":false}`))
 				return
 			}
-			_, _ = response.Write([]byte(`{"success":true,"obj":{"subListen":"100.64.0.10","subPort":2096,"subPath":"/sub/","subClashEnable":false}}`))
+			_, _ = response.Write([]byte(`{"success":true,"obj":{"subListen":"100.64.0.10","subPort":2096,"subPath":"/sub/","subClashEnable":false,"remarkTemplate":"{{INBOUND}}-{{EMAIL}}"}}`))
 		case "/panel/api/setting/update":
 			if err := json.NewDecoder(request.Body).Decode(&updated); err != nil {
 				t.Fatal(err)
@@ -107,6 +117,9 @@ func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) 
 	}
 	if updated["subClashEnable"] != true || updated["subClashPath"] != "/clash/" || updated["subClashURI"] != "https://subscribe.example.com/clash/" || updated["subClashAutoDetect"] != true || updated["subClashUserAgentRegex"] != `(?i)(clash|mihomo)` {
 		t.Fatalf("Clash/Mihomo subscription endpoint was not enabled: %#v", updated)
+	}
+	if updated["remarkTemplate"] != "{{INBOUND}}" {
+		t.Fatalf("subscription node names still include client identity: %#v", updated["remarkTemplate"])
 	}
 	if restartCount.Load() != 1 {
 		t.Fatalf("3x-ui restart count = %d, want 1", restartCount.Load())


### PR DESCRIPTION
## Outcome

- synchronize the 3x-ui global `remarkTemplate` to `{{INBOUND}}`
- keep master subscription settings explicit across install, reconfigure, migration, public publication, and subscription reveal
- share one template constant with managed REALITY hosts so controller and remote-node names do not diverge
- regress the production `-test` suffix caused by 3x-ui's default `{{EMAIL}}` template

## Non-goals

- no Center schema or API changes
- no change to worker subscription behavior
- no production configuration is modified by this PR itself

## Interface impact

Subscription node names use only their configured inbound display name; client identifiers are no longer appended.

## Validation

- [ ] `make check` (CI)
- [ ] `make security-check` (CI)
- [x] `go test ./internal/agent`
- [x] Tests cover migration from the old `{{INBOUND}}-{{EMAIL}}` setting.

## Security review

- [x] No secret, private host, account, or runtime data is added.
- [x] The change preserves the Center-Agent trust boundary.