### PR TITLE
fix: support browsers without media query events

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -50,6 +50,16 @@ async function renderReadyApp() {
 }
 
 describe("application shell", () => {
+  it("renders when the browser cannot observe system theme changes", async () => {
+    Object.defineProperty(window, "matchMedia", { configurable: true, value: vi.fn().mockImplementation((query: string) => ({ matches: true, media: query })) });
+    mockReadyCenter();
+
+    const container = await renderReadyApp();
+
+    expect(container.textContent).toContain("Center connected");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
   it("lets the user switch themes and remembers the choice", async () => {
     mockReadyCenter();
     const container = await renderReadyApp();

--- a/web/src/components/theme.tsx
+++ b/web/src/components/theme.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState, t
 import { MoonIcon, SunIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { observeMediaQuery } from "@/lib/media-query";
 import type { Language } from "@/translations";
 
 type Theme = "light" | "dark";
@@ -49,8 +50,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const followSystem = () => {
       if (!storedTheme()) setTheme(media.matches ? "dark" : "light");
     };
-    media.addEventListener("change", followSystem);
-    return () => media.removeEventListener("change", followSystem);
+    return observeMediaQuery(media, followSystem);
   }, []);
 
   const toggleTheme = useCallback(() => {

--- a/web/src/hooks/use-mobile.ts
+++ b/web/src/hooks/use-mobile.ts
@@ -1,5 +1,7 @@
 import * as React from "react"
 
+import { observeMediaQuery } from "@/lib/media-query"
+
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
@@ -10,9 +12,9 @@ export function useIsMobile() {
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
-    mql.addEventListener("change", onChange)
+    const stopObserving = observeMediaQuery(mql, onChange)
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
+    return stopObserving
   }, [])
 
   return !!isMobile

--- a/web/src/lib/media-query.ts
+++ b/web/src/lib/media-query.ts
@@ -1,0 +1,11 @@
+export function observeMediaQuery(media: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
+  if (typeof media.addEventListener === "function") {
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }
+  if (typeof media.addListener === "function") {
+    media.addListener(listener);
+    return () => media.removeListener(listener);
+  }
+  return () => undefined;
+}


### PR DESCRIPTION
## Summary
- prevent a blank Center UI when a browser implements matchMedia without change-event APIs
- share one media-query observer between theme and responsive sidebar behavior
- cover the in-app browser capability profile with a regression test

## Verification
- npm run lint
- npm run test (81 tests)
- npm run build
- git diff --check
- reproduced against the ARM alpha.49 deployment in the in-app browser