### PR TITLE
feat: add built-in Center updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ local URL starts the administrator, location, and network wizard without
 claiming public port 443. Users do not clone this repository or enter a
 container image digest. Each Center then generates its own short-lived,
 one-line Agent install command. See [`deploy/center`](deploy/center/README.md)
-for the complete bootstrap flow and local release packaging. Running the same
-command again upgrades an existing managed installation in place while keeping
-its configuration.
+for the complete bootstrap flow and local release packaging. Center checks the
+official complete release selected by that endpoint and offers a confirmed
+in-place update in Settings. The first release with this capability may still
+be installed by running the same command again; later updates preserve the
+configuration and use the built-in updater.
 
 Released Center schemas upgrade in place through ordered, forward-only
 migrations. Center writes a private, consistent SQLite snapshot before applying

--- a/cmd/vastora/center_cmd.go
+++ b/cmd/vastora/center_cmd.go
@@ -115,13 +115,15 @@ func runCenter(arguments []string) error {
 		centerServer := center.NewServer(store, *webDir, *tlsCert != "").
 			WithOfficialCatalog(catalogPayload).
 			WithAgentBinaries(*agentBinariesDir).
-			WithSetupAgentConnectURL(normalizedAgentConnectURL)
+			WithSetupAgentConnectURL(normalizedAgentConnectURL).
+			WithCenterReleaseChecker(center.NewOfficialReleaseChecker(""))
 		if *deployerSocket != "" {
 			installer, err := deployapi.NewClient(*deployerSocket)
 			if err != nil {
 				return err
 			}
 			centerServer.WithInfrastructureManager(installer)
+			centerServer.WithCenterUpdater(installer)
 			go func() {
 				reconcileContext, cancel := context.WithTimeout(maintenanceContext, 8*time.Minute)
 				defer cancel()

--- a/cmd/vastora/deployer_cmd.go
+++ b/cmd/vastora/deployer_cmd.go
@@ -18,6 +18,7 @@ func runDeployer(arguments []string) error {
 	socket := flags.String("socket", "/run/vastora-deployer/deployer.sock", "Unix socket exposed to Center")
 	dockerSocket := flags.String("docker-socket", "unix:///var/run/docker.sock", "Docker Engine socket")
 	configDir := flags.String("headscale-config-dir", "/var/lib/vastora-headscale-config", "persisted generated Headscale configuration")
+	centerInstallDir := flags.String("center-install-dir", "/var/lib/vastora-center-install", "host Center installation directory mounted into the helper")
 	centerOrigin := flags.String("center-origin", "127.0.0.1:8080", "loopback Center origin used by the HTTPS gateway")
 	centerUID := flags.Int("center-uid", 65532, "Center user ID allowed to connect")
 	centerGID := flags.Int("center-gid", 65532, "Center group ID allowed to connect")
@@ -33,5 +34,6 @@ func runDeployer(arguments []string) error {
 		CenterOrigin: *centerOrigin,
 	}
 	fmt.Printf("Deployment helper listening on %s\n", *socket)
-	return deployer.ServeUnix(*socket, *centerUID, *centerGID, deployer.NewServer(installer).Handler())
+	server := deployer.NewServer(installer).WithCenterUpdater(deployer.FileCenterUpdater{InstallDir: *centerInstallDir})
+	return deployer.ServeUnix(*socket, *centerUID, *centerGID, server.Handler())
 }

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -73,17 +73,22 @@ supports `--release-url` for a trusted mirror and `--install-dir` for a custom
 location. `setup.sh` supports `--bootstrap-port` and `--ssh-host` after the `--`
 separator.
 
-Run the same public command to upgrade. It keeps `.env`, replaces only managed
-deployment files, validates and pulls the new immutable image before changing
-anything, then starts Center and waits for health. If this host also runs the
-official Vastora Agent service, the upgrader first extracts the matching Agent
-from that pinned image and restarts it before Center can reconcile a newer
-Gateway desired-state schema. It then waits for Center and built-in Headscale
-startup readiness and restarts the Agent again, restoring any shared HTTPS
-gateway from encrypted local desired state. If the new Center has already
-started, the upgrader never rolls the database or image backward automatically;
-inspect the printed logs and restore Center's pre-migration SQLite backup when a
-manual downgrade is required.
+Center checks the same public endpoint for a complete official release. An
+administrator can confirm the update in Settings; a narrow deployer operation
+queues a root systemd one-shot service on the host, so Center still never mounts
+the Docker socket. For the first release containing this updater, run the same
+public command once to install the service.
+
+Both entry points keep `.env`, replace only managed deployment files, validate
+and pull the new immutable image before changing anything, then start Center and
+wait for health. If this host also runs the official Vastora Agent service, the
+upgrader first extracts the matching Agent from that pinned image and restarts
+it before Center can reconcile a newer Gateway desired-state schema. It then
+waits for Center and built-in Headscale startup readiness and restarts the Agent
+again, restoring any shared HTTPS gateway from encrypted local desired state.
+If the new Center has already started, the upgrader never rolls the database or
+image backward automatically; inspect the printed logs and restore Center's
+pre-migration SQLite backup when a manual downgrade is required.
 
 ## Automated releases
 

--- a/deploy/center/compose.yaml
+++ b/deploy/center/compose.yaml
@@ -35,6 +35,8 @@ services:
       - /run/vastora-deployer/deployer.sock
       - --headscale-config-dir
       - /var/lib/vastora-headscale-config
+      - --center-install-dir
+      - /var/lib/vastora-center-install
       - --center-origin
       - 127.0.0.1:${VASTORA_CENTER_BOOTSTRAP_PORT:-8080}
     network_mode: host
@@ -44,6 +46,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /run/vastora:/run/vastora
+      - .:/var/lib/vastora-center-install
       - deployer-socket:/run/vastora-deployer
       - headscale-config:/var/lib/vastora-headscale-config
     security_opt:

--- a/deploy/center/install-update-service.sh
+++ b/deploy/center/install-update-service.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -eu
+
+install_dir="/opt/vastora/center"
+systemd_unit_dir="${VASTORA_SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --install-dir) install_dir="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$install_dir" in
+  /*) ;;
+  *) echo "The Center installation directory must be absolute." >&2; exit 2 ;;
+esac
+case "$install_dir" in
+  *[!A-Za-z0-9_./-]*)
+    echo "Automatic updates require an installation path containing only letters, numbers, dot, underscore, slash, and hyphen." >&2
+    exit 2
+    ;;
+esac
+case "$systemd_unit_dir" in
+  /*) ;;
+  *) echo "The systemd unit directory must be absolute." >&2; exit 2 ;;
+esac
+if [ "$systemd_unit_dir" = "/etc/systemd/system" ] && [ "$(id -u)" -ne 0 ]; then
+  echo "Installing the Center update service requires root." >&2
+  exit 1
+fi
+for required in install mktemp systemctl; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    echo "Required command is not installed: $required" >&2
+    exit 1
+  fi
+done
+if [ ! -x "$install_dir/update-center.sh" ]; then
+  echo "The Center update runner is missing from $install_dir." >&2
+  exit 1
+fi
+
+service_unit="$(mktemp "${TMPDIR:-/tmp}/vastora-center-update-service.XXXXXX")"
+path_unit="$(mktemp "${TMPDIR:-/tmp}/vastora-center-update-path.XXXXXX")"
+cleanup() { rm -f "$service_unit" "$path_unit"; }
+trap cleanup EXIT HUP INT TERM
+
+cat > "$service_unit" <<EOF
+[Unit]
+Description=Vastora Center verified update
+Documentation=https://github.com/petauron/vastora
+After=docker.service network-online.target
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=$install_dir/update-center.sh --install-dir $install_dir
+PrivateTmp=true
+UMask=0077
+TimeoutStartSec=30min
+EOF
+
+cat > "$path_unit" <<EOF
+[Unit]
+Description=Watch for a Vastora Center update request
+
+[Path]
+PathExists=$install_dir/.update-request
+Unit=vastora-center-update.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+install -d -m 0755 "$systemd_unit_dir"
+install -m 0644 "$service_unit" "$systemd_unit_dir/vastora-center-update.service"
+install -m 0644 "$path_unit" "$systemd_unit_dir/vastora-center-update.path"
+systemctl daemon-reload
+systemctl enable --now vastora-center-update.path >/dev/null
+install -m 0644 /dev/null "$install_dir/.update-service-enabled"

--- a/deploy/center/setup.sh
+++ b/deploy/center/setup.sh
@@ -114,6 +114,9 @@ until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
   sleep 2
 done
 
+echo "Enabling verified Center updates..."
+"$script_dir/install-update-service.sh" --install-dir "$script_dir"
+
 if [ -z "$ssh_host" ] && [ -n "${SSH_CONNECTION:-}" ]; then
   ssh_host="$(printf '%s\n' "$SSH_CONNECTION" | awk '{print $3}')"
 fi

--- a/deploy/center/update-center.sh
+++ b/deploy/center/update-center.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -eu
+
+install_dir="/opt/vastora/center"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --install-dir) install_dir="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$install_dir" in
+  /*) ;;
+  *) echo "The Center installation directory must be absolute." >&2; exit 2 ;;
+esac
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Center updates must run as root." >&2
+  exit 1
+fi
+
+request="$install_dir/.update-request"
+status_file="$install_dir/.update-status.json"
+if [ ! -f "$request" ]; then
+  exit 0
+fi
+
+target_version="$(awk 'NR == 1 {print; exit}' "$request")"
+rm -f "$request"
+if ! printf '%s\n' "$target_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "The requested Center version is invalid." >&2
+  exit 2
+fi
+
+write_status() {
+  update_state="$1"
+  update_version="$2"
+  update_message="$3"
+  update_time="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  temporary_status="$(mktemp "$install_dir/.update-status.XXXXXX")"
+  chmod 0600 "$temporary_status"
+  printf '{"state":"%s","targetVersion":"%s","message":"%s","updatedAt":"%s"}\n' \
+    "$update_state" "$update_version" "$update_message" "$update_time" > "$temporary_status"
+  mv "$temporary_status" "$status_file"
+}
+
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-center-update.XXXXXX")"
+installer="$temporary_dir/install.sh"
+completed=no
+cleanup() {
+  result=$?
+  rm -rf "$temporary_dir"
+  if [ "$result" -ne 0 ] && [ "$completed" = no ]; then
+    write_status failed "$target_version" "Update failed. Review the host service log, then retry."
+  fi
+  exit "$result"
+}
+trap cleanup EXIT HUP INT TERM
+
+write_status applying "$target_version" "Downloading and applying the verified release."
+release_base="https://github.com/petauron/vastora/releases/download/v$target_version"
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
+  "$release_base/install.sh" -o "$installer"
+chmod 0700 "$installer"
+/bin/sh "$installer" center \
+  --release-url "$release_base/vastora-center-install.tar.gz" \
+  --install-dir "$install_dir"
+
+installed_version="$(awk -F= '$1 == "VASTORA_VERSION" {sub(/^[^=]*=/, ""); print; exit}' "$install_dir/release.env")"
+if [ -z "$installed_version" ]; then installed_version="$target_version"; fi
+write_status succeeded "$installed_version" "Center was updated successfully."
+completed=yes

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -30,7 +30,7 @@ if [ ! -f "$install_dir/.env" ] || [ ! -f "$install_dir/compose.yaml" ]; then
   echo "$install_dir is not a complete Center installation." >&2
   exit 1
 fi
-for required_file in setup.sh upgrade.sh compose.yaml release.env; do
+for required_file in setup.sh upgrade.sh install-update-service.sh update-center.sh compose.yaml release.env; do
   if [ ! -f "$source_dir/$required_file" ]; then
     echo "The upgrade bundle is incomplete: missing $required_file" >&2
     exit 1
@@ -75,7 +75,7 @@ if [ "$(docker inspect -f '{{.State.Running}}' vastora-gateway-haproxy 2>/dev/nu
 fi
 
 restore_files() {
-  for relative in setup.sh upgrade.sh compose.yaml release.env .env; do
+  for relative in setup.sh upgrade.sh install-update-service.sh update-center.sh compose.yaml release.env .env; do
     if [ -f "$backup_dir/$relative" ]; then
       install -d -m 0755 "$(dirname "$install_dir/$relative")"
       install -m 0644 "$backup_dir/$relative" "$install_dir/$relative"
@@ -85,6 +85,8 @@ restore_files() {
   done
   chmod 0755 "$install_dir/setup.sh"
   if [ -f "$install_dir/upgrade.sh" ]; then chmod 0755 "$install_dir/upgrade.sh"; fi
+  if [ -f "$install_dir/install-update-service.sh" ]; then chmod 0755 "$install_dir/install-update-service.sh"; fi
+  if [ -f "$install_dir/update-center.sh" ]; then chmod 0755 "$install_dir/update-center.sh"; fi
 }
 
 cleanup() {
@@ -158,7 +160,7 @@ if [ -f "$agent_executable" ] && [ -f "$agent_unit" ] && grep -Fq 'Description=V
   echo "Co-located Agent updated to $new_version before Center reconciliation."
 fi
 
-for relative in setup.sh upgrade.sh compose.yaml release.env .env; do
+for relative in setup.sh upgrade.sh install-update-service.sh update-center.sh compose.yaml release.env .env; do
   if [ -f "$install_dir/$relative" ]; then
     install -d -m 0755 "$(dirname "$backup_dir/$relative")"
     install -m 0644 "$install_dir/$relative" "$backup_dir/$relative"
@@ -167,6 +169,8 @@ done
 
 install -m 0755 "$source_dir/setup.sh" "$install_dir/setup.sh"
 install -m 0755 "$source_dir/upgrade.sh" "$install_dir/upgrade.sh"
+install -m 0755 "$source_dir/install-update-service.sh" "$install_dir/install-update-service.sh"
+install -m 0755 "$source_dir/update-center.sh" "$install_dir/update-center.sh"
 install -m 0644 "$source_dir/compose.yaml" "$install_dir/compose.yaml"
 install -m 0644 "$source_dir/release.env" "$install_dir/release.env"
 install -m 0600 "$candidate_env" "$install_dir/.env"
@@ -235,4 +239,5 @@ fi
 files_changed=no
 agent_changed=no
 center_started=no
+"$install_dir/install-update-service.sh" --install-dir "$install_dir"
 echo "Vastora Center was updated successfully${new_version:+ to $new_version}."

--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ fi
 install -d -m 0755 "$(dirname "$install_dir")"
 staging="$(mktemp -d "${install_dir}.new.XXXXXX")"
 tar -xzf "$archive" -C "$staging"
-for required_file in setup.sh upgrade.sh compose.yaml release.env; do
+for required_file in setup.sh upgrade.sh install-update-service.sh update-center.sh compose.yaml release.env; do
   if [ ! -f "$staging/$required_file" ]; then
     echo "The Center release is incomplete: missing $required_file" >&2
     exit 1
@@ -127,6 +127,8 @@ for required_file in setup.sh upgrade.sh compose.yaml release.env; do
 done
 chmod 0755 "$staging/setup.sh"
 chmod 0755 "$staging/upgrade.sh"
+chmod 0755 "$staging/install-update-service.sh"
+chmod 0755 "$staging/update-center.sh"
 
 if [ -d "$install_dir" ]; then
   if [ ! -f "$install_dir/.env" ]; then

--- a/internal/center/center_update.go
+++ b/internal/center/center_update.go
@@ -1,0 +1,174 @@
+package center
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/mod/semver"
+)
+
+const officialInstallerURL = "https://vastora.petauron.com/install.sh"
+
+type CenterReleaseChecker interface {
+	LatestVersion(context.Context) (string, time.Time, error)
+}
+
+type CenterUpdateStatus struct {
+	CurrentVersion  string `json:"currentVersion"`
+	LatestVersion   string `json:"latestVersion,omitempty"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	Automatic       bool   `json:"automatic"`
+	State           string `json:"state"`
+	TargetVersion   string `json:"targetVersion,omitempty"`
+	Message         string `json:"message,omitempty"`
+	CheckedAt       string `json:"checkedAt,omitempty"`
+	UpdatedAt       string `json:"updatedAt,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+type OfficialReleaseChecker struct {
+	url       string
+	client    *http.Client
+	mu        sync.Mutex
+	version   string
+	checkedAt time.Time
+	expiresAt time.Time
+}
+
+func NewOfficialReleaseChecker(endpoint string) *OfficialReleaseChecker {
+	if endpoint == "" {
+		endpoint = officialInstallerURL
+	}
+	return &OfficialReleaseChecker{
+		url: endpoint,
+		client: &http.Client{
+			Timeout:       15 * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		},
+	}
+}
+
+func (checker *OfficialReleaseChecker) LatestVersion(ctx context.Context) (string, time.Time, error) {
+	checker.mu.Lock()
+	defer checker.mu.Unlock()
+	now := time.Now().UTC()
+	if checker.version != "" && now.Before(checker.expiresAt) {
+		return checker.version, checker.checkedAt, nil
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodHead, checker.url, nil)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	request.Header.Set("User-Agent", "Vastora/"+Version)
+	response, err := checker.client.Do(request)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("center: check official release: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 300 || response.StatusCode > 399 {
+		return "", time.Time{}, fmt.Errorf("center: official installer returned HTTP %d", response.StatusCode)
+	}
+	version, err := releaseVersionFromLocation(response.Header.Get("Location"))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	checker.version = version
+	checker.checkedAt = now
+	checker.expiresAt = now.Add(10 * time.Minute)
+	return version, now, nil
+}
+
+func releaseVersionFromLocation(location string) (string, error) {
+	target, err := url.Parse(location)
+	if err != nil || target.Scheme != "https" || !strings.EqualFold(target.Hostname(), "github.com") {
+		return "", errors.New("center: official installer selected an invalid release URL")
+	}
+	const prefix = "/petauron/vastora/releases/download/v"
+	if !strings.HasPrefix(target.Path, prefix) || !strings.HasSuffix(target.Path, "/install.sh") {
+		return "", errors.New("center: official installer selected an unexpected release asset")
+	}
+	version := strings.TrimSuffix(strings.TrimPrefix(target.Path, prefix), "/install.sh")
+	if strings.Contains(version, "/") || !semver.IsValid("v"+version) {
+		return "", errors.New("center: official installer selected an invalid release version")
+	}
+	return version, nil
+}
+
+func (s *Server) handleCenterUpdateStatus(writer http.ResponseWriter, request *http.Request) {
+	writeJSON(writer, http.StatusOK, s.centerUpdateStatus(request.Context()))
+}
+
+func (s *Server) handleStartCenterUpdate(writer http.ResponseWriter, request *http.Request) {
+	status := s.centerUpdateStatus(request.Context())
+	if status.Error != "" {
+		writeError(writer, http.StatusConflict, errors.New(status.Error))
+		return
+	}
+	if !status.UpdateAvailable {
+		writeError(writer, http.StatusConflict, errors.New("center: no newer release is available"))
+		return
+	}
+	if !status.Automatic || s.updates == nil {
+		writeError(writer, http.StatusConflict, errors.New("center: automatic updates are not available on this installation"))
+		return
+	}
+	execution, err := s.updates.StartCenterUpdate(request.Context(), status.LatestVersion)
+	if err != nil {
+		writeError(writer, http.StatusConflict, err)
+		return
+	}
+	status.State = execution.State
+	status.TargetVersion = execution.TargetVersion
+	status.Message = execution.Message
+	status.UpdatedAt = execution.UpdatedAt
+	writeJSON(writer, http.StatusAccepted, status)
+}
+
+func (s *Server) centerUpdateStatus(ctx context.Context) CenterUpdateStatus {
+	result := CenterUpdateStatus{CurrentVersion: Version, State: "idle"}
+	if s.releaseChecker == nil {
+		result.Error = "center: release checking is unavailable"
+		return result
+	}
+	latest, checkedAt, err := s.releaseChecker.LatestVersion(ctx)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.LatestVersion = latest
+	result.CheckedAt = checkedAt.Format(time.RFC3339)
+	currentSemver := "v" + strings.TrimPrefix(Version, "v")
+	latestSemver := "v" + latest
+	if !semver.IsValid(currentSemver) {
+		result.Error = "center: current version is not a released semantic version"
+		return result
+	}
+	result.UpdateAvailable = semver.Compare(latestSemver, currentSemver) > 0
+	if s.updates == nil {
+		return result
+	}
+	execution, err := s.updates.CenterUpdateStatus(ctx)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.Automatic = execution.Available
+	if execution.State == "queued" || execution.State == "applying" || execution.TargetVersion == latest {
+		result.State = execution.State
+		result.TargetVersion = execution.TargetVersion
+		result.Message = execution.Message
+		result.UpdatedAt = execution.UpdatedAt
+	} else if execution.State == "succeeded" && execution.TargetVersion == strings.TrimPrefix(Version, "v") {
+		result.State = execution.State
+		result.TargetVersion = execution.TargetVersion
+		result.Message = execution.Message
+		result.UpdatedAt = execution.UpdatedAt
+	}
+	return result
+}

--- a/internal/center/center_update_test.go
+++ b/internal/center/center_update_test.go
@@ -1,0 +1,70 @@
+package center
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/petauron/vastora/internal/deployapi"
+)
+
+type fixedReleaseChecker struct {
+	version string
+	err     error
+}
+
+func (checker fixedReleaseChecker) LatestVersion(context.Context) (string, time.Time, error) {
+	return checker.version, time.Date(2026, 8, 25, 1, 2, 3, 0, time.UTC), checker.err
+}
+
+type fakeCenterUpdater struct {
+	status  deployapi.CenterUpdateExecution
+	started string
+}
+
+func (updater *fakeCenterUpdater) CenterUpdateStatus(context.Context) (deployapi.CenterUpdateExecution, error) {
+	return updater.status, nil
+}
+
+func (updater *fakeCenterUpdater) StartCenterUpdate(_ context.Context, version string) (deployapi.CenterUpdateExecution, error) {
+	updater.started = version
+	return deployapi.CenterUpdateExecution{Available: true, State: "queued", TargetVersion: version}, nil
+}
+
+func TestOfficialReleaseCheckerReadsTheInstallerSelectedRelease(t *testing.T) {
+	installer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodHead {
+			t.Fatalf("method = %s", request.Method)
+		}
+		writer.Header().Set("Location", "https://github.com/petauron/vastora/releases/download/v0.1.0-alpha.48/install.sh")
+		writer.WriteHeader(http.StatusFound)
+	}))
+	defer installer.Close()
+	checker := NewOfficialReleaseChecker(installer.URL)
+	version, checkedAt, err := checker.LatestVersion(context.Background())
+	if err != nil || version != "0.1.0-alpha.48" || checkedAt.IsZero() {
+		t.Fatalf("unexpected release: version=%q checked=%s err=%v", version, checkedAt, err)
+	}
+	if _, err := releaseVersionFromLocation("https://example.com/v0.1.0/install.sh"); err == nil {
+		t.Fatal("untrusted release location was accepted")
+	}
+}
+
+func TestCenterUpdateStatusAndStartUseTheRestrictedUpdater(t *testing.T) {
+	previousVersion := Version
+	Version = "0.1.0-alpha.47"
+	defer func() { Version = previousVersion }()
+	updater := &fakeCenterUpdater{status: deployapi.CenterUpdateExecution{Available: true, State: "idle"}}
+	server := &Server{updates: updater, releaseChecker: fixedReleaseChecker{version: "0.1.0-alpha.48"}}
+	status := server.centerUpdateStatus(context.Background())
+	if !status.UpdateAvailable || !status.Automatic || status.LatestVersion != "0.1.0-alpha.48" {
+		t.Fatalf("unexpected update status: %#v", status)
+	}
+	response := httptest.NewRecorder()
+	server.handleStartCenterUpdate(response, httptest.NewRequest(http.MethodPost, "/api/v1/system/update", nil))
+	if response.Code != http.StatusAccepted || updater.started != "0.1.0-alpha.48" {
+		t.Fatalf("start status=%d body=%s version=%q", response.Code, response.Body.String(), updater.started)
+	}
+}

--- a/internal/center/server.go
+++ b/internal/center/server.go
@@ -26,12 +26,24 @@ type Server struct {
 	secureCookies        bool
 	officialCatalog      []byte
 	infrastructure       deployapi.InfrastructureManager
+	updates              deployapi.CenterUpdater
+	releaseChecker       CenterReleaseChecker
 	startupReady         atomic.Bool
 }
 
 func (s *Server) WithInfrastructureManager(manager deployapi.InfrastructureManager) *Server {
 	s.infrastructure = manager
 	s.startupReady.Store(false)
+	return s
+}
+
+func (s *Server) WithCenterUpdater(updates deployapi.CenterUpdater) *Server {
+	s.updates = updates
+	return s
+}
+
+func (s *Server) WithCenterReleaseChecker(checker CenterReleaseChecker) *Server {
+	s.releaseChecker = checker
 	return s
 }
 
@@ -71,6 +83,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("PUT /api/v1/auth/password", s.requireAuth(true, s.handleChangePassword))
 	mux.HandleFunc("GET /api/v1/status", s.requireAuth(false, s.handleStatus))
 	mux.HandleFunc("GET /api/v1/diagnostics", s.requireAuth(false, s.handleDiagnostics))
+	mux.HandleFunc("GET /api/v1/system/update", s.requireAuth(false, s.handleCenterUpdateStatus))
+	mux.HandleFunc("POST /api/v1/system/update", s.requireAuth(true, s.handleStartCenterUpdate))
 	mux.HandleFunc("POST /api/v1/backups", s.requireAuth(true, s.handleCreateBackup))
 	mux.HandleFunc("GET /api/v1/deployments", s.requireAuth(false, s.handleListDeployments))
 	mux.HandleFunc("POST /api/v1/deployments", s.requireAuth(true, s.handleCreateDeployment))

--- a/internal/deployapi/center_update.go
+++ b/internal/deployapi/center_update.go
@@ -1,0 +1,53 @@
+package deployapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type CenterUpdateExecution struct {
+	Available     bool   `json:"available"`
+	State         string `json:"state"`
+	TargetVersion string `json:"targetVersion,omitempty"`
+	Message       string `json:"message,omitempty"`
+	UpdatedAt     string `json:"updatedAt,omitempty"`
+}
+
+type CenterUpdater interface {
+	CenterUpdateStatus(context.Context) (CenterUpdateExecution, error)
+	StartCenterUpdate(context.Context, string) (CenterUpdateExecution, error)
+}
+
+func (client *Client) CenterUpdateStatus(ctx context.Context) (CenterUpdateExecution, error) {
+	body, err := client.request(ctx, http.MethodGet, "/v1/center/update", nil)
+	if err != nil {
+		return CenterUpdateExecution{}, err
+	}
+	return decodeCenterUpdateExecution(body)
+}
+
+func (client *Client) StartCenterUpdate(ctx context.Context, version string) (CenterUpdateExecution, error) {
+	payload, err := json.Marshal(map[string]string{"version": version})
+	if err != nil {
+		return CenterUpdateExecution{}, err
+	}
+	body, err := client.request(ctx, http.MethodPost, "/v1/center/update", payload)
+	if err != nil {
+		return CenterUpdateExecution{}, err
+	}
+	return decodeCenterUpdateExecution(body)
+}
+
+func decodeCenterUpdateExecution(body []byte) (CenterUpdateExecution, error) {
+	var result CenterUpdateExecution
+	if err := json.Unmarshal(body, &result); err != nil {
+		return CenterUpdateExecution{}, fmt.Errorf("center: decode update helper response: %w", err)
+	}
+	if result.State == "" {
+		return CenterUpdateExecution{}, errors.New("center: update helper returned an incomplete result")
+	}
+	return result, nil
+}

--- a/internal/deployer/center_update.go
+++ b/internal/deployer/center_update.go
@@ -1,0 +1,152 @@
+package deployer
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/petauron/vastora/internal/deployapi"
+	"golang.org/x/mod/semver"
+)
+
+type FileCenterUpdater struct {
+	InstallDir string
+}
+
+func (updater FileCenterUpdater) CenterUpdateStatus(context.Context) (deployapi.CenterUpdateExecution, error) {
+	if updater.InstallDir == "" || !filepath.IsAbs(updater.InstallDir) {
+		return deployapi.CenterUpdateExecution{}, errors.New("deployer: Center installation directory is invalid")
+	}
+	available := regularFile(filepath.Join(updater.InstallDir, ".update-service-enabled")) && regularFile(filepath.Join(updater.InstallDir, "update-center.sh"))
+	statusPath := filepath.Join(updater.InstallDir, ".update-status.json")
+	file, err := os.Open(statusPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return deployapi.CenterUpdateExecution{Available: available, State: "idle"}, nil
+	}
+	if err != nil {
+		return deployapi.CenterUpdateExecution{}, fmt.Errorf("deployer: read Center update status: %w", err)
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(io.LimitReader(file, 16<<10))
+	decoder.DisallowUnknownFields()
+	var result deployapi.CenterUpdateExecution
+	if err := decoder.Decode(&result); err != nil {
+		return deployapi.CenterUpdateExecution{}, fmt.Errorf("deployer: decode Center update status: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return deployapi.CenterUpdateExecution{}, errors.New("deployer: Center update status contains trailing data")
+	}
+	if !validUpdateState(result.State) {
+		return deployapi.CenterUpdateExecution{}, errors.New("deployer: Center update status is invalid")
+	}
+	result.Available = available
+	return result, nil
+}
+
+func (updater FileCenterUpdater) StartCenterUpdate(ctx context.Context, version string) (deployapi.CenterUpdateExecution, error) {
+	version = strings.TrimSpace(version)
+	if !semver.IsValid("v" + version) {
+		return deployapi.CenterUpdateExecution{}, errors.New("deployer: requested Center version is invalid")
+	}
+	status, err := updater.CenterUpdateStatus(ctx)
+	if err != nil {
+		return deployapi.CenterUpdateExecution{}, err
+	}
+	if !status.Available {
+		return deployapi.CenterUpdateExecution{}, errors.New("deployer: automatic Center updates are not installed")
+	}
+	currentVersion, err := installedCenterVersion(filepath.Join(updater.InstallDir, "release.env"))
+	if err != nil {
+		return deployapi.CenterUpdateExecution{}, err
+	}
+	if semver.Compare("v"+version, "v"+currentVersion) <= 0 {
+		return deployapi.CenterUpdateExecution{}, fmt.Errorf("deployer: Center update %s is not newer than installed version %s", version, currentVersion)
+	}
+	if status.State == "queued" || status.State == "applying" {
+		if status.TargetVersion == version {
+			return status, nil
+		}
+		return deployapi.CenterUpdateExecution{}, errors.New("deployer: another Center update is already running")
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	queued := deployapi.CenterUpdateExecution{Available: true, State: "queued", TargetVersion: version, Message: "Waiting for the host update service.", UpdatedAt: now}
+	statusPayload, err := json.Marshal(queued)
+	if err != nil {
+		return deployapi.CenterUpdateExecution{}, err
+	}
+	if err := writeCenterUpdateFile(filepath.Join(updater.InstallDir, ".update-status.json"), append(statusPayload, '\n'), 0o600); err != nil {
+		return deployapi.CenterUpdateExecution{}, fmt.Errorf("deployer: queue Center update status: %w", err)
+	}
+	if err := writeCenterUpdateFile(filepath.Join(updater.InstallDir, ".update-request"), []byte(version+"\n"), 0o600); err != nil {
+		return deployapi.CenterUpdateExecution{}, fmt.Errorf("deployer: queue Center update request: %w", err)
+	}
+	return queued, nil
+}
+
+func installedCenterVersion(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("deployer: read installed Center release: %w", err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(io.LimitReader(file, 16<<10))
+	for scanner.Scan() {
+		if version, found := strings.CutPrefix(scanner.Text(), "VASTORA_VERSION="); found {
+			version = strings.TrimSpace(version)
+			if !semver.IsValid("v" + version) {
+				return "", errors.New("deployer: installed Center version is invalid")
+			}
+			return version, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("deployer: read installed Center release: %w", err)
+	}
+	return "", errors.New("deployer: installed Center version is missing")
+}
+
+func writeCenterUpdateFile(path string, payload []byte, mode os.FileMode) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".vastora-write-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(mode); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(payload); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+func regularFile(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func validUpdateState(value string) bool {
+	switch value {
+	case "idle", "queued", "applying", "succeeded", "failed":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/deployer/center_update_test.go
+++ b/internal/deployer/center_update_test.go
@@ -1,0 +1,54 @@
+package deployer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileCenterUpdaterQueuesOneVerifiedRelease(t *testing.T) {
+	installDir := t.TempDir()
+	for _, name := range []string{".update-service-enabled", "update-center.sh"} {
+		if err := os.WriteFile(filepath.Join(installDir, name), []byte("ready\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "release.env"), []byte("VASTORA_VERSION=0.1.0-alpha.47\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	updater := FileCenterUpdater{InstallDir: installDir}
+	initial, err := updater.CenterUpdateStatus(context.Background())
+	if err != nil || !initial.Available || initial.State != "idle" {
+		t.Fatalf("unexpected initial status: %#v err=%v", initial, err)
+	}
+	if _, err := updater.StartCenterUpdate(context.Background(), "0.1.0-alpha.47"); err == nil {
+		t.Fatal("same-version update was accepted")
+	}
+	queued, err := updater.StartCenterUpdate(context.Background(), "0.1.0-alpha.48")
+	if err != nil || queued.State != "queued" || queued.TargetVersion != "0.1.0-alpha.48" {
+		t.Fatalf("unexpected queued status: %#v err=%v", queued, err)
+	}
+	request, err := os.ReadFile(filepath.Join(installDir, ".update-request"))
+	if err != nil || string(request) != "0.1.0-alpha.48\n" {
+		t.Fatalf("unexpected update request %q err=%v", request, err)
+	}
+	persisted, err := updater.CenterUpdateStatus(context.Background())
+	if err != nil || persisted.State != "queued" || persisted.TargetVersion != queued.TargetVersion {
+		t.Fatalf("unexpected persisted status: %#v err=%v", persisted, err)
+	}
+	if _, err := updater.StartCenterUpdate(context.Background(), "not-a-version"); err == nil {
+		t.Fatal("invalid release version was accepted")
+	}
+}
+
+func TestFileCenterUpdaterRequiresInstalledHostService(t *testing.T) {
+	updater := FileCenterUpdater{InstallDir: t.TempDir()}
+	status, err := updater.CenterUpdateStatus(context.Background())
+	if err != nil || status.Available || status.State != "idle" {
+		t.Fatalf("unexpected unavailable status: %#v err=%v", status, err)
+	}
+	if _, err := updater.StartCenterUpdate(context.Background(), "0.1.0"); err == nil {
+		t.Fatal("update was queued without the host service")
+	}
+}

--- a/internal/deployer/server.go
+++ b/internal/deployer/server.go
@@ -16,10 +16,16 @@ import (
 type Server struct {
 	installer         deployapi.HeadscaleInstaller
 	publicEntryProber deployapi.PublicEntryProber
+	centerUpdater     deployapi.CenterUpdater
 }
 
 func NewServer(installer deployapi.HeadscaleInstaller) *Server {
 	return &Server{installer: installer, publicEntryProber: NewPublicEntryProbeService()}
+}
+
+func (server *Server) WithCenterUpdater(updater deployapi.CenterUpdater) *Server {
+	server.centerUpdater = updater
+	return server
 }
 
 func (server *Server) Handler() http.Handler {
@@ -31,7 +37,41 @@ func (server *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /v1/headscale/reconcile", server.reconcileHeadscale)
 	mux.HandleFunc("POST /v1/public-entry/probes", server.startPublicEntryProbe)
 	mux.HandleFunc("DELETE /v1/public-entry/probes/{id}", server.stopPublicEntryProbe)
+	mux.HandleFunc("GET /v1/center/update", server.centerUpdateStatus)
+	mux.HandleFunc("POST /v1/center/update", server.startCenterUpdate)
 	return mux
+}
+
+func (server *Server) centerUpdateStatus(writer http.ResponseWriter, request *http.Request) {
+	if server.centerUpdater == nil {
+		writeJSON(writer, http.StatusOK, deployapi.CenterUpdateExecution{State: "idle"})
+		return
+	}
+	result, err := server.centerUpdater.CenterUpdateStatus(request.Context())
+	if err != nil {
+		writeError(writer, http.StatusConflict, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, result)
+}
+
+func (server *Server) startCenterUpdate(writer http.ResponseWriter, request *http.Request) {
+	if server.centerUpdater == nil {
+		writeError(writer, http.StatusConflict, errors.New("deployer: automatic Center updates are unavailable"))
+		return
+	}
+	var input struct {
+		Version string `json:"version"`
+	}
+	if !decodeRequest(writer, request, &input) {
+		return
+	}
+	result, err := server.centerUpdater.StartCenterUpdate(request.Context(), input.Version)
+	if err != nil {
+		writeError(writer, http.StatusConflict, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, result)
 }
 
 func (server *Server) startPublicEntryProbe(writer http.ResponseWriter, request *http.Request) {

--- a/scripts/package-center-install.sh
+++ b/scripts/package-center-install.sh
@@ -68,6 +68,8 @@ trap cleanup EXIT HUP INT TERM
 
 install -m 0755 "$project_dir/deploy/center/setup.sh" "$temporary_dir/setup.sh"
 install -m 0755 "$project_dir/deploy/center/upgrade.sh" "$temporary_dir/upgrade.sh"
+install -m 0755 "$project_dir/deploy/center/install-update-service.sh" "$temporary_dir/install-update-service.sh"
+install -m 0755 "$project_dir/deploy/center/update-center.sh" "$temporary_dir/update-center.sh"
 install -m 0644 "$project_dir/deploy/center/compose.yaml" "$temporary_dir/compose.yaml"
 {
   printf 'VASTORA_VERSION=%s\n' "$version"

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -31,6 +31,8 @@ grep -Fqx 'VASTORA_VERSION=0.1.0-test' "$temporary_dir/release.env"
 grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$temporary_dir/release.env"
 test -x "$temporary_dir/setup.sh"
 test -x "$temporary_dir/upgrade.sh"
+test -x "$temporary_dir/install-update-service.sh"
+test -x "$temporary_dir/update-center.sh"
 test -f "$temporary_dir/compose.yaml"
 grep -Fq 'docker cp "$agent_container:/usr/local/bin/vastora"' "$temporary_dir/upgrade.sh"
 grep -Fq 'Co-located Agent updated to $new_version before Center reconciliation.' "$temporary_dir/upgrade.sh"
@@ -77,13 +79,22 @@ cat > "$fake_bin/curl" <<'EOF'
 #!/bin/sh
 exit 0
 EOF
-chmod 0755 "$fake_bin/docker" "$fake_bin/curl"
-PATH="$fake_bin:$PATH" "$temporary_dir/upgrade.sh" --install-dir "$existing" >/dev/null
+cat > "$fake_bin/systemctl" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod 0755 "$fake_bin/docker" "$fake_bin/curl" "$fake_bin/systemctl"
+VASTORA_SYSTEMD_UNIT_DIR="$temporary_dir/systemd" PATH="$fake_bin:$PATH" "$temporary_dir/upgrade.sh" --install-dir "$existing" >/dev/null
 grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$existing/.env"
 grep -Fqx 'VASTORA_CENTER_BOOTSTRAP_PORT=19090' "$existing/.env"
 grep -Fqx 'VASTORA_CUSTOM_VALUE=preserved' "$existing/.env"
 grep -Fqx 'VASTORA_VERSION=0.1.0-test' "$existing/release.env"
 test -x "$existing/upgrade.sh"
+test -x "$existing/update-center.sh"
+test -f "$temporary_dir/systemd/vastora-center-update.service"
+test -f "$temporary_dir/systemd/vastora-center-update.path"
+grep -Fq "PathExists=$existing/.update-request" "$temporary_dir/systemd/vastora-center-update.path"
+grep -Fq "$existing/update-center.sh --install-dir $existing" "$temporary_dir/systemd/vastora-center-update.service"
 
 if "$project_dir/scripts/package-center-install.sh" \
   --version 0.1.0-test \

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -27,6 +27,7 @@ afterEach(() => {
 function mockReadyCenter() {
   vi.spyOn(api, "setupStatus").mockResolvedValue({ administratorConfigured: true, onboardingComplete: true, suggestedAgentConnectUrl: "https://center.example.com", builtinHeadscaleAvailable: true, cloudflareOAuthAvailable: true, cloudflareConfigured: false, publicAddressCandidates: [], gatewayAddressCandidates: [] });
   const status = vi.spyOn(api, "status").mockResolvedValue({ version: "test", agentInstallerAvailable: true, agentConnectionMode: "lan", agentConnectUrl: "https://center.example.com" });
+  vi.spyOn(api, "centerUpdate").mockResolvedValue({ currentVersion: "test", latestVersion: "test", updateAvailable: false, automatic: true, state: "idle" });
   vi.spyOn(api, "sites").mockResolvedValue({ sites: [] });
   vi.spyOn(api, "agents").mockResolvedValue({ agents: [] });
   vi.spyOn(api, "applications").mockResolvedValue({ applications: [] });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { Action, AgentEnrollment, AgentView, ApplicationCommand, ApplicationCommandKind, AppView, Application, CatalogSource, CloudflareOAuthPoll, CloudflareOAuthStart, CenterStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Region, RegionSuggestion, Route, Service, SetupStatus, Site, SiteInput, ThreeXUIClientCommandInput, ThreeXUIControllerMigration } from "./types";
+import type { Action, AgentEnrollment, AgentView, ApplicationCommand, ApplicationCommandKind, AppView, Application, CatalogSource, CloudflareOAuthPoll, CloudflareOAuthStart, CenterStatus, CenterUpdateStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Region, RegionSuggestion, Route, Service, SetupStatus, Site, SiteInput, ThreeXUIClientCommandInput, ThreeXUIControllerMigration } from "./types";
 
 export class APIError extends Error {
   constructor(
@@ -70,6 +70,8 @@ export const api = {
   logout: () => request<{ authenticated: boolean }>("/api/v1/auth/logout", { method: "POST", body: "{}" }),
   changePassword: (currentPassword: string, newPassword: string) => request<{ changed: boolean }>("/api/v1/auth/password", { method: "PUT", body: JSON.stringify({ currentPassword, newPassword }) }),
   status: () => request<CenterStatus>("/api/v1/status"),
+  centerUpdate: () => request<CenterUpdateStatus>("/api/v1/system/update"),
+  startCenterUpdate: () => request<CenterUpdateStatus>("/api/v1/system/update", { method: "POST", body: "{}" }),
   diagnostics: () => request<Diagnostics>("/api/v1/diagnostics"),
   downloadDiagnostics: () => download("/api/v1/diagnostics", `vastora-diagnostics-${new Date().toISOString().slice(0, 10)}.json`),
   downloadBackup: (password: string) => download("/api/v1/backups", "vastora-center.vastora", { method: "POST", body: JSON.stringify({ password }) }),

--- a/web/src/app-data.test.ts
+++ b/web/src/app-data.test.ts
@@ -20,6 +20,7 @@ afterEach(() => {
 describe("screen-scoped data loading", () => {
   it("loads only the home summary resources", async () => {
     vi.spyOn(api, "status").mockResolvedValue(status);
+    vi.spyOn(api, "centerUpdate").mockResolvedValue({ currentVersion: "test", latestVersion: "test", updateAvailable: false, automatic: true, state: "idle" });
     vi.spyOn(api, "sites").mockResolvedValue({ sites: [] });
     vi.spyOn(api, "agents").mockResolvedValue({ agents: [] });
     vi.spyOn(api, "applications").mockResolvedValue({ applications: [] });

--- a/web/src/app-data.ts
+++ b/web/src/app-data.ts
@@ -6,6 +6,7 @@ export type AppDataPatch = Partial<AppData> & { status: CenterStatus };
 export function emptyAppData(status: CenterStatus): AppData {
   return {
     status,
+    centerUpdate: { currentVersion: status.version, updateAvailable: false, automatic: false, state: "idle" },
     sources: [],
     apps: [],
     agents: [],
@@ -27,8 +28,9 @@ export async function loadScreenData(screen: Screen): Promise<AppDataPatch> {
 
   switch (screen) {
     case "home": {
-      const [status, sites, agents, applications, publications, actions] = await Promise.all([
+      const [status, centerUpdate, sites, agents, applications, publications, actions] = await Promise.all([
         statusPromise,
+        api.centerUpdate(),
         api.sites(),
         api.agents(),
         api.applications(),
@@ -37,6 +39,7 @@ export async function loadScreenData(screen: Screen): Promise<AppDataPatch> {
       ]);
       return {
         status,
+        centerUpdate,
         sites: sites.sites,
         agents: agents.agents,
         applications: applications.applications,
@@ -103,14 +106,16 @@ export async function loadScreenData(screen: Screen): Promise<AppDataPatch> {
       return { status, actions: actions.actions, agents: agents.agents };
     }
     case "settings": {
-      const [status, sources, applications, agents] = await Promise.all([
+      const [status, centerUpdate, sources, applications, agents] = await Promise.all([
         statusPromise,
+        api.centerUpdate(),
         api.sources(),
         api.applications(),
         api.agents()
       ]);
       return {
         status,
+        centerUpdate,
         sources: sources.sources,
         applications: applications.applications,
         agents: agents.agents

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -24,6 +24,7 @@ export type Screen = "home" | "nodes" | "apps" | "network" | "activity" | "setti
 
 export type AppData = {
   status: CenterStatus;
+  centerUpdate: CenterUpdateStatus;
   sources: CatalogSource[];
   apps: AppView[];
   agents: AgentView[];
@@ -37,6 +38,19 @@ export type AppData = {
   integrations: Integration[];
   actions: Action[];
   threeXUIControllerMigrations: ThreeXUIControllerMigration[];
+};
+
+export type CenterUpdateStatus = {
+  currentVersion: string;
+  latestVersion?: string;
+  updateAvailable: boolean;
+  automatic: boolean;
+  state: "idle" | "queued" | "applying" | "succeeded" | "failed";
+  targetVersion?: string;
+  message?: string;
+  checkedAt?: string;
+  updatedAt?: string;
+  error?: string;
 };
 
 export type AgentConnectionMode = "lan" | "headscale" | "public";

--- a/web/src/views/CenterUpdateCard.tsx
+++ b/web/src/views/CenterUpdateCard.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { CircleArrowUpIcon, CircleCheckIcon, RotateCcwIcon, ShieldCheckIcon } from "lucide-react";
+import { api } from "../api";
+import type { CenterUpdateStatus } from "../types";
+import type { Language } from "../translations";
+import { CopyButton, copy, formatDate, userError } from "./shared";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { FieldError } from "@/components/ui/field";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Spinner } from "@/components/ui/spinner";
+
+const manualCommand = "curl -LsSf https://vastora.petauron.com/install.sh | sudo sh -s -- center";
+
+export function CenterUpdateCard({ initial, language }: { initial: CenterUpdateStatus; language: Language }) {
+  const [status, setStatus] = useState(initial);
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const running = status.state === "queued" || status.state === "applying";
+
+  useEffect(() => { setStatus(initial); }, [initial]);
+  useEffect(() => {
+    if (!running) return;
+    let stopped = false;
+    const poll = async () => {
+      try {
+        const next = await api.centerUpdate();
+        if (!stopped) setStatus(next);
+      } catch {
+        // Center restarts during a normal update. Keep the progress state and retry.
+      }
+    };
+    const timer = window.setInterval(() => void poll(), 2000);
+    void poll();
+    return () => { stopped = true; window.clearInterval(timer); };
+  }, [running]);
+
+  const refresh = async () => {
+    setBusy(true); setError("");
+    try { setStatus(await api.centerUpdate()); } catch (refreshError) { setError(userError(language, refreshError)); } finally { setBusy(false); }
+  };
+  const start = async () => {
+    setBusy(true); setError("");
+    try { setStatus(await api.startCenterUpdate()); setConfirming(false); } catch (updateError) { setError(userError(language, updateError)); } finally { setBusy(false); }
+  };
+
+  return <>
+    <Card>
+      <CardHeader><CardTitle className="flex items-center gap-2"><CircleArrowUpIcon />{copy(language, "Center 更新", "Center update")}</CardTitle><CardDescription>{copy(language, "自动检查官方完整版本，并沿用安装时的安全升级流程。", "Checks complete official releases and reuses the verified installation upgrade flow.")}</CardDescription><CardAction>{running ? <Spinner /> : status.updateAvailable ? <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">{copy(language, "有新版本", "Update available")}</span> : <CircleCheckIcon className="size-5 text-success" />}</CardAction></CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <dl className="grid gap-4 text-sm sm:grid-cols-2"><div><dt className="text-muted-foreground">{copy(language, "当前版本", "Current version")}</dt><dd className="mt-1 font-medium">{status.currentVersion}</dd></div><div><dt className="text-muted-foreground">{copy(language, "官方版本", "Official version")}</dt><dd className="mt-1 font-medium">{status.latestVersion || "—"}</dd></div></dl>
+        {running ? <Alert><Spinner /><AlertTitle>{copy(language, `正在更新到 ${status.targetVersion || status.latestVersion}`, `Updating to ${status.targetVersion || status.latestVersion}`)}</AlertTitle><AlertDescription>{copy(language, "Center 会短暂重启，本页会自动重新连接。请不要关闭服务器或 Docker。", "Center briefly restarts and this page reconnects automatically. Do not stop the server or Docker.")}</AlertDescription></Alert> : null}
+        {status.state === "succeeded" && !status.updateAvailable ? <Alert><ShieldCheckIcon /><AlertTitle>{copy(language, "更新完成", "Update complete")}</AlertTitle><AlertDescription>{copy(language, `Center 已安全更新到 ${status.currentVersion}。`, `Center was safely updated to ${status.currentVersion}.`)}</AlertDescription></Alert> : null}
+        {status.state === "failed" ? <FieldError role="alert">{copy(language, "更新没有完成。系统保留了可诊断状态，请重试；若仍失败，请下载诊断报告。", "The update did not finish. Diagnostic state was preserved; retry, then download diagnostics if it still fails.")}</FieldError> : null}
+        {status.error ? <FieldError role="alert">{copy(language, "暂时无法检查官方版本，请稍后重试。", "The official release cannot be checked right now. Try again shortly.")}</FieldError> : null}
+        {status.updateAvailable && !status.automatic ? <Alert><ShieldCheckIcon /><AlertTitle>{copy(language, "当前安装需要先手动更新一次", "One manual update is required")}</AlertTitle><AlertDescription><p>{copy(language, "运行一次下面的官方命令后，后续版本即可在这里更新。", "Run the official command once; future releases can then be installed here.")}</p><div className="relative mt-3"><code className="block break-all rounded-lg bg-muted p-3 pr-12 text-xs leading-5">{manualCommand}</code><CopyButton className="absolute right-1.5 top-1.5" label={copy(language, "复制更新命令", "Copy update command")} language={language} size="icon-sm" value={manualCommand} /></div></AlertDescription></Alert> : null}
+        {error ? <FieldError role="alert">{error}</FieldError> : null}
+        {status.checkedAt ? <p className="text-xs text-muted-foreground">{copy(language, "上次检查", "Last checked")}：{formatDate(language, status.checkedAt)}</p> : null}
+      </CardContent>
+      <CardFooter className="justify-end gap-2"><Button disabled={busy || running} onClick={() => void refresh()} size="sm" variant="outline">{busy && !confirming ? <Spinner data-icon="inline-start" /> : <RotateCcwIcon data-icon="inline-start" />}{copy(language, "检查更新", "Check again")}</Button>{status.updateAvailable && status.automatic ? <Button disabled={busy || running} onClick={() => setConfirming(true)} size="sm">{copy(language, status.state === "failed" ? "重试更新" : "更新 Center", status.state === "failed" ? "Retry update" : "Update Center")}</Button> : null}</CardFooter>
+    </Card>
+    <Sheet onOpenChange={(open) => { if (!open && !busy) setConfirming(false); }} open={confirming}><SheetContent><SheetHeader><SheetTitle>{copy(language, `更新到 ${status.latestVersion}`, `Update to ${status.latestVersion}`)}</SheetTitle><SheetDescription>{copy(language, "更新会保留配置与数据，并在迁移数据库前创建备份。Center 和同机 Agent 会按顺序更新。", "Configuration and data are preserved, with a backup before database migration. Center and a co-located Agent update in order.")}</SheetDescription></SheetHeader><div className="flex-1 px-4"><Alert><ShieldCheckIcon /><AlertTitle>{copy(language, "预计短暂断开连接", "Expect a brief reconnect")}</AlertTitle><AlertDescription>{copy(language, "升级过程会校验下载摘要、等待健康检查；数据库一旦迁移不会自动降级。", "The upgrade verifies download integrity and waits for health checks. A migrated database is never downgraded automatically.")}</AlertDescription></Alert>{error ? <FieldError className="mt-4" role="alert">{error}</FieldError> : null}</div><SheetFooter><Button disabled={busy} onClick={() => setConfirming(false)} variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy} onClick={() => void start()}>{busy ? <Spinner data-icon="inline-start" /> : <CircleArrowUpIcon data-icon="inline-start" />}{copy(language, "开始更新", "Start update")}</Button></SheetFooter></SheetContent></Sheet>
+  </>;
+}

--- a/web/src/views/HomeView.tsx
+++ b/web/src/views/HomeView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type FormEvent, type ReactNode } from "react";
-import { AppWindowIcon, ArrowRightIcon, CircleCheckIcon, PencilIcon, PlusIcon, ServerIcon } from "lucide-react";
+import { AppWindowIcon, ArrowRightIcon, CircleCheckIcon, CircleArrowUpIcon, PencilIcon, PlusIcon, ServerIcon } from "lucide-react";
 import { api } from "../api";
 import { browserTimezone } from "../lib/network";
 import { actionKind, actionMessage, groupActions } from "./ActivityView";
@@ -29,6 +29,7 @@ export function HomeView({ data, language, onNavigate, mutate }: { data: AppData
   return (
     <section className="flex flex-col gap-7">
       <PageHeading title={copy(language, "欢迎回来", "Welcome back")} description={copy(language, "从这里查看节点、应用和访问入口是否正常。", "See whether your nodes, apps, and access points are healthy.")} />
+      {data.centerUpdate.updateAvailable ? <Card size="sm"><CardHeader><CardTitle className="flex items-center gap-2"><CircleArrowUpIcon />{copy(language, `Center ${data.centerUpdate.latestVersion} 已发布`, `Center ${data.centerUpdate.latestVersion} is available`)}</CardTitle><CardDescription>{copy(language, "可在设置中查看并安全更新；配置和数据会保留。", "Review and update safely in Settings; configuration and data are preserved.")}</CardDescription><CardAction><Button onClick={() => onNavigate("settings")} size="sm">{copy(language, "查看更新", "View update")}<ArrowRightIcon data-icon="inline-end" /></Button></CardAction></CardHeader></Card> : null}
       <SetupGuide activeAgents={activeAgents.length} language={language} needsNetwork={needsNetwork} onNavigate={onNavigate} runningApps={data.applications.filter((application) => application.status === "running").length} />
       <div className="grid gap-4 sm:grid-cols-3">
         <SummaryCard description={copy(language, "在线节点", "online nodes")} icon={<ServerIcon />} title={`${connected}/${activeAgents.length}`} />

--- a/web/src/views/SettingsView.tsx
+++ b/web/src/views/SettingsView.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { CenterUpdateCard } from "./CenterUpdateCard";
 
 export function SettingsView({ data, language, mutate, onLogout }: { data: AppData; language: Language; mutate: Mutate; onLogout: () => Promise<void> }) {
   const [adding, setAdding] = useState(false);
@@ -29,6 +30,7 @@ export function SettingsView({ data, language, mutate, onLogout }: { data: AppDa
         <CardContent><dl className="grid gap-4 text-sm sm:grid-cols-3"><div><dt className="text-muted-foreground">{copy(language, "版本", "Version")}</dt><dd className="mt-1 font-medium">{data.status.version}</dd></div><div><dt className="text-muted-foreground">{copy(language, "节点", "Nodes")}</dt><dd className="mt-1 font-medium">{data.agents.filter((agent) => agent.status === "active").length}</dd></div><div><dt className="text-muted-foreground">{copy(language, "应用", "Apps")}</dt><dd className="mt-1 font-medium">{data.applications.length}</dd></div></dl></CardContent>
         <CardFooter className="justify-end"><Button onClick={() => setPasswordOpen(true)} size="sm" variant="outline"><KeyRoundIcon data-icon="inline-start" />{copy(language, "修改管理员密码", "Change administrator password")}</Button></CardFooter>
       </Card>
+      <CenterUpdateCard initial={data.centerUpdate} language={language} />
       <Card>
         <CardHeader><CardTitle className="flex items-center gap-2"><ShieldCheckIcon />{copy(language, "数据与故障排查", "Data & troubleshooting")}</CardTitle><CardDescription>{copy(language, "备份 Center 配置，或下载不含密钥的诊断信息。", "Back up Center configuration or download diagnostics that contain no secret values.")}</CardDescription></CardHeader>
         <CardContent>

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -32,6 +32,7 @@ afterEach(() => {
 
 const dashboard = (): AppData => ({
   status: { version: "test", agentInstallerAvailable: true, agentConnectionMode: "lan", agentConnectUrl: "https://center.example.com" },
+  centerUpdate: { currentVersion: "test", latestVersion: "test", updateAvailable: false, automatic: true, state: "idle", checkedAt: "2026-08-18T00:00:00Z" },
   sources: [], organizations: [], routes: [], actions: [], integrations: [], threeXUIControllerMigrations: [],
   sites: [{ id: "site", organizationId: "org", name: "Home", code: "home", description: "", timezone: "Asia/Singapore", domainSuffix: "home.example", status: "active", gatewayNodes: ["agent"], gatewayStatus: "ready", createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" }],
   agents: [{ id: "agent", name: "home-server", version: "test", operatingSystem: "linux", architecture: "amd64", status: "active", appliedInstallations: 1, enrolledAt: "2026-08-18T00:00:00Z", lastSeenAt: "2026-08-18T00:00:00Z", connected: true, siteId: "site", roles: ["worker", "gateway"], capabilities: { docker: true, gateway: true, tunnel: true, metrics: false, logs: false }, networkCandidates: [{ address: "192.168.1.2", interface: "eth0", family: "ipv4", kind: "lan", observedAt: "2026-08-18T00:00:00Z" }], networkProfile: { serviceAddress: "192.168.1.2", lanAddress: "192.168.1.2", enabledKinds: ["lan"], directPublic: false }, gatewayHealthy: true }],
@@ -1168,5 +1169,17 @@ describe("network and app views", () => {
     act(() => changePassword?.click());
     expect(document.querySelector<HTMLInputElement>("#new-password")?.minLength).toBe(10);
     expect(document.body.textContent).toContain("至少 10 个字符。");
+  });
+
+  it("shows a confirmed Center update instead of exposing Docker access", () => {
+    const data = dashboard();
+    data.centerUpdate = { currentVersion: "0.1.0-alpha.47", latestVersion: "0.1.0-alpha.48", updateAvailable: true, automatic: true, state: "idle", checkedAt: "2026-08-25T00:00:00Z" };
+    const container = render(<SettingsView data={data} language="zh-CN" mutate={async () => undefined} onLogout={async () => undefined} />);
+    expect(container.textContent).toContain("Center 更新");
+    expect(container.textContent).toContain("0.1.0-alpha.48");
+    const update = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("更新 Center"));
+    act(() => update?.click());
+    expect(document.body.textContent).toContain("预计短暂断开连接");
+    expect(document.body.textContent).toContain("开始更新");
   });
 });


### PR DESCRIPTION
## Summary
- detect the newest complete official Center release
- add confirmed in-product updates with reconnecting progress UI
- keep Docker access in the restricted deployer and execute exact-version upgrades through a host systemd one-shot service
- reuse existing database backup, migration, health-check, and co-located Agent upgrade flow

## Validation
- Go deployapi, deployer, and Center tests
- cmd/vastora compile check
- Center install bundle test
- frontend ESLint
- 64 targeted frontend tests
- production frontend build