### PR TITLE
feat: add safe control plane migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,14 @@
 version: 2
 # Routine version PRs are limited to patch and minor releases. Major upgrades
 # are reviewed and tested manually; Dependabot security updates remain enabled.
-# A high open PR limit avoids GitHub's default five-PR version-update backlog.
+# Keep each ecosystem's routine update backlog bounded so dependency churn does
+# not fan out into an unbounded number of full pull-request checks.
 updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10
     allow:
       - dependency-name: "*"
         update-types:
@@ -17,7 +18,7 @@ updates:
     directory: "/web"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10
     allow:
       - dependency-name: "*"
         update-types:
@@ -62,7 +63,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10
     allow:
       - dependency-name: "*"
         update-types:
@@ -72,7 +73,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10
     allow:
       - dependency-name: "*"
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,29 +2,138 @@ name: CI
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   pull_request:
+  schedule:
+    - cron: "41 3 * * 1"
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  go:
+  changes:
+    name: Classify changes
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      web: ${{ steps.filter.outputs.web }}
+      deployment: ${{ steps.filter.outputs.deployment }}
+      security: ${{ steps.filter.outputs.non_release }}
+      container: ${{ steps.filter.outputs.container }}
+      release_metadata: ${{ steps.filter.outputs.release_metadata }}
+      full: ${{ steps.filter.outputs.full == 'true' || steps.filter.outputs.unknown == 'true' }}
+    steps:
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: some-with-excludes
+          filters: |
+            go:
+              - 'cmd/**'
+              - 'internal/**'
+              - 'go.mod'
+              - 'go.sum'
+            web:
+              - 'web/**'
+            deployment:
+              - 'deploy/**'
+              - 'scripts/**'
+              - 'install.sh'
+              - 'catalog/**'
+              - 'Dockerfile*'
+              - 'release-please-config.json'
+            container:
+              - 'Dockerfile.center'
+              - '.dockerignore'
+              - 'go.mod'
+              - 'go.sum'
+              - 'web/package.json'
+              - 'web/package-lock.json'
+              - 'catalog/catalog.json'
+            non_release:
+              - '**'
+              - '!CHANGELOG.md'
+              - '!.release-please-manifest.json'
+              - '!version.txt'
+            release_metadata:
+              - 'CHANGELOG.md'
+              - '.release-please-manifest.json'
+              - 'version.txt'
+            full:
+              - '.github/workflows/**'
+              - '.github/dependabot.yml'
+              - 'Makefile'
+              - 'release-please-config.json'
+            unknown:
+              - '**'
+              - '!cmd/**'
+              - '!internal/**'
+              - '!web/**'
+              - '!deploy/**'
+              - '!scripts/**'
+              - '!catalog/**'
+              - '!.github/**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!Dockerfile*'
+              - '!.dockerignore'
+              - '!go.mod'
+              - '!go.sum'
+              - '!install.sh'
+              - '!version.txt'
+              - '!.release-please-manifest.json'
+              - '!release-please-config.json'
+              - '!LICENSE'
+
+  warm-dependency-caches:
+    name: Warm dependency caches
+    if: github.event_name == 'push'
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.6"
+      - run: go mod download
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.19.0"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: cd web && npm ci --ignore-scripts
+
+  go:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (needs.changes.outputs.go == 'true' || needs.changes.outputs.full == 'true'))
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26.6"
       - run: make go-check
+      - run: make go-security-check
       - name: Cross-compile Agent binaries
         run: make agent-binaries
 
   web:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (needs.changes.outputs.web == 'true' || needs.changes.outputs.full == 'true'))
+    needs: changes
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -34,31 +143,38 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: cd web && npm ci --ignore-scripts
       - run: make web-check
+      - run: make web-security-check
 
   deployment:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (needs.changes.outputs.deployment == 'true' || needs.changes.outputs.full == 'true'))
+    needs: changes
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: make deployment-check
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
+      - name: Require x64 and ARM64 runtime images
+        run: scripts/check-runtime-image-platforms.sh
 
   security:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && needs.changes.outputs.security == 'true')
+    needs: changes
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26.6"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24.19.0"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: cd web && npm ci --ignore-scripts
-      - name: Scan full Git history for secrets
-        run: go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --redact --verbose .
-      - run: make dependency-security-check
+      - name: Scan Git history for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
@@ -66,13 +182,27 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "1"
-      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+  release-metadata:
+    name: Release metadata
+    if: github.event_name == 'pull_request' && needs.changes.outputs.release_metadata == 'true'
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          path: .
-          artifact-name: vastora-sbom.spdx.json
+          fetch-depth: 0
+      - name: Validate release pull request metadata
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: scripts/validate-release-metadata.sh "$BASE_SHA"
 
   container-image-security:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (needs.changes.outputs.container == 'true' || needs.changes.outputs.full == 'true'))
+    needs: changes
     runs-on: ubuntu-24.04
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -80,12 +210,12 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
-
       - name: Build Center image for scanning
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
@@ -97,8 +227,6 @@ jobs:
           build-args: VASTORA_VERSION=0.0.0-ci
           tags: local/vastora-center:${{ github.sha }}-${{ matrix.architecture }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: Scan Center image for vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -110,7 +238,6 @@ jobs:
           ignore-unfixed: true
           limit-severities-for-sarif: true
           exit-code: "1"
-
       - name: Upload Center image scan results
         if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
@@ -118,11 +245,26 @@ jobs:
           sarif_file: trivy-center-image-${{ matrix.architecture }}.sarif
           category: trivy-vastora-center-ci-${{ matrix.architecture }}
 
-  runtime-image-platforms:
+  gate:
+    name: CI / gate
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+    needs: [changes, go, web, deployment, security, release-metadata, container-image-security]
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
-      - name: Require x64 and ARM64 runtime images
-        run: scripts/check-runtime-image-platforms.sh
+      - name: Require every applicable CI job
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          GO_RESULT: ${{ needs.go.result }}
+          WEB_RESULT: ${{ needs.web.result }}
+          DEPLOYMENT_RESULT: ${{ needs.deployment.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+          RELEASE_METADATA_RESULT: ${{ needs.release-metadata.result }}
+          CONTAINER_RESULT: ${{ needs.container-image-security.result }}
+        run: |
+          for result in "$CHANGES_RESULT" "$GO_RESULT" "$WEB_RESULT" "$DEPLOYMENT_RESULT" "$SECURITY_RESULT" "$RELEASE_METADATA_RESULT" "$CONTAINER_RESULT"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "Required CI job did not succeed: $result" >&2; exit 1 ;;
+            esac
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,75 +25,21 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       web: ${{ steps.filter.outputs.web }}
       deployment: ${{ steps.filter.outputs.deployment }}
-      security: ${{ steps.filter.outputs.non_release }}
+      security: ${{ steps.filter.outputs.security }}
       container: ${{ steps.filter.outputs.container }}
       release_metadata: ${{ steps.filter.outputs.release_metadata }}
-      full: ${{ steps.filter.outputs.full == 'true' || steps.filter.outputs.unknown == 'true' }}
+      full: ${{ steps.filter.outputs.full }}
     steps:
       - if: github.event_name == 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        with:
-          predicate-quantifier: some-with-excludes
-          filters: |
-            go:
-              - 'cmd/**'
-              - 'internal/**'
-              - 'go.mod'
-              - 'go.sum'
-            web:
-              - 'web/**'
-            deployment:
-              - 'deploy/**'
-              - 'scripts/**'
-              - 'install.sh'
-              - 'catalog/**'
-              - 'Dockerfile*'
-              - 'release-please-config.json'
-            container:
-              - 'Dockerfile.center'
-              - '.dockerignore'
-              - 'go.mod'
-              - 'go.sum'
-              - 'web/package.json'
-              - 'web/package-lock.json'
-              - 'catalog/catalog.json'
-            non_release:
-              - '**'
-              - '!CHANGELOG.md'
-              - '!.release-please-manifest.json'
-              - '!version.txt'
-            release_metadata:
-              - 'CHANGELOG.md'
-              - '.release-please-manifest.json'
-              - 'version.txt'
-            full:
-              - '.github/workflows/**'
-              - '.github/dependabot.yml'
-              - 'Makefile'
-              - 'release-please-config.json'
-            unknown:
-              - '**'
-              - '!cmd/**'
-              - '!internal/**'
-              - '!web/**'
-              - '!deploy/**'
-              - '!scripts/**'
-              - '!catalog/**'
-              - '!.github/**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!Dockerfile*'
-              - '!.dockerignore'
-              - '!go.mod'
-              - '!go.sum'
-              - '!install.sh'
-              - '!version.txt'
-              - '!.release-please-manifest.json'
-              - '!release-please-config.json'
-              - '!LICENSE'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/classify-ci-changes.sh --git ci "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   warm-dependency-caches:
     name: Warm dependency caches
@@ -171,10 +117,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.6"
       - name: Scan Git history for secrets
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        run: go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --redact --verbose .
       - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,49 +23,18 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       javascript: ${{ steps.filter.outputs.javascript }}
-      full: ${{ steps.filter.outputs.full == 'true' || steps.filter.outputs.unknown == 'true' }}
+      full: ${{ steps.filter.outputs.full }}
     steps:
       - if: github.event_name == 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        with:
-          predicate-quantifier: some-with-excludes
-          filters: |
-            go:
-              - 'cmd/**'
-              - 'internal/**'
-              - 'go.mod'
-              - 'go.sum'
-            javascript:
-              - 'web/**'
-              - 'deploy/installer-worker/**'
-              - 'scripts/**/*.mjs'
-              - 'scripts/**/*.js'
-            full:
-              - '.github/workflows/codeql.yml'
-              - 'Makefile'
-            unknown:
-              - '**'
-              - '!cmd/**'
-              - '!internal/**'
-              - '!web/**'
-              - '!deploy/**'
-              - '!scripts/**'
-              - '!catalog/**'
-              - '!.github/**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!Dockerfile*'
-              - '!.dockerignore'
-              - '!go.mod'
-              - '!go.sum'
-              - '!install.sh'
-              - '!version.txt'
-              - '!.release-please-manifest.json'
-              - '!release-please-config.json'
-              - '!LICENSE'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/classify-ci-changes.sh --git codeql "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   analyze-go:
     name: Analyze (go)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,20 +8,111 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
   security-events: write
 
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
+  changes:
+    name: Classify languages
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [go, javascript-typescript]
+    timeout-minutes: 5
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      javascript: ${{ steps.filter.outputs.javascript }}
+      full: ${{ steps.filter.outputs.full == 'true' || steps.filter.outputs.unknown == 'true' }}
+    steps:
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: some-with-excludes
+          filters: |
+            go:
+              - 'cmd/**'
+              - 'internal/**'
+              - 'go.mod'
+              - 'go.sum'
+            javascript:
+              - 'web/**'
+              - 'deploy/installer-worker/**'
+              - 'scripts/**/*.mjs'
+              - 'scripts/**/*.js'
+            full:
+              - '.github/workflows/codeql.yml'
+              - 'Makefile'
+            unknown:
+              - '**'
+              - '!cmd/**'
+              - '!internal/**'
+              - '!web/**'
+              - '!deploy/**'
+              - '!scripts/**'
+              - '!catalog/**'
+              - '!.github/**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!Dockerfile*'
+              - '!.dockerignore'
+              - '!go.mod'
+              - '!go.sum'
+              - '!install.sh'
+              - '!version.txt'
+              - '!.release-please-manifest.json'
+              - '!release-please-config.json'
+              - '!LICENSE'
+
+  analyze-go:
+    name: Analyze (go)
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true' || needs.changes.outputs.full == 'true'
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
-          languages: ${{ matrix.language }}
+          languages: go
       - uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+
+  analyze-javascript:
+    name: Analyze (javascript-typescript)
+    if: github.event_name != 'pull_request' || needs.changes.outputs.javascript == 'true' || needs.changes.outputs.full == 'true'
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+
+  gate:
+    name: CodeQL / gate
+    if: always()
+    needs: [changes, analyze-go, analyze-javascript]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Require every applicable CodeQL job
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          GO_RESULT: ${{ needs.analyze-go.result }}
+          JAVASCRIPT_RESULT: ${{ needs.analyze-javascript.result }}
+        run: |
+          for result in "$CHANGES_RESULT" "$GO_RESULT" "$JAVASCRIPT_RESULT"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "Required CodeQL job did not succeed: $result" >&2; exit 1 ;;
+            esac
+          done

--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   scan:
     runs-on: ubuntu-24.04
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,25 +16,25 @@ concurrency:
 
 jobs:
   prepare:
+    name: Prepare existing release
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
-      checks: write
       contents: write
-      issues: write
-      pull-requests: write
     outputs:
       release_created: ${{ steps.retry.outputs.release_created || steps.release.outputs.release_created }}
       release_sha: ${{ steps.retry.outputs.release_sha || steps.release.outputs.sha }}
       release_tag: ${{ steps.retry.outputs.release_tag || steps.release.outputs.tag_name }}
       release_version: ${{ steps.retry.outputs.release_version || steps.release.outputs.version }}
     steps:
-      - name: Create or update release pull request
+      - name: Create a release without updating the next release pull request
         id: release
         if: github.event_name != 'workflow_dispatch' || inputs.release_tag == ''
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ github.token }}
           target-branch: main
+          skip-github-pull-request: true
 
       - name: Resolve draft release retry
         id: retry
@@ -68,68 +68,19 @@ jobs:
             echo "release_version=${RELEASE_TAG#v}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Resolve release pull request
-        id: release_pr
-        if: steps.release.outputs.prs_created == 'true'
-        env:
-          RELEASE_PR: ${{ steps.release.outputs.pr }}
-        run: |
-          head_branch="$(printf '%s' "$RELEASE_PR" | jq -er '.headBranchName')"
-          {
-            echo "head_branch=$head_branch"
-            echo "base_sha=$GITHUB_SHA"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Check out release pull request
-        if: steps.release.outputs.prs_created == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ steps.release_pr.outputs.head_branch }}
-          fetch-depth: 0
-
-      - name: Start release metadata check
-        id: release_metadata_check
-        if: steps.release.outputs.prs_created == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          check_id="$(
-            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs" \
-              -f name='Release metadata' \
-              -f head_sha="$(git rev-parse HEAD)" \
-              -f status='in_progress' \
-              -f details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-              --jq '.id'
-          )"
-          echo "id=$check_id" >> "$GITHUB_OUTPUT"
-
-      - name: Validate release pull request metadata
-        id: validate_release_metadata
-        if: steps.release.outputs.prs_created == 'true'
-        env:
-          BASE_SHA: ${{ steps.release_pr.outputs.base_sha }}
-        run: scripts/validate-release-metadata.sh "$BASE_SHA"
-
-      - name: Finish release metadata check
-        if: always() && steps.release.outputs.prs_created == 'true' && steps.release_metadata_check.outputs.id != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          CHECK_ID: ${{ steps.release_metadata_check.outputs.id }}
-          CHECK_CONCLUSION: ${{ steps.validate_release_metadata.outcome == 'success' && 'success' || 'failure' }}
-        run: |
-          gh api --method PATCH "/repos/$GITHUB_REPOSITORY/check-runs/$CHECK_ID" \
-            -f status='completed' \
-            -f conclusion="$CHECK_CONCLUSION" >/dev/null
-
   publish:
     needs: prepare
     if: needs.prepare.outputs.release_created == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: write
       id-token: write
       packages: write
+    env:
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
       - name: Check out release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -220,3 +171,82 @@ jobs:
           sha256sum --check vastora-center-install.tar.gz.sha256
           actual_version="$(tar -xOzf vastora-center-install.tar.gz ./release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')"
           test "$actual_version" = "$EXPECTED_VERSION"
+
+  release-pr:
+    name: Prepare next release pull request
+    needs: [prepare, publish]
+    if: always() && needs.prepare.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      checks: write
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Create or update the next release pull request without publishing
+        id: release_pr_action
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
+          token: ${{ github.token }}
+          target-branch: main
+          skip-github-release: true
+
+      - name: Resolve release pull request
+        id: release_pr
+        if: steps.release_pr_action.outputs.prs_created == 'true'
+        env:
+          RELEASE_PR: ${{ steps.release_pr_action.outputs.pr }}
+        run: |
+          head_branch="$(printf '%s' "$RELEASE_PR" | jq -er '.headBranchName')"
+          {
+            echo "head_branch=$head_branch"
+            echo "base_sha=$GITHUB_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out release pull request
+        if: steps.release_pr_action.outputs.prs_created == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.release_pr.outputs.head_branch }}
+          fetch-depth: 0
+
+      - name: Start release gate checks
+        id: release_gate_checks
+        if: steps.release_pr_action.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          start_check() {
+            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs" \
+              -f name="$1" \
+              -f head_sha="$(git rev-parse HEAD)" \
+              -f status='in_progress' \
+              -f details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+              --jq '.id'
+          }
+          {
+            echo "ci_id=$(start_check 'CI / gate')"
+            echo "codeql_id=$(start_check 'CodeQL / gate')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate release pull request metadata
+        id: validate_release_metadata
+        if: steps.release_pr_action.outputs.prs_created == 'true'
+        env:
+          BASE_SHA: ${{ steps.release_pr.outputs.base_sha }}
+        run: scripts/validate-release-metadata.sh "$BASE_SHA"
+
+      - name: Finish release gate checks
+        if: always() && steps.release_pr_action.outputs.prs_created == 'true' && steps.release_gate_checks.outputs.ci_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CI_CHECK_ID: ${{ steps.release_gate_checks.outputs.ci_id }}
+          CODEQL_CHECK_ID: ${{ steps.release_gate_checks.outputs.codeql_id }}
+          CHECK_CONCLUSION: ${{ steps.validate_release_metadata.outcome == 'success' && 'success' || 'failure' }}
+        run: |
+          for check_id in "$CI_CHECK_ID" "$CODEQL_CHECK_ID"; do
+            gh api --method PATCH "/repos/$GITHUB_REPOSITORY/check-runs/$check_id" \
+              -f status='completed' \
+              -f conclusion="$CHECK_CONCLUSION" >/dev/null
+          done

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_PACKAGES := ./cmd/... ./internal/...
 STATICCHECK_VERSION := v0.7.0
 GOVULNCHECK_VERSION := v1.7.0
 
-.PHONY: bootstrap check go-check web-check deployment-check security-check dependency-security-check agent-binaries center-install-bundle image-center image-agent
+.PHONY: bootstrap check go-check web-check deployment-check security-check dependency-security-check go-security-check web-security-check agent-binaries center-install-bundle image-center image-agent
 
 bootstrap:
 	$(GO) mod download
@@ -35,6 +35,7 @@ deployment-check:
 	sh -n scripts/test-center-install.sh
 	sh -n scripts/test-release-metadata.sh
 	sh -n scripts/test-release-workflow.sh
+	sh -n scripts/test-ci-workflows.sh
 	node scripts/test-installer-worker.mjs
 	./install.sh --help >/dev/null
 	deploy/center/setup.sh --help >/dev/null
@@ -43,14 +44,21 @@ deployment-check:
 	scripts/test-center-install.sh
 	scripts/test-release-metadata.sh
 	scripts/test-release-workflow.sh
+	scripts/test-ci-workflows.sh
 
 security-check:
 	gitleaks detect --no-git --redact --source .
 	$(MAKE) dependency-security-check
 
 dependency-security-check:
-	cd web && npm audit --audit-level=high
+	$(MAKE) go-security-check
+	$(MAKE) web-security-check
+
+go-security-check:
 	$(GO) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) $(GO_PACKAGES)
+
+web-security-check:
+	cd web && npm audit --audit-level=high
 
 agent-binaries:
 	mkdir -p bin/agent-binaries

--- a/cmd/vastora/agent_cmd.go
+++ b/cmd/vastora/agent_cmd.go
@@ -32,6 +32,7 @@ func runAgent(arguments []string) error {
 		dataDir := flags.String("data-dir", "/var/lib/vastora/agent", "Agent state directory")
 		centerURL := flags.String("center-url", "", "Center HTTPS URL or loopback HTTP URL")
 		tokenFile := flags.String("token-file", "", "0600 enrollment token file, or - for standard input")
+		replaceExisting := flags.Bool("replace-existing", false, "replace an existing Center enrollment after explicit confirmation")
 		if err := flags.Parse(arguments[1:]); err != nil {
 			return err
 		}
@@ -49,29 +50,70 @@ func runAgent(arguments []string) error {
 			return err
 		}
 		defer store.Close()
-		if _, connectionErr := store.Connection(context.Background()); connectionErr == nil {
+		existing, connectionErr := store.Connection(context.Background())
+		if connectionErr == nil && !*replaceExisting {
 			return errors.New("agent is already installed; use agent update or agent configure")
+		}
+		if connectionErr != nil && *replaceExisting {
+			return errors.New("agent cannot replace a Center enrollment because no existing enrollment was found")
 		}
 		token, err := readPrivateToken(*tokenFile)
 		if err != nil {
 			return err
 		}
-		enrollment, err := (agent.Client{}).Enroll(context.Background(), store, *centerURL, token)
+		client := agent.Client{}
+		var enrollment agent.Enrollment
+		if *replaceExisting {
+			enrollment, err = client.MigrateEnrollment(context.Background(), store, *centerURL, token)
+		} else {
+			enrollment, err = client.Enroll(context.Background(), store, *centerURL, token)
+		}
 		if err != nil {
 			return err
+		}
+		rollback := func(cause error) error {
+			if !*replaceExisting {
+				return cause
+			}
+			if rollbackErr := store.ReplaceConnection(context.Background(), existing); rollbackErr != nil {
+				return fmt.Errorf("%w; additionally failed to restore the previous Center connection: %v", cause, rollbackErr)
+			}
+			return cause
 		}
 		roles, capabilities, err := validatedNodeRuntime(strings.Join(enrollment.Roles, ","), nodeCapabilitiesString(enrollment.Capabilities))
 		if err != nil {
-			return fmt.Errorf("center returned an invalid Agent profile: %w", err)
+			return rollback(fmt.Errorf("center returned an invalid Agent profile: %w", err))
 		}
 		executable, err := os.Executable()
 		if err != nil {
-			return fmt.Errorf("locate vastora executable: %w", err)
+			return rollback(fmt.Errorf("locate vastora executable: %w", err))
 		}
 		if err := installSystemdAgent(executable, *dataDir, strings.Join(roles, ","), nodeCapabilitiesString(capabilities)); err != nil {
-			return err
+			return rollback(err)
+		}
+		if *replaceExisting {
+			if output, restartErr := exec.Command("systemctl", "restart", "vastora-agent.service").CombinedOutput(); restartErr != nil {
+				cause := rollback(fmt.Errorf("restart migrated Agent service: %s: %w", strings.TrimSpace(string(output)), restartErr))
+				_, _ = exec.Command("systemctl", "restart", "vastora-agent.service").CombinedOutput()
+				return cause
+			}
+			fmt.Printf("Agent %s moved to the new Center and restarted\n", enrollment.Name)
+			return nil
 		}
 		fmt.Printf("Agent %s installed and started\n", enrollment.Name)
+		return nil
+	case "status":
+		flags := flag.NewFlagSet("agent status", flag.ContinueOnError)
+		flags.SetOutput(os.Stderr)
+		dataDir := flags.String("data-dir", "/var/lib/vastora/agent", "Agent state directory")
+		if err := flags.Parse(arguments[1:]); err != nil {
+			return err
+		}
+		connection, err := agent.InspectConnection(*dataDir)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Agent: %s\nCenter: %s\nAgent ID: %s\n", connection.Name, connection.CenterURL, connection.AgentID)
 		return nil
 	case "configure":
 		flags := flag.NewFlagSet("agent configure", flag.ContinueOnError)

--- a/cmd/vastora/main.go
+++ b/cmd/vastora/main.go
@@ -71,7 +71,8 @@ Usage:
   vastora deployer serve --socket /run/vastora-deployer/deployer.sock
   vastora agent init --data-dir DIR
   vastora agent enroll --data-dir DIR --center-url URL --token-file FILE
-  vastora agent install --center-url URL --token-file FILE
+  vastora agent install --center-url URL --token-file FILE [--replace-existing]
+  vastora agent status [--data-dir /var/lib/vastora/agent]
   vastora agent configure --roles worker[,gateway] --capabilities docker[,gateway,tunnel]
   vastora agent update [--data-dir /var/lib/vastora/agent]
   vastora agent serve --data-dir DIR [--listen 127.0.0.1:8090]

--- a/internal/agent/caddy_driver.go
+++ b/internal/agent/caddy_driver.go
@@ -131,9 +131,15 @@ func validateProtectedSystemRoutes(desired gateway.DesiredState, services []stri
 		}
 	}
 	if protected["center"] && protected["headscale"] {
-		route, exists := routes["system-agent-bootstrap"]
-		if !exists || !route.System || !route.TLSEnabled || route.ListenerKind != "public" || route.Path != "/install/agent.sh" {
-			return errors.New("agent: refusing to replace protected system gateway without public Agent bootstrap route")
+		required := []struct{ id, path string }{
+			{"system-agent-bootstrap", "/install/agent.sh"},
+			{"system-agent-binary-bootstrap", "/api/v1/agent-binaries/*"},
+		}
+		for _, expected := range required {
+			route, exists := routes[expected.id]
+			if !exists || !route.System || !route.TLSEnabled || route.ListenerKind != "public" || route.Path != expected.path {
+				return errors.New("agent: refusing to replace protected system gateway without public Agent bootstrap routes")
+			}
 		}
 	}
 	return nil

--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -323,6 +323,16 @@ type ApplicationEndpointObservation struct {
 }
 
 func (c Client) Enroll(ctx context.Context, store *Store, centerURL, enrollmentToken string) (Enrollment, error) {
+	return c.enroll(ctx, store, centerURL, enrollmentToken, false)
+}
+
+// MigrateEnrollment explicitly replaces an existing Center identity while
+// preserving all workload state held by the Agent store.
+func (c Client) MigrateEnrollment(ctx context.Context, store *Store, centerURL, enrollmentToken string) (Enrollment, error) {
+	return c.enroll(ctx, store, centerURL, enrollmentToken, true)
+}
+
+func (c Client) enroll(ctx context.Context, store *Store, centerURL, enrollmentToken string, replace bool) (Enrollment, error) {
 	baseURL, err := normalizeCenterURL(centerURL)
 	if err != nil {
 		return Enrollment{}, err
@@ -339,7 +349,13 @@ func (c Client) Enroll(ctx context.Context, store *Store, centerURL, enrollmentT
 	if response.ID == "" || response.Credential == "" || strings.TrimSpace(response.Name) == "" || len(response.Roles) == 0 {
 		return Enrollment{}, errors.New("agent: Center returned an incomplete enrollment response")
 	}
-	if err := store.SaveConnection(ctx, Connection{AgentID: response.ID, Name: response.Name, CenterURL: baseURL, Credential: response.Credential}); err != nil {
+	connection := Connection{AgentID: response.ID, Name: response.Name, CenterURL: baseURL, Credential: response.Credential}
+	if replace {
+		err = store.ReplaceConnection(ctx, connection)
+	} else {
+		err = store.SaveConnection(ctx, connection)
+	}
+	if err != nil {
 		return Enrollment{}, err
 	}
 	return response, nil
@@ -374,11 +390,48 @@ func (c Client) heartbeat(ctx context.Context, store *Store) (error, error) {
 	} else if observeErr != nil {
 		observeErr = fmt.Errorf("agent: observe 3x-ui: %w", observeErr)
 	}
+	var response struct {
+		CenterURL string `json:"centerUrl"`
+	}
 	err = c.post(ctx, connection.CenterURL+"/api/v1/agents/"+url.PathEscape(connection.AgentID)+"/heartbeat", map[string]any{
 		"version": Version, "appliedInstallations": len(states), "roles": c.Roles,
 		"capabilities": c.Capabilities, "networkCandidates": candidates, "applicationEndpoints": endpoints, "applicationEndpointsObserved": endpointsObserved, "gatewayHealthy": gatewayHealthy,
-	}, connection.Credential, nil)
-	return observeErr, err
+	}, connection.Credential, &response)
+	if err != nil {
+		return observeErr, err
+	}
+	if err := c.applyDesiredCenterURL(ctx, store, connection, response.CenterURL); err != nil {
+		return observeErr, err
+	}
+	return observeErr, nil
+}
+
+func (c Client) applyDesiredCenterURL(ctx context.Context, store *Store, connection Connection, desired string) error {
+	desired = strings.TrimSpace(desired)
+	if desired == "" {
+		return nil
+	}
+	normalized, err := normalizeCenterURL(desired)
+	if err != nil {
+		return fmt.Errorf("agent: reject Center-directed URL update: %w", err)
+	}
+	if normalized == connection.CenterURL {
+		return nil
+	}
+	var health struct {
+		Status string `json:"status"`
+	}
+	if err := c.get(ctx, normalized+"/healthz", "", &health); err != nil {
+		return fmt.Errorf("agent: verify new Center URL before switching: %w", err)
+	}
+	if health.Status != "ok" {
+		return errors.New("agent: verify new Center URL before switching: health check is not OK")
+	}
+	connection.CenterURL = normalized
+	if err := store.ReplaceConnection(ctx, connection); err != nil {
+		return fmt.Errorf("agent: save new Center URL: %w", err)
+	}
+	return nil
 }
 
 func observeThreeXUI(ctx context.Context, store *Store) ([]ApplicationEndpointObservation, error) {

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -44,6 +44,42 @@ func TestEnrollmentReportsNativePlatform(t *testing.T) {
 	}
 }
 
+func TestMigrateEnrollmentReplacesOnlyCenterConnection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"id":"new-agent","credential":"new-credential","name":"moved-node","roles":["worker","gateway"],"capabilities":{"docker":true,"gateway":true}}`))
+	}))
+	defer server.Close()
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "old-agent", Name: "old-node", CenterURL: "https://old-center.example.com", Credential: "old-credential"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{InstanceID: "existing-app", AppKey: "vastora-official/cpa", Version: "1.0.0", Config: json.RawMessage(`{}`), Secrets: json.RawMessage(`{}`), ServiceAddress: "100.64.0.2"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (Client{HTTPClient: server.Client()}).MigrateEnrollment(context.Background(), store, server.URL, "one-time-token"); err != nil {
+		t.Fatal(err)
+	}
+	connection, err := store.Connection(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connection.AgentID != "new-agent" || connection.Name != "moved-node" || connection.CenterURL != server.URL || connection.Credential != "new-credential" {
+		t.Fatalf("migrated connection = %#v", connection)
+	}
+	installations, err := store.ListApplied(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installations) != 1 || installations[0].InstanceID != "existing-app" {
+		t.Fatalf("migration changed local application state: %#v", installations)
+	}
+}
+
 func TestObserveThreeXUISynchronizesEnabledInboundsWithoutChangingThem(t *testing.T) {
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
@@ -231,6 +267,81 @@ func TestHeartbeatKeepsCenterConnectedWhenThreeXUIObservationFails(t *testing.T)
 	}
 	if observationErr == nil || heartbeats != 1 {
 		t.Fatalf("observation error was not isolated: err=%v heartbeats=%d", observationErr, heartbeats)
+	}
+}
+
+func TestHeartbeatSwitchesToVerifiedCenterURL(t *testing.T) {
+	healthChecks := 0
+	newCenter := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/healthz" {
+			t.Fatalf("unexpected new Center request path: %s", request.URL.Path)
+		}
+		healthChecks++
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer newCenter.Close()
+
+	oldCenter := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/agents/agent-1/heartbeat" {
+			t.Fatalf("unexpected old Center request path: %s", request.URL.Path)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(response).Encode(map[string]any{"connected": true, "centerUrl": newCenter.URL})
+	}))
+	defer oldCenter.Close()
+
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "agent-1", Name: "test", CenterURL: oldCenter.URL, Credential: "credential"}); err != nil {
+		t.Fatal(err)
+	}
+	observationErr, heartbeatErr := (Client{}).heartbeat(context.Background(), store)
+	if observationErr != nil || heartbeatErr != nil {
+		t.Fatalf("heartbeat failed: observation=%v heartbeat=%v", observationErr, heartbeatErr)
+	}
+	connection, err := store.Connection(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connection.CenterURL != newCenter.URL || healthChecks != 1 {
+		t.Fatalf("Center URL was not switched after verification: connection=%#v healthChecks=%d", connection, healthChecks)
+	}
+}
+
+func TestHeartbeatKeepsCurrentCenterWhenDesiredURLIsNotReady(t *testing.T) {
+	newCenter := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"status":"reconciling"}`))
+	}))
+	defer newCenter.Close()
+	oldCenter := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(response).Encode(map[string]any{"connected": true, "centerUrl": newCenter.URL})
+	}))
+	defer oldCenter.Close()
+
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "agent-1", Name: "test", CenterURL: oldCenter.URL, Credential: "credential"}); err != nil {
+		t.Fatal(err)
+	}
+	_, heartbeatErr := (Client{}).heartbeat(context.Background(), store)
+	if heartbeatErr == nil || !strings.Contains(heartbeatErr.Error(), "health check is not OK") {
+		t.Fatalf("unready Center URL was not rejected: %v", heartbeatErr)
+	}
+	connection, err := store.Connection(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connection.CenterURL != oldCenter.URL {
+		t.Fatalf("unready Center URL replaced the working address: %#v", connection)
 	}
 }
 

--- a/internal/agent/gateway_test.go
+++ b/internal/agent/gateway_test.go
@@ -464,6 +464,7 @@ func TestProtectedSystemGatewayAcceptsCompleteSystemRoutes(t *testing.T) {
 		)
 	}
 	desired.Routes = append(desired.Routes, gateway.Route{ID: "system-agent-bootstrap", Hostname: "headscale.example.test", Path: "/install/agent.sh", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "public", System: true})
+	desired.Routes = append(desired.Routes, gateway.Route{ID: "system-agent-binary-bootstrap", Hostname: "headscale.example.test", Path: "/api/v1/agent-binaries/*", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "public", System: true})
 	if err := validateProtectedSystemRoutes(desired, []string{"center", "headscale"}); err != nil {
 		t.Fatalf("complete protected system state was rejected: %v", err)
 	}

--- a/internal/agent/inspection.go
+++ b/internal/agent/inspection.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+)
+
+// ConnectionSummary contains only non-secret enrollment metadata and opens the
+// Agent database read-only. Installers use it before migration approval so an
+// inspection can never initialize or migrate local state.
+type ConnectionSummary struct {
+	AgentID   string
+	Name      string
+	CenterURL string
+}
+
+func InspectConnection(dataDir string) (ConnectionSummary, error) {
+	absolute, err := filepath.Abs(dataDir)
+	if err != nil {
+		return ConnectionSummary{}, fmt.Errorf("agent: resolve data directory: %w", err)
+	}
+	dsn := (&url.URL{Scheme: "file", Path: filepath.Join(absolute, "agent.db"), RawQuery: "mode=ro"}).String()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return ConnectionSummary{}, fmt.Errorf("agent: inspect state: %w", err)
+	}
+	defer db.Close()
+	var summary ConnectionSummary
+	err = db.QueryRow(`SELECT agent_id, name, center_url FROM control_plane_connection WHERE id = 1`).Scan(&summary.AgentID, &summary.Name, &summary.CenterURL)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ConnectionSummary{}, errors.New("agent: not enrolled")
+	}
+	if err != nil {
+		return ConnectionSummary{}, fmt.Errorf("agent: inspect Center connection: %w", err)
+	}
+	return summary, nil
+}

--- a/internal/agent/inspection_test.go
+++ b/internal/agent/inspection_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInspectConnectionIsReadOnlyAndExcludesCredential(t *testing.T) {
+	directory := t.TempDir()
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "agent-1", Name: "edge", CenterURL: "https://center.example.com", Credential: "secret-credential"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(filepath.Join(directory, "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary, err := InspectConnection(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(filepath.Join(directory, "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.AgentID != "agent-1" || summary.Name != "edge" || summary.CenterURL != "https://center.example.com" {
+		t.Fatalf("connection summary = %#v", summary)
+	}
+	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("read-only inspection changed the Agent database: before=%v after=%v", before, after)
+	}
+}
+
+func TestInspectConnectionDoesNotCreateState(t *testing.T) {
+	directory := t.TempDir()
+	if _, err := InspectConnection(directory); err == nil {
+		t.Fatal("missing Agent state was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(directory, "agent.db")); !os.IsNotExist(err) {
+		t.Fatalf("inspection created Agent state: %v", err)
+	}
+}

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -273,12 +273,9 @@ func (s *Store) ClearGatewayState(ctx context.Context) error {
 }
 
 func (s *Store) SaveConnection(ctx context.Context, connection Connection) error {
-	if strings.TrimSpace(connection.AgentID) == "" || strings.TrimSpace(connection.Name) == "" || strings.TrimSpace(connection.CenterURL) == "" || connection.Credential == "" {
-		return errors.New("agent: incomplete Center connection")
-	}
-	sealed, err := secret.Seal(s.key, []byte(connection.Credential), []byte("agent-control-plane:"+connection.AgentID))
+	sealed, err := s.sealConnection(connection)
 	if err != nil {
-		return fmt.Errorf("agent: encrypt Center credential: %w", err)
+		return err
 	}
 	result, err := s.db.ExecContext(ctx, `INSERT INTO control_plane_connection(id, agent_id, name, center_url, sealed_credential) VALUES(1, ?, ?, ?, ?) ON CONFLICT(id) DO NOTHING`, connection.AgentID, connection.Name, connection.CenterURL, sealed)
 	if err != nil {
@@ -292,6 +289,36 @@ func (s *Store) SaveConnection(ctx context.Context, connection Connection) error
 		return errors.New("agent: already enrolled; clear the Agent data directory before enrolling again")
 	}
 	return nil
+}
+
+// ReplaceConnection changes only the control-plane identity. Application,
+// gateway, and recovery state remain intact so an explicitly approved Center
+// migration cannot stop or forget locally managed workloads.
+func (s *Store) ReplaceConnection(ctx context.Context, connection Connection) error {
+	sealed, err := s.sealConnection(connection)
+	if err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO control_plane_connection(id, agent_id, name, center_url, sealed_credential)
+		VALUES(1, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET agent_id = excluded.agent_id, name = excluded.name, center_url = excluded.center_url, sealed_credential = excluded.sealed_credential`, connection.AgentID, connection.Name, connection.CenterURL, sealed); err != nil {
+		return fmt.Errorf("agent: replace Center connection: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) sealConnection(connection Connection) ([]byte, error) {
+	connection.AgentID = strings.TrimSpace(connection.AgentID)
+	connection.Name = strings.TrimSpace(connection.Name)
+	connection.CenterURL = strings.TrimSpace(connection.CenterURL)
+	if connection.AgentID == "" || connection.Name == "" || connection.CenterURL == "" || connection.Credential == "" {
+		return nil, errors.New("agent: incomplete Center connection")
+	}
+	sealed, err := secret.Seal(s.key, []byte(connection.Credential), []byte("agent-control-plane:"+connection.AgentID))
+	if err != nil {
+		return nil, fmt.Errorf("agent: encrypt Center credential: %w", err)
+	}
+	return sealed, nil
 }
 
 func (s *Store) Connection(ctx context.Context) (Connection, error) {

--- a/internal/center/agent_install.go
+++ b/internal/center/agent_install.go
@@ -35,8 +35,8 @@ if [ "$(id -u)" -ne 0 ]; then
   exec sudo "$0" "$token"
 fi
 
-center_url=@@CENTER_URL@@
-case "$center_url" in
+bootstrap_url=@@CENTER_URL@@
+case "$bootstrap_url" in
   https://*) curl_protocol="https" ;;
   http://127.0.0.1:*|http://127.0.0.1|http://localhost:*|http://localhost) curl_protocol="http" ;;
   *) echo "Center must use HTTPS; only loopback development addresses may use HTTP." >&2; exit 1 ;;
@@ -46,7 +46,7 @@ installer="$(mktemp -t vastora-agent-installer.XXXXXX)"
 trap 'rm -f "$installer"' EXIT HUP INT TERM
 curl --proto "=$curl_protocol" --tlsv1.2 --max-filesize 1048576 -fsS \
   -H "Authorization: Bearer $token" \
-  "${center_url%/}/install/agent.sh" -o "$installer"
+  "${bootstrap_url%/}/install/agent.sh" -o "$installer"
 printf '%s\n' "$token" | sh "$installer"
 `
 
@@ -54,6 +54,7 @@ const agentInstallScript = `#!/bin/sh
 set -eu
 
 center_url=@@CENTER_URL@@
+bootstrap_url=@@BOOTSTRAP_URL@@
 IFS= read -r token
 if [ -z "$token" ]; then
   echo "The one-time Agent token is required." >&2
@@ -82,12 +83,10 @@ case "$(uname -m)" in
   *) echo "Vastora Agent supports Ubuntu 24.04 on x86_64 and ARM64." >&2; exit 1 ;;
 esac
 
-@@HEADSCALE_BOOTSTRAP@@
-
 temporary="$(mktemp -t vastora-agent.XXXXXX)"
 headers="$(mktemp -t vastora-agent-headers.XXXXXX)"
 trap 'rm -f "$temporary" "$headers"' EXIT HUP INT TERM
-case "$center_url" in
+case "$bootstrap_url" in
   https://*) curl_protocol="https" ;;
   http://127.0.0.1:*|http://127.0.0.1|http://localhost:*|http://localhost) curl_protocol="http" ;;
   *) echo "Center must use HTTPS; only loopback development addresses may use HTTP." >&2; exit 1 ;;
@@ -95,7 +94,7 @@ esac
 echo "Downloading the Vastora Agent for $arch..."
 curl --proto "=$curl_protocol" --tlsv1.2 --max-filesize 268435456 -fsS \
   -D "$headers" -H "Authorization: Bearer $token" \
-  "${center_url%/}/api/v1/agent-binaries/linux/$arch" -o "$temporary"
+  "${bootstrap_url%/}/api/v1/agent-binaries/linux/$arch" -o "$temporary"
 expected_digest="$(awk 'tolower($1) == "x-vastora-sha256:" {gsub("\\r", "", $2); value=tolower($2)} END {print value}' "$headers")"
 expected_version="$(awk 'tolower($1) == "x-vastora-version:" {sub("^[^:]*:[[:space:]]*", ""); gsub("\\r", ""); value=$0} END {print value}' "$headers")"
 actual_digest="$(sha256sum "$temporary" | awk '{print tolower($1)}')"
@@ -108,16 +107,69 @@ if [ -z "$expected_version" ] || [ "$("$temporary" version)" != "$expected_versi
   echo "The downloaded Agent failed its version check." >&2
   exit 1
 fi
+
+replace_existing=0
+if [ -s /var/lib/vastora/agent/agent.db ] || systemctl is-enabled --quiet vastora-agent.service 2>/dev/null || systemctl is-active --quiet vastora-agent.service 2>/dev/null; then
+  if ! existing_status="$("$temporary" agent status --data-dir /var/lib/vastora/agent 2>&1)"; then
+    echo "An existing Vastora Agent was found, but its Center registration could not be inspected." >&2
+    echo "$existing_status" >&2
+    echo "The existing Agent was not changed." >&2
+    exit 1
+  fi
+  printf '%s\n' "This server is already registered with a Center:" >&2
+  printf '%s\n' "$existing_status" >&2
+  printf '%s\n' "Requested Center: $center_url" >&2
+  printf '%s\n' "Switching keeps running Docker apps and local Agent state, but does not copy their records from the previous Center." >&2
+  if ! ( : </dev/tty ) 2>/dev/null; then
+    echo "Interactive confirmation is required to switch an existing Agent." >&2
+    exit 1
+  fi
+  printf 'Switch this Agent to the requested Center? [y/N] ' >/dev/tty
+  IFS= read -r answer </dev/tty
+  case "$answer" in
+    y|Y|yes|Yes|YES) replace_existing=1 ;;
+    *) echo "The existing Agent was not changed." >&2; exit 0 ;;
+  esac
+fi
+
+@@HEADSCALE_BOOTSTRAP@@
+
+case "$center_url" in
+  https://*) center_protocol="https" ;;
+  http://127.0.0.1:*|http://127.0.0.1|http://localhost:*|http://localhost) center_protocol="http" ;;
+  *) echo "Center must use HTTPS; only loopback development addresses may use HTTP." >&2; exit 1 ;;
+esac
+echo "Waiting for the requested Center to become reachable..."
+center_ready=0
+attempt=1
+while [ "$attempt" -le 15 ]; do
+  if curl --proto "=$center_protocol" --tlsv1.2 --max-filesize 1048576 -fs \
+    -H "Authorization: Bearer $token" "${center_url%/}/install/agent.sh" -o /dev/null 2>/dev/null; then
+    center_ready=1
+    break
+  fi
+  attempt=$((attempt + 1))
+  sleep 2
+done
+if [ "$center_ready" -ne 1 ]; then
+  echo "The requested Center did not become reachable after joining the private network. The existing Agent was not migrated." >&2
+  exit 1
+fi
+
 install -m 0755 "$temporary" /usr/local/bin/vastora
 echo "Registering this node and starting the system service..."
-printf '%s' "$token" | /usr/local/bin/vastora agent install --center-url "$center_url" --token-file -
+if [ "$replace_existing" -eq 1 ]; then
+  printf '%s' "$token" | /usr/local/bin/vastora agent install --center-url "$center_url" --token-file - --replace-existing
+else
+  printf '%s' "$token" | /usr/local/bin/vastora agent install --center-url "$center_url" --token-file -
+fi
 `
 
 func renderAgentInstallLoader(centerURL string) string {
 	return strings.ReplaceAll(agentInstallLoaderScript, "@@CENTER_URL@@", shellQuote(centerURL))
 }
 
-func renderAgentInstallScript(profile AgentEnrollmentInstallProfile) string {
+func renderAgentInstallScript(profile AgentEnrollmentInstallProfile, bootstrapURL string) string {
 	headscaleBootstrap := ":"
 	if profile.HeadscaleCommand != "" {
 		headscaleBootstrap = `tailscale_version=@@TAILSCALE_VERSION@@
@@ -149,6 +201,7 @@ echo "Joining the private network..."
 	}
 	return strings.NewReplacer(
 		"@@CENTER_URL@@", shellQuote(profile.CenterURL),
+		"@@BOOTSTRAP_URL@@", shellQuote(bootstrapURL),
 		"@@HEADSCALE_BOOTSTRAP@@", headscaleBootstrap,
 	).Replace(agentInstallScript)
 }
@@ -203,9 +256,14 @@ func (s *Server) handleAgentInstallScript(writer http.ResponseWriter, request *h
 		writeError(writer, http.StatusUnauthorized, err)
 		return
 	}
+	bootstrapURL, err := agentInstallerRequestURL(request)
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, err)
+		return
+	}
 	writer.Header().Set("Content-Type", "text/x-shellscript; charset=utf-8")
 	writer.Header().Set("Content-Disposition", `attachment; filename="vastora-agent-install.sh"`)
-	_, _ = writer.Write([]byte(renderAgentInstallScript(profile)))
+	_, _ = writer.Write([]byte(renderAgentInstallScript(profile, bootstrapURL)))
 }
 
 func agentInstallerRequestURL(request *http.Request) (string, error) {

--- a/internal/center/agent_install_test.go
+++ b/internal/center/agent_install_test.go
@@ -134,7 +134,7 @@ func TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload(t *testing.T) {
 		t.Fatalf("public installer status = %d", response.Code)
 	}
 	loader := response.Body.String()
-	for _, expected := range []string{"token=\"${1:-}\"", "exec sudo \"$0\" \"$token\"", "center_url='https://center.example.com'", "Authorization: Bearer $token", "${center_url%/}/install/agent.sh", "printf '%s\\n' \"$token\" | sh \"$installer\""} {
+	for _, expected := range []string{"token=\"${1:-}\"", "exec sudo \"$0\" \"$token\"", "bootstrap_url='https://center.example.com'", "Authorization: Bearer $token", "${bootstrap_url%/}/install/agent.sh", "printf '%s\\n' \"$token\" | sh \"$installer\""} {
 		if !strings.Contains(loader, expected) {
 			t.Fatalf("installer loader is missing %q:\n%s", expected, loader)
 		}
@@ -151,7 +151,7 @@ func TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload(t *testing.T) {
 		t.Fatalf("authenticated installer status = %d, body = %q", response.Code, response.Body.String())
 	}
 	script := response.Body.String()
-	for _, expected := range []string{"center_url='https://center.example.com'", "IFS= read -r token", "command -v \"$required\"", "docker info", "sha256sum", "x86_64|amd64", "aarch64|arm64", "supports Ubuntu 24.04 on x86_64 and ARM64", "--proto \"=$curl_protocol\"", "--max-filesize 268435456", "Authorization: Bearer $token", "${center_url%/}/api/v1/agent-binaries/linux/$arch", "x-vastora-sha256:", "failed its SHA-256 integrity check", "failed its version check", "install -m 0755", "agent install --center-url \"$center_url\" --token-file -"} {
+	for _, expected := range []string{"center_url='https://center.example.com'", "bootstrap_url='https://center.example.com'", "IFS= read -r token", "command -v \"$required\"", "docker info", "sha256sum", "x86_64|amd64", "aarch64|arm64", "supports Ubuntu 24.04 on x86_64 and ARM64", "--proto \"=$curl_protocol\"", "--max-filesize 268435456", "Authorization: Bearer $token", "${bootstrap_url%/}/api/v1/agent-binaries/linux/$arch", "agent status --data-dir /var/lib/vastora/agent", "Switch this Agent to the requested Center? [y/N]", "Waiting for the requested Center to become reachable", "${center_url%/}/install/agent.sh", "--replace-existing", "x-vastora-sha256:", "failed its SHA-256 integrity check", "failed its version check", "install -m 0755", "agent install --center-url \"$center_url\" --token-file -"} {
 		if !strings.Contains(script, expected) {
 			t.Fatalf("installer is missing %q:\n%s", expected, script)
 		}
@@ -183,7 +183,7 @@ func TestAgentInstallScriptInstallsTailscaleBeforeJoiningHeadscale(t *testing.T)
 	script := renderAgentInstallScript(AgentEnrollmentInstallProfile{
 		CenterURL:        "https://center.example.com",
 		HeadscaleCommand: "sudo tailscale up --login-server 'https://headscale.example.com' --auth-key 'one-time-key' --reset",
-	})
+	}, "https://headscale.example.com")
 	for _, expected := range []string{
 		"tailscale_version='1.102.3'",
 		"Installing Tailscale $tailscale_version...",
@@ -202,6 +202,9 @@ func TestAgentInstallScriptInstallsTailscaleBeforeJoiningHeadscale(t *testing.T)
 	}
 	if strings.Contains(script, "Tailscale must be installed before") {
 		t.Fatal("private-network installer still requires Tailscale to be installed manually")
+	}
+	if download, prompt, join := strings.Index(script, "Downloading the Vastora Agent"), strings.Index(script, "Switch this Agent to the requested Center?"), strings.Index(script, "Joining the private network"); download < 0 || prompt < download || join < prompt {
+		t.Fatalf("installer does not inspect and confirm an existing Agent before changing Headscale:\n%s", script)
 	}
 	command := exec.Command("sh", "-n")
 	command.Stdin = strings.NewReader(script)

--- a/internal/center/certificates.go
+++ b/internal/center/certificates.go
@@ -33,18 +33,36 @@ type managedCertificate struct {
 }
 
 func (s *Store) obtainPrivateCertificate(ctx context.Context, requestedNames ...string) (managedCertificate, error) {
-	names, err := normalizeCertificateDNSNames(requestedNames)
-	if err != nil {
-		return managedCertificate{}, err
-	}
-	s.certificateMu.Lock()
-	defer s.certificateMu.Unlock()
-
 	cloudflare, err := s.cloudflare(ctx)
 	if err != nil {
 		return managedCertificate{}, errors.New("center: connect Cloudflare before enabling trusted private HTTPS")
 	}
-	client, err := s.acmeClient(ctx)
+	var zoneName string
+	if err := s.db.QueryRowContext(ctx, `SELECT endpoint FROM network_integrations WHERE kind = 'cloudflare' AND status = 'configured'`).Scan(&zoneName); err != nil {
+		return managedCertificate{}, errors.New("center: connect Cloudflare before enabling trusted private HTTPS")
+	}
+	return s.obtainPrivateCertificateWithCloudflare(ctx, cloudflare, zoneName, requestedNames...)
+}
+
+func (s *Store) obtainPrivateCertificateWithCloudflare(ctx context.Context, cloudflare cloudflareClient, zoneName string, requestedNames ...string) (managedCertificate, error) {
+	names, err := normalizeCertificateDNSNames(requestedNames)
+	if err != nil {
+		return managedCertificate{}, err
+	}
+	zoneName = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(zoneName), "."))
+	if !domainSuffixPattern.MatchString(zoneName) {
+		return managedCertificate{}, errors.New("center: Cloudflare Zone is invalid")
+	}
+	for _, name := range names {
+		base := strings.TrimPrefix(name, "*.")
+		if base != zoneName && !strings.HasSuffix(base, "."+zoneName) {
+			return managedCertificate{}, fmt.Errorf("center: certificate hostname %s is outside the selected Cloudflare Zone %s", name, zoneName)
+		}
+	}
+	s.certificateMu.Lock()
+	defer s.certificateMu.Unlock()
+
+	client, err := s.acmeClient(ctx, zoneName)
 	if err != nil {
 		return managedCertificate{}, err
 	}
@@ -182,7 +200,7 @@ func certificateCoversNames(certificate *x509.Certificate, names []string) bool 
 	return true
 }
 
-func (s *Store) acmeClient(ctx context.Context) (*acme.Client, error) {
+func (s *Store) acmeClient(ctx context.Context, zoneName string) (*acme.Client, error) {
 	var accountURI, secretID string
 	err := s.db.QueryRowContext(ctx, `SELECT account_uri, secret_id FROM certificate_authorities WHERE id = ?`, letsencryptAccountID).Scan(&accountURI, &secretID)
 	if err == nil {
@@ -203,8 +221,8 @@ func (s *Store) acmeClient(ctx context.Context) (*acme.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("center: generate ACME account key: %w", err)
 	}
-	var zoneName string
-	if err := s.db.QueryRowContext(ctx, `SELECT endpoint FROM network_integrations WHERE kind = 'cloudflare' AND status = 'configured'`).Scan(&zoneName); err != nil {
+	zoneName = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(zoneName), "."))
+	if !domainSuffixPattern.MatchString(zoneName) {
 		return nil, errors.New("center: connect Cloudflare before enabling trusted private HTTPS")
 	}
 	client := &acme.Client{Key: key, DirectoryURL: acme.LetsEncryptURL, UserAgent: "Vastora/" + Version}
@@ -294,11 +312,30 @@ func (s *Store) gatewayCertificates(ctx context.Context, tx *sql.Tx, gatewayID s
 		if err != nil {
 			return nil, err
 		}
+		primaryHostname := hostname
 		certificate, err := s.loadSystemCenterCertificate(ctx, tx, "", hostname)
 		if err != nil {
 			return nil, err
 		}
 		values = append(values, gateway.Certificate{Hostname: hostname, CertificatePEM: certificate.CertificatePEM, PrivateKeyPEM: certificate.PrivateKeyPEM})
+		aliases, err := readSystemEndpointAliases(ctx, tx, "center")
+		if err != nil {
+			return nil, err
+		}
+		for _, alias := range aliases {
+			hostname, err := gatewayEndpointHostname(alias.Endpoint)
+			if err != nil {
+				return nil, err
+			}
+			if hostname == primaryHostname {
+				continue
+			}
+			certificate, err := s.loadSystemCenterCertificate(ctx, tx, alias.CertificateSecretID, hostname)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, gateway.Certificate{Hostname: hostname, CertificatePEM: certificate.CertificatePEM, PrivateKeyPEM: certificate.PrivateKeyPEM})
+		}
 	}
 	siteCertificates, err := s.gatewaySiteCertificates(ctx, tx, gatewayID)
 	if err != nil {

--- a/internal/center/cloudflare_oauth.go
+++ b/internal/center/cloudflare_oauth.go
@@ -230,37 +230,12 @@ func (s *Store) PollCloudflareOAuth(ctx context.Context, sessionID string) (Clou
 }
 
 func (s *Store) CompleteCloudflareOAuth(ctx context.Context, sessionID, zoneID string) (IntegrationView, error) {
-	sessionID = strings.TrimSpace(sessionID)
-	zoneID = strings.TrimSpace(zoneID)
-	s.cloudflareOAuthMu.Lock()
-	s.cleanupCloudflareOAuthSessionsLocked(s.now().UTC())
-	session := s.cloudflareOAuthSessions[sessionID]
-	if session == nil || session.Token.AccessToken == "" {
-		s.cloudflareOAuthMu.Unlock()
-		return IntegrationView{}, errors.New("center: Cloudflare authorization is not complete")
-	}
-	var selected CloudflareZone
-	for _, zone := range session.Zones {
-		if zone.ID == zoneID {
-			selected = zone
-			break
-		}
-	}
-	token := session.Token
-	s.cloudflareOAuthMu.Unlock()
-	if selected.ID == "" {
-		return IntegrationView{}, errors.New("center: selected Cloudflare zone was not authorized")
+	sessionID, selected, token, err := s.cloudflareOAuthSelection(sessionID, zoneID)
+	if err != nil {
+		return IntegrationView{}, err
 	}
 	client := cloudflareClient{accountID: selected.AccountID, zoneID: selected.ID, token: token.AccessToken, baseURL: s.cloudflareOAuth.APIURL, http: s.cloudflareOAuth.HTTPClient}
 	zoneName, err := client.verify(ctx)
-	if err != nil {
-		return IntegrationView{}, err
-	}
-	encoded, err := json.Marshal(token)
-	if err != nil {
-		return IntegrationView{}, err
-	}
-	existingSecretID, _, err := s.integrationSecret(ctx, "cloudflare")
 	if err != nil {
 		return IntegrationView{}, err
 	}
@@ -269,20 +244,8 @@ func (s *Store) CompleteCloudflareOAuth(ctx context.Context, sessionID, zoneID s
 		return IntegrationView{}, err
 	}
 	defer tx.Rollback()
-	secretID, err := s.putSecret(ctx, tx, encoded, "integration:cloudflare")
-	if err != nil {
+	if err := s.saveCloudflareOAuthIntegrationTx(ctx, tx, selected, token, zoneName); err != nil {
 		return IntegrationView{}, err
-	}
-	now := s.now().UTC().Format(time.RFC3339Nano)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO network_integrations(kind, mode, endpoint, account_id, zone_id, secret_id, status, created_at, updated_at)
-		VALUES('cloudflare', 'oauth', ?, ?, ?, ?, 'configured', ?, ?)
-		ON CONFLICT(kind) DO UPDATE SET mode = 'oauth', endpoint = excluded.endpoint, account_id = excluded.account_id, zone_id = excluded.zone_id, secret_id = excluded.secret_id, status = 'configured', last_error = '', updated_at = excluded.updated_at`, zoneName, selected.AccountID, selected.ID, secretID, now, now); err != nil {
-		return IntegrationView{}, fmt.Errorf("center: save Cloudflare OAuth integration: %w", err)
-	}
-	if existingSecretID != "" && existingSecretID != secretID {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id = ?`, existingSecretID); err != nil {
-			return IntegrationView{}, err
-		}
 	}
 	if err := tx.Commit(); err != nil {
 		return IntegrationView{}, err
@@ -291,6 +254,52 @@ func (s *Store) CompleteCloudflareOAuth(ctx context.Context, sessionID, zoneID s
 	delete(s.cloudflareOAuthSessions, sessionID)
 	s.cloudflareOAuthMu.Unlock()
 	return s.Integration(ctx, "cloudflare")
+}
+
+func (s *Store) saveCloudflareOAuthIntegrationTx(ctx context.Context, tx *sql.Tx, selected CloudflareZone, token cloudflareOAuthToken, zoneName string) error {
+	encoded, err := json.Marshal(token)
+	if err != nil {
+		return err
+	}
+	secretID, err := s.putSecret(ctx, tx, encoded, "integration:cloudflare")
+	if err != nil {
+		return err
+	}
+	var existingSecretID string
+	err = tx.QueryRowContext(ctx, `SELECT COALESCE(secret_id, '') FROM network_integrations WHERE kind = 'cloudflare'`).Scan(&existingSecretID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("center: read existing Cloudflare integration: %w", err)
+	}
+	now := s.now().UTC().Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO network_integrations(kind, mode, endpoint, account_id, zone_id, secret_id, status, created_at, updated_at)
+		VALUES('cloudflare', 'oauth', ?, ?, ?, ?, 'configured', ?, ?)
+		ON CONFLICT(kind) DO UPDATE SET mode = 'oauth', endpoint = excluded.endpoint, account_id = excluded.account_id, zone_id = excluded.zone_id, secret_id = excluded.secret_id, status = 'configured', last_error = '', updated_at = excluded.updated_at`, zoneName, selected.AccountID, selected.ID, secretID, now, now); err != nil {
+		return fmt.Errorf("center: save Cloudflare OAuth integration: %w", err)
+	}
+	if existingSecretID != "" && existingSecretID != secretID {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id = ?`, existingSecretID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) cloudflareOAuthSelection(sessionID, zoneID string) (string, CloudflareZone, cloudflareOAuthToken, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	zoneID = strings.TrimSpace(zoneID)
+	s.cloudflareOAuthMu.Lock()
+	defer s.cloudflareOAuthMu.Unlock()
+	s.cleanupCloudflareOAuthSessionsLocked(s.now().UTC())
+	session := s.cloudflareOAuthSessions[sessionID]
+	if session == nil || session.Token.AccessToken == "" {
+		return "", CloudflareZone{}, cloudflareOAuthToken{}, errors.New("center: Cloudflare authorization is not complete")
+	}
+	for _, zone := range session.Zones {
+		if zone.ID == zoneID {
+			return sessionID, zone, session.Token, nil
+		}
+	}
+	return "", CloudflareZone{}, cloudflareOAuthToken{}, errors.New("center: selected Cloudflare zone was not authorized")
 }
 
 func (s *Store) ConfigureSetupDNS(ctx context.Context, input SetupDNSInput, candidates []networking.Candidate) ([]SetupDNSRecord, error) {

--- a/internal/center/headscale.go
+++ b/internal/center/headscale.go
@@ -275,6 +275,10 @@ func (s *Store) authorizedHeadscaleEndpoint(value string) (string, error) {
 }
 
 func (s *Store) reconcileHeadscaleDNS(ctx context.Context) error {
+	return s.reconcileHeadscaleDNSForSystem(ctx, "", nil)
+}
+
+func (s *Store) reconcileHeadscaleDNSForSystem(ctx context.Context, primaryCenterEndpoint string, additionalCenterEndpoints []string) error {
 	var mode string
 	if err := s.db.QueryRowContext(ctx, `SELECT mode FROM network_integrations WHERE kind = 'headscale' AND status = 'configured'`).Scan(&mode); errors.Is(err, sql.ErrNoRows) {
 		return errors.New("center: Headscale integration is not configured")
@@ -294,18 +298,32 @@ func (s *Store) reconcileHeadscaleDNS(ctx context.Context) error {
 	modeErr := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, agentConnectionModeSetting).Scan(&connectionMode)
 	endpointErr := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, agentConnectURLSetting).Scan(&centerEndpoint)
 	if modeErr == nil && endpointErr == nil && connectionMode == "headscale" {
+		if strings.TrimSpace(primaryCenterEndpoint) != "" {
+			centerEndpoint = primaryCenterEndpoint
+		}
 		if centerAddress, err := s.coLocatedHeadscaleAddress(ctx); err != nil {
 			return err
 		} else if centerAddress != "" {
-			hostname, err := gatewayEndpointHostname(centerEndpoint)
-			if err != nil {
-				return err
-			}
 			recordType := "A"
 			if strings.Contains(centerAddress, ":") {
 				recordType = "AAAA"
 			}
-			records = append(records, record{Name: hostname, Type: recordType, Value: centerAddress})
+			endpoints := []string{centerEndpoint}
+			aliases, err := readSystemEndpointAliases(ctx, s.db, "center")
+			if err != nil {
+				return err
+			}
+			for _, alias := range aliases {
+				endpoints = append(endpoints, alias.Endpoint)
+			}
+			endpoints = append(endpoints, additionalCenterEndpoints...)
+			for _, endpoint := range endpoints {
+				hostname, err := gatewayEndpointHostname(endpoint)
+				if err != nil {
+					return err
+				}
+				records = append(records, record{Name: hostname, Type: recordType, Value: centerAddress})
+			}
 		}
 	} else if (modeErr != nil && !errors.Is(modeErr, sql.ErrNoRows)) || (endpointErr != nil && !errors.Is(endpointErr, sql.ErrNoRows)) {
 		return errors.Join(modeErr, endpointErr)
@@ -333,6 +351,17 @@ func (s *Store) reconcileHeadscaleDNS(ctx context.Context) error {
 	if err := rows.Close(); err != nil {
 		return err
 	}
+	unique := make([]record, 0, len(records))
+	seen := make(map[string]struct{}, len(records))
+	for _, value := range records {
+		key := value.Name + "\x00" + value.Type + "\x00" + value.Value
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, value)
+	}
+	records = unique
 	sort.Slice(records, func(i, j int) bool {
 		if records[i].Name == records[j].Name {
 			return records[i].Value < records[j].Value

--- a/internal/center/headscale_deployer_test.go
+++ b/internal/center/headscale_deployer_test.go
@@ -208,7 +208,7 @@ func TestReconcileBuiltinHeadscaleAppliesAnOlderRuntimeOnce(t *testing.T) {
 	if err := server.ReconcileBuiltinHeadscale(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if installer.reconcileInput != (deployapi.HeadscaleInstallRequest{}) {
+	if installer.reconcileInput.CenterURL != "" || installer.reconcileInput.HeadscaleURL != "" {
 		t.Fatal("current built-in runtime was reconciled again")
 	}
 }

--- a/internal/center/migrations/00021_system_endpoint_aliases.sql
+++ b/internal/center/migrations/00021_system_endpoint_aliases.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+CREATE TABLE system_endpoint_aliases (
+    kind TEXT NOT NULL CHECK(kind IN ('center', 'headscale')),
+    endpoint TEXT NOT NULL,
+    certificate_secret_id TEXT REFERENCES secrets(id) ON DELETE RESTRICT,
+    certificate_not_after TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY(kind, endpoint)
+);
+
+PRAGMA user_version = 21;

--- a/internal/center/migrations_test.go
+++ b/internal/center/migrations_test.go
@@ -705,6 +705,7 @@ func createLegacyVersion3Database(t *testing.T, directory string) {
 		`DROP TABLE three_x_ui_migrations`,
 		`DROP TABLE three_x_ui_backups`,
 		`DROP TABLE three_x_ui_nodes`,
+		`DROP TABLE system_endpoint_aliases`,
 		`DROP INDEX applications_one_three_x_ui_master_idx`,
 		`ALTER TABLE agents DROP COLUMN operating_system`,
 		`ALTER TABLE agents DROP COLUMN architecture`,

--- a/internal/center/orchestration_test.go
+++ b/internal/center/orchestration_test.go
@@ -512,7 +512,7 @@ func TestCoLocatedGatewayDesiredStateOwnsBundledSystemRoutes(t *testing.T) {
 	if task.Kind != "gateway.routes.apply" || task.GatewayState == nil {
 		t.Fatalf("co-located gateway did not receive system desired state: %#v", task)
 	}
-	if len(task.GatewayState.Routes) != 5 || len(task.GatewayState.Listeners) != 3 {
+	if len(task.GatewayState.Routes) != 6 || len(task.GatewayState.Listeners) != 3 {
 		t.Fatalf("unexpected system gateway state: %#v", task.GatewayState)
 	}
 	for _, route := range task.GatewayState.Routes {

--- a/internal/center/schema.go
+++ b/internal/center/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const centerSchemaVersion = 20
+const centerSchemaVersion = 21
 
 func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
@@ -326,6 +326,15 @@ func (s *Store) initializeCurrentSchema(ctx context.Context) error {
 			last_error TEXT NOT NULL DEFAULT '',
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE system_endpoint_aliases (
+			kind TEXT NOT NULL CHECK(kind IN ('center', 'headscale')),
+			endpoint TEXT NOT NULL,
+			certificate_secret_id TEXT REFERENCES secrets(id) ON DELETE RESTRICT,
+			certificate_not_after TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY(kind, endpoint)
 		)`,
 		`CREATE TABLE application_secrets (
 			application_id TEXT PRIMARY KEY REFERENCES applications(id) ON DELETE CASCADE,

--- a/internal/center/server.go
+++ b/internal/center/server.go
@@ -85,6 +85,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/v1/diagnostics", s.requireAuth(false, s.handleDiagnostics))
 	mux.HandleFunc("GET /api/v1/system/update", s.requireAuth(false, s.handleCenterUpdateStatus))
 	mux.HandleFunc("POST /api/v1/system/update", s.requireAuth(true, s.handleStartCenterUpdate))
+	mux.HandleFunc("GET /api/v1/system/domain", s.requireAuth(false, s.handleSystemDomain))
+	mux.HandleFunc("POST /api/v1/system/domain", s.requireAuth(true, s.handleSwitchSystemDomain))
 	mux.HandleFunc("POST /api/v1/backups", s.requireAuth(true, s.handleCreateBackup))
 	mux.HandleFunc("GET /api/v1/deployments", s.requireAuth(false, s.handleListDeployments))
 	mux.HandleFunc("POST /api/v1/deployments", s.requireAuth(true, s.handleCreateDeployment))

--- a/internal/center/server_agent.go
+++ b/internal/center/server_agent.go
@@ -163,7 +163,12 @@ func (s *Server) handleAgentHeartbeat(writer http.ResponseWriter, request *http.
 		writeError(writer, http.StatusUnauthorized, err)
 		return
 	}
-	writeJSON(writer, http.StatusOK, map[string]bool{"connected": true})
+	network, err := s.store.CenterNetworkConfig(request.Context())
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"connected": true, "centerUrl": network.AgentConnectURL})
 }
 
 func (s *Server) handleClaimTask(writer http.ResponseWriter, request *http.Request) {

--- a/internal/center/server_integrations.go
+++ b/internal/center/server_integrations.go
@@ -61,6 +61,29 @@ func (s *Server) handleCompleteCloudflareOAuth(writer http.ResponseWriter, reque
 	writeJSON(writer, http.StatusOK, value)
 }
 
+func (s *Server) handleSystemDomain(writer http.ResponseWriter, request *http.Request) {
+	value, err := s.store.SystemDomain(request.Context())
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, value)
+}
+
+func (s *Server) handleSwitchSystemDomain(writer http.ResponseWriter, request *http.Request) {
+	var input SystemDomainSwitchInput
+	if err := decodeJSON(request, &input); err != nil {
+		writeError(writer, http.StatusBadRequest, err)
+		return
+	}
+	value, err := s.SwitchSystemDomain(request.Context(), input)
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, value)
+}
+
 func (s *Server) handleConfigureSetupDNS(writer http.ResponseWriter, request *http.Request) {
 	var input SetupDNSInput
 	if err := decodeJSON(request, &input); err != nil {
@@ -117,9 +140,15 @@ func (s *Server) configureHeadscale(ctx context.Context, input HeadscaleInput, c
 	if err != nil {
 		return IntegrationView{}, err
 	}
+	centerAliases, headscaleAliases, err := s.store.deploymentEndpointAliases(ctx)
+	if err != nil {
+		return IntegrationView{}, err
+	}
 	result, err := s.infrastructure.InstallHeadscale(ctx, deployapi.HeadscaleInstallRequest{
 		CenterURL:               centerURL,
 		HeadscaleURL:            input.URL,
+		CenterAliases:           centerAliases,
+		HeadscaleAliases:        headscaleAliases,
 		PublicAddress:           binding.PublicAddress,
 		GatewayBindAddress:      binding.BindAddress,
 		CenterCertificatePEM:    centerCertificate.CertificatePEM,
@@ -168,9 +197,15 @@ func (s *Server) ReconcileBuiltinHeadscale(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	centerAliases, headscaleAliases, err := s.store.deploymentEndpointAliases(ctx)
+	if err != nil {
+		return err
+	}
 	if err := s.infrastructure.ReconcileHeadscale(ctx, deployapi.HeadscaleInstallRequest{
 		CenterURL:               network.AgentConnectURL,
 		HeadscaleURL:            endpoint,
+		CenterAliases:           centerAliases,
+		HeadscaleAliases:        headscaleAliases,
 		PublicAddress:           binding.PublicAddress,
 		GatewayBindAddress:      binding.BindAddress,
 		CenterCertificatePEM:    centerCertificate.CertificatePEM,

--- a/internal/center/store.go
+++ b/internal/center/store.go
@@ -35,6 +35,7 @@ type Store struct {
 	cloudflareOAuthSessions        map[string]*cloudflareOAuthSession
 	cloudflareTokenMu              sync.Mutex
 	certificateMu                  sync.Mutex
+	domainSwitchMu                 sync.Mutex
 	siteCertificateMu              sync.Mutex
 	publicationCleanupMu           sync.Mutex
 	publicationVerificationMu      sync.Mutex
@@ -49,6 +50,7 @@ type Store struct {
 	lookupGatewayAddress           func(string) (string, error)
 	verifyPublicEntry              func(context.Context, string, deployapi.PublicEntryProbe) error
 	issuePrivateCertificate        func(context.Context, ...string) (managedCertificate, error)
+	issueDomainCertificate         func(context.Context, cloudflareClient, string, ...string) (managedCertificate, error)
 }
 
 func Open(dataDir string, headscaleAllowedURLs ...string) (*Store, error) {
@@ -108,6 +110,7 @@ func Open(dataDir string, headscaleAllowedURLs ...string) (*Store, error) {
 	}
 	store.verifyPublication = store.verifyPublicationRevision
 	store.issuePrivateCertificate = store.obtainPrivateCertificate
+	store.issueDomainCertificate = store.obtainPrivateCertificateWithCloudflare
 	if err := store.initializeSchema(context.Background(), existingDatabase); err != nil {
 		backgroundCancel()
 		_ = db.Close()

--- a/internal/center/system_certificate.go
+++ b/internal/center/system_certificate.go
@@ -65,8 +65,14 @@ func (s *Store) ensureSystemCenterCertificate(ctx context.Context, endpoint stri
 		}
 	}
 	if secretID != "" && secretID != newSecretID {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id = ?`, secretID); err != nil {
+		var aliases int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM system_endpoint_aliases WHERE certificate_secret_id = ?`, secretID).Scan(&aliases); err != nil {
 			return managedCertificate{}, false, err
+		}
+		if aliases == 0 {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id = ?`, secretID); err != nil {
+				return managedCertificate{}, false, err
+			}
 		}
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/center/system_domain.go
+++ b/internal/center/system_domain.go
@@ -1,0 +1,353 @@
+package center
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/petauron/vastora/internal/deployapi"
+)
+
+type SystemDomainView struct {
+	Namespace                string                    `json:"namespace"`
+	CenterURL                string                    `json:"centerUrl"`
+	HeadscaleURL             string                    `json:"headscaleUrl"`
+	CloudflareZone           string                    `json:"cloudflareZone"`
+	Aliases                  []SystemEndpointAliasView `json:"aliases"`
+	ActivePublications       int                       `json:"activePublications"`
+	PendingCleanup           int                       `json:"pendingCleanup"`
+	BuiltinHeadscale         bool                      `json:"builtinHeadscale"`
+	CloudflareOAuthAvailable bool                      `json:"cloudflareOAuthAvailable"`
+}
+
+type SystemDomainSwitchInput struct {
+	SessionID string `json:"sessionId"`
+	ZoneID    string `json:"zoneId"`
+	Confirm   bool   `json:"confirm"`
+}
+
+type SystemDomainSwitchResult struct {
+	SystemDomainView
+	PreviousCenterURL    string `json:"previousCenterUrl"`
+	PreviousHeadscaleURL string `json:"previousHeadscaleUrl"`
+	BackupCreated        bool   `json:"backupCreated"`
+}
+
+func (s *Store) SystemDomain(ctx context.Context) (SystemDomainView, error) {
+	network, err := s.CenterNetworkConfig(ctx)
+	if err != nil {
+		return SystemDomainView{}, err
+	}
+	var headscaleURL, headscaleMode, cloudflareZone string
+	if err := s.db.QueryRowContext(ctx, `SELECT mode, endpoint FROM network_integrations WHERE kind = 'headscale' AND status = 'configured'`).Scan(&headscaleMode, &headscaleURL); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return SystemDomainView{}, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT endpoint FROM network_integrations WHERE kind = 'cloudflare' AND status = 'configured'`).Scan(&cloudflareZone); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return SystemDomainView{}, err
+	}
+	aliases, err := s.ListSystemEndpointAliases(ctx)
+	if err != nil {
+		return SystemDomainView{}, err
+	}
+	var active, cleanup int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM publications WHERE status <> 'stopped'`).Scan(&active); err != nil {
+		return SystemDomainView{}, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM publications WHERE cleanup_pending = 1`).Scan(&cleanup); err != nil {
+		return SystemDomainView{}, err
+	}
+	namespace := domainNamespaceFromCenterURL(network.AgentConnectURL)
+	return SystemDomainView{
+		Namespace: namespace, CenterURL: network.AgentConnectURL, HeadscaleURL: headscaleURL,
+		CloudflareZone: cloudflareZone, Aliases: aliases, ActivePublications: active,
+		PendingCleanup: cleanup, BuiltinHeadscale: headscaleMode == "builtin",
+		CloudflareOAuthAvailable: s.CloudflareOAuthAvailable(),
+	}, nil
+}
+
+func domainNamespaceFromCenterURL(endpoint string) string {
+	hostname, err := gatewayEndpointHostname(endpoint)
+	if err != nil || !strings.HasPrefix(hostname, "center.") {
+		return ""
+	}
+	return strings.TrimPrefix(hostname, "center.")
+}
+
+func systemNamespaceForZone(zoneName string) string {
+	return "vastora." + strings.ToLower(strings.TrimSuffix(strings.TrimSpace(zoneName), "."))
+}
+
+func (s *Server) SwitchSystemDomain(ctx context.Context, input SystemDomainSwitchInput) (SystemDomainSwitchResult, error) {
+	if !input.Confirm {
+		return SystemDomainSwitchResult{}, errors.New("center: confirm the system domain switch")
+	}
+	if s.infrastructure == nil {
+		return SystemDomainSwitchResult{}, errors.New("center: this installation does not include the deployment helper")
+	}
+	s.store.domainSwitchMu.Lock()
+	defer s.store.domainSwitchMu.Unlock()
+
+	current, err := s.store.SystemDomain(ctx)
+	if err != nil {
+		return SystemDomainSwitchResult{}, err
+	}
+	if !current.BuiltinHeadscale {
+		return SystemDomainSwitchResult{}, errors.New("center: switching the system domain currently requires bundled Headscale")
+	}
+	if current.ActivePublications != 0 || current.PendingCleanup != 0 {
+		return SystemDomainSwitchResult{}, errors.New("center: stop all access points and wait for cleanup before switching the system domain")
+	}
+	sessionID, selected, token, err := s.store.cloudflareOAuthSelection(input.SessionID, input.ZoneID)
+	if err != nil {
+		return SystemDomainSwitchResult{}, err
+	}
+	cloudflare := cloudflareClient{accountID: selected.AccountID, zoneID: selected.ID, token: token.AccessToken, baseURL: s.store.cloudflareOAuth.APIURL, http: s.store.cloudflareOAuth.HTTPClient}
+	zoneName, err := cloudflare.verify(ctx)
+	if err != nil {
+		return SystemDomainSwitchResult{}, err
+	}
+	namespace := systemNamespaceForZone(zoneName)
+	centerURL := "https://center." + namespace
+	headscaleURL := "https://headscale." + namespace
+	if centerURL == current.CenterURL && headscaleURL == current.HeadscaleURL {
+		return SystemDomainSwitchResult{}, errors.New("center: the selected domain is already in use")
+	}
+	binding, configured, err := s.store.setupGatewayBinding(ctx)
+	if err != nil {
+		return SystemDomainSwitchResult{}, err
+	}
+	if !configured || net.ParseIP(binding.PublicAddress) == nil {
+		return SystemDomainSwitchResult{}, errors.New("center: the public gateway address is not configured")
+	}
+	if address, err := s.store.coLocatedHeadscaleAddress(ctx); err != nil {
+		return SystemDomainSwitchResult{}, err
+	} else if address == "" {
+		return SystemDomainSwitchResult{}, errors.New("center: the co-located Agent must join the private network before switching domains")
+	}
+	if _, err := s.store.createSystemDomainBackup(ctx); err != nil {
+		return SystemDomainSwitchResult{}, err
+	}
+
+	newDNS, createdDNS, err := ensureSystemDNSRecord(ctx, cloudflare, headscaleURL, binding.PublicAddress)
+	if err != nil {
+		return SystemDomainSwitchResult{}, err
+	}
+	rollbackDNS := func() {
+		if createdDNS {
+			_ = cloudflare.deleteDNSRecord(context.WithoutCancel(ctx), newDNS.ID)
+		}
+	}
+	newCertificate, err := s.store.issueDomainCertificate(ctx, cloudflare, zoneName, strings.TrimPrefix(centerURL, "https://"))
+	if err != nil {
+		rollbackDNS()
+		return SystemDomainSwitchResult{}, err
+	}
+	oldHostname, err := gatewayEndpointHostname(current.CenterURL)
+	if err != nil {
+		rollbackDNS()
+		return SystemDomainSwitchResult{}, err
+	}
+	oldCertificate, err := s.store.loadSystemCenterCertificate(ctx, s.store.db, "", oldHostname)
+	if err != nil {
+		rollbackDNS()
+		return SystemDomainSwitchResult{}, fmt.Errorf("center: load current Center certificate: %w", err)
+	}
+	centerAliases, headscaleAliases, err := s.store.deploymentEndpointAliases(ctx)
+	if err != nil {
+		rollbackDNS()
+		return SystemDomainSwitchResult{}, err
+	}
+	centerAliases = append(centerAliases, deployapi.CenterEndpointAlias{URL: current.CenterURL, CertificatePEM: oldCertificate.CertificatePEM, CertificateKeyPEM: oldCertificate.PrivateKeyPEM})
+	headscaleAliases = append(headscaleAliases, current.HeadscaleURL)
+	if err := s.store.reconcileHeadscaleDNSForSystem(ctx, centerURL, []string{current.CenterURL}); err != nil {
+		rollbackDNS()
+		return SystemDomainSwitchResult{}, fmt.Errorf("center: prepare private DNS for the new domain: %w", err)
+	}
+	request := deployapi.HeadscaleInstallRequest{
+		CenterURL: centerURL, HeadscaleURL: headscaleURL, CenterAliases: centerAliases, HeadscaleAliases: headscaleAliases,
+		PublicAddress: binding.PublicAddress, GatewayBindAddress: binding.BindAddress,
+		CenterCertificatePEM: newCertificate.CertificatePEM, CenterCertificateKeyPEM: newCertificate.PrivateKeyPEM,
+	}
+	if err := s.infrastructure.ReconcileHeadscale(ctx, request); err != nil {
+		rollbackDNS()
+		restoreErr := s.store.reconcileHeadscaleDNS(context.WithoutCancel(ctx))
+		return SystemDomainSwitchResult{}, errors.Join(fmt.Errorf("center: apply the new system domain: %w", err), restoreErr)
+	}
+	if err := s.store.commitSystemDomainSwitch(ctx, current, selected, token, zoneName, centerURL, headscaleURL, newCertificate, newDNS); err != nil {
+		rollback := deployapi.HeadscaleInstallRequest{
+			CenterURL: current.CenterURL, HeadscaleURL: current.HeadscaleURL,
+			CenterAliases:    append(centerAliases[:len(centerAliases)-1], deployapi.CenterEndpointAlias{URL: centerURL, CertificatePEM: newCertificate.CertificatePEM, CertificateKeyPEM: newCertificate.PrivateKeyPEM}),
+			HeadscaleAliases: append(headscaleAliases[:len(headscaleAliases)-1], headscaleURL),
+			PublicAddress:    binding.PublicAddress, GatewayBindAddress: binding.BindAddress,
+			CenterCertificatePEM: oldCertificate.CertificatePEM, CenterCertificateKeyPEM: oldCertificate.PrivateKeyPEM,
+		}
+		rollbackErr := s.infrastructure.ReconcileHeadscale(context.WithoutCancel(ctx), rollback)
+		rollbackDNS()
+		restoreErr := s.store.reconcileHeadscaleDNS(context.WithoutCancel(ctx))
+		return SystemDomainSwitchResult{}, errors.Join(err, rollbackErr, restoreErr)
+	}
+	s.store.cloudflareOAuthMu.Lock()
+	delete(s.store.cloudflareOAuthSessions, sessionID)
+	s.store.cloudflareOAuthMu.Unlock()
+	updated, err := s.store.SystemDomain(ctx)
+	if err != nil {
+		return SystemDomainSwitchResult{}, err
+	}
+	return SystemDomainSwitchResult{SystemDomainView: updated, PreviousCenterURL: current.CenterURL, PreviousHeadscaleURL: current.HeadscaleURL, BackupCreated: true}, nil
+}
+
+func ensureSystemDNSRecord(ctx context.Context, client cloudflareClient, endpoint, address string) (SetupDNSRecord, bool, error) {
+	hostname, err := gatewayEndpointHostname(endpoint)
+	if err != nil {
+		return SetupDNSRecord{}, false, err
+	}
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return SetupDNSRecord{}, false, errors.New("center: public gateway address is invalid")
+	}
+	recordType := "AAAA"
+	if ip.To4() != nil {
+		recordType = "A"
+	}
+	existing, err := client.listDNSRecords(ctx, hostname)
+	if err != nil {
+		return SetupDNSRecord{}, false, err
+	}
+	if len(existing) != 0 {
+		if len(existing) == 1 && existing[0].Type == recordType && existing[0].Content == ip.String() && !existing[0].Proxied {
+			return SetupDNSRecord{ID: existing[0].ID, Type: recordType, Name: hostname, Content: ip.String()}, false, nil
+		}
+		return SetupDNSRecord{}, false, fmt.Errorf("center: DNS record %s already exists with a different value", hostname)
+	}
+	id, err := client.createDNSRecord(ctx, recordType, hostname, ip.String(), false)
+	if err != nil {
+		return SetupDNSRecord{}, false, err
+	}
+	return SetupDNSRecord{ID: id, Type: recordType, Name: hostname, Content: ip.String()}, true, nil
+}
+
+func (s *Store) createSystemDomainBackup(ctx context.Context) (string, error) {
+	directory := filepath.Join(s.dataDir, "domain-switch-backups")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return "", fmt.Errorf("center: create domain switch backup directory: %w", err)
+	}
+	path := filepath.Join(directory, "center-before-domain-switch-"+s.now().UTC().Format("20060102T150405.000000000Z")+".db")
+	if _, err := s.db.ExecContext(ctx, `VACUUM INTO ?`, path); err != nil {
+		return "", fmt.Errorf("center: create domain switch database backup: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return "", fmt.Errorf("center: protect domain switch database backup: %w", err)
+	}
+	return path, nil
+}
+
+func (s *Store) commitSystemDomainSwitch(ctx context.Context, current SystemDomainView, selected CloudflareZone, token cloudflareOAuthToken, zoneName, centerURL, headscaleURL string, certificate managedCertificate, dns SetupDNSRecord) error {
+	encodedCertificate, err := json.Marshal(certificate)
+	if err != nil {
+		return err
+	}
+	encodedDNS, err := json.Marshal([]SetupDNSRecord{dns})
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var oldCertificateSecretID, oldCertificateExpiry string
+	if err := tx.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, systemCenterCertificateSecretSetting).Scan(&oldCertificateSecretID); err != nil {
+		return err
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, systemCenterCertificateExpirySetting).Scan(&oldCertificateExpiry); err != nil {
+		return err
+	}
+	now := s.now().UTC().Format(time.RFC3339Nano)
+	var replacedAliasSecretID string
+	err = tx.QueryRowContext(ctx, `SELECT COALESCE(certificate_secret_id, '') FROM system_endpoint_aliases WHERE kind = 'center' AND endpoint = ?`, centerURL).Scan(&replacedAliasSecretID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM system_endpoint_aliases WHERE (kind = 'center' AND endpoint = ?) OR (kind = 'headscale' AND endpoint = ?)`, centerURL, headscaleURL); err != nil {
+		return err
+	}
+	if replacedAliasSecretID != "" && replacedAliasSecretID != oldCertificateSecretID {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id = ?`, replacedAliasSecretID); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO system_endpoint_aliases(kind, endpoint, certificate_secret_id, certificate_not_after, created_at, updated_at)
+		VALUES('center', ?, ?, ?, ?, ?) ON CONFLICT(kind, endpoint) DO UPDATE SET certificate_secret_id = excluded.certificate_secret_id, certificate_not_after = excluded.certificate_not_after, updated_at = excluded.updated_at`, current.CenterURL, oldCertificateSecretID, oldCertificateExpiry, now, now); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO system_endpoint_aliases(kind, endpoint, created_at, updated_at)
+		VALUES('headscale', ?, ?, ?) ON CONFLICT(kind, endpoint) DO UPDATE SET updated_at = excluded.updated_at`, current.HeadscaleURL, now, now); err != nil {
+		return err
+	}
+	newCertificateSecretID, err := s.putSecret(ctx, tx, encodedCertificate, systemCenterCertificateContext)
+	if err != nil {
+		return err
+	}
+	for key, value := range map[string]string{
+		agentConnectURLSetting:               centerURL,
+		systemCenterCertificateSecretSetting: newCertificateSecretID,
+		systemCenterCertificateExpirySetting: certificate.NotAfter.Format(time.RFC3339Nano),
+		"cloudflare_setup_dns_records":       string(encodedDNS),
+		builtinHeadscaleRuntimeSetting:       builtinHeadscaleRuntimeVersion,
+	} {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO settings(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`, key, value); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE network_integrations SET endpoint = ?, updated_at = ? WHERE kind = 'headscale' AND mode = 'builtin' AND status = 'configured'`, headscaleURL, now); err != nil {
+		return err
+	}
+	if err := s.saveCloudflareOAuthIntegrationTx(ctx, tx, selected, token, zoneName); err != nil {
+		return err
+	}
+	oldNamespace := domainNamespaceFromCenterURL(current.CenterURL)
+	newNamespace := domainNamespaceFromCenterURL(centerURL)
+	if oldNamespace != "" && oldNamespace != newNamespace {
+		rows, err := tx.QueryContext(ctx, `SELECT secret_id FROM site_certificates WHERE site_id IN (SELECT id FROM sites WHERE domain_suffix = ?) AND secret_id IS NOT NULL`, oldNamespace)
+		if err != nil {
+			return err
+		}
+		var obsoleteSecrets []string
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return err
+			}
+			obsoleteSecrets = append(obsoleteSecrets, id)
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM site_certificates WHERE site_id IN (SELECT id FROM sites WHERE domain_suffix = ?)`, oldNamespace); err != nil {
+			return err
+		}
+		for _, id := range obsoleteSecrets {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id = ?`, id); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE sites SET domain_suffix = ?, updated_at = ? WHERE domain_suffix = ?`, newNamespace, now, oldNamespace); err != nil {
+			return err
+		}
+	}
+	if err := s.queueAllGatewayStatesTx(ctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("center: commit system domain switch: %w", err)
+	}
+	return nil
+}

--- a/internal/center/system_domain_test.go
+++ b/internal/center/system_domain_test.go
@@ -1,0 +1,145 @@
+package center
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petauron/vastora/internal/networking"
+)
+
+func TestSwitchSystemDomainMovesPrimaryEndpointsAndKeepsAliases(t *testing.T) {
+	ctx := context.Background()
+	cloudflare := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/accounts/new-account/cfd_tunnel":
+			_, _ = writer.Write([]byte(`{"success":true,"errors":[],"result":[]}`))
+		case request.Method == http.MethodGet && request.URL.Path == "/zones/new-zone":
+			_, _ = writer.Write([]byte(`{"success":true,"errors":[],"result":{"name":"new.example.com"}}`))
+		case request.Method == http.MethodGet && request.URL.Path == "/zones/new-zone/dns_records" && request.URL.Query().Get("name") == "headscale.vastora.new.example.com":
+			_, _ = writer.Write([]byte(`{"success":true,"errors":[],"result":[]}`))
+		case request.Method == http.MethodPost && request.URL.Path == "/zones/new-zone/dns_records":
+			_, _ = writer.Write([]byte(`{"success":true,"errors":[],"result":{"id":"new-headscale-record"}}`))
+		default:
+			t.Fatalf("unexpected Cloudflare request: %s %s", request.Method, request.URL.String())
+		}
+	}))
+	defer cloudflare.Close()
+
+	directory := t.TempDir()
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	store.cloudflareOAuth = cloudflareOAuthConfig{APIURL: cloudflare.URL, HTTPClient: cloudflare.Client()}
+	store.discoverNetworkCandidates = func(time.Time) ([]networking.Candidate, error) {
+		return []networking.Candidate{{Address: "100.64.0.1", Interface: "tailscale0", Family: "ipv4", Kind: networking.KindHeadscale}}, nil
+	}
+	store.cloudflareOAuthSessions["switch-session"] = &cloudflareOAuthSession{
+		Token:     cloudflareOAuthToken{AccessToken: "new-access-token", RefreshToken: "new-refresh-token", ExpiresAt: time.Now().Add(time.Hour)},
+		Zones:     []CloudflareZone{{ID: "new-zone", Name: "new.example.com", AccountID: "new-account"}},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	store.issueDomainCertificate = func(_ context.Context, _ cloudflareClient, zone string, names ...string) (managedCertificate, error) {
+		if zone != "new.example.com" || len(names) != 1 || names[0] != "center.vastora.new.example.com" {
+			t.Fatalf("unexpected certificate request: zone=%q names=%v", zone, names)
+		}
+		return testManagedCertificate(t, names...), nil
+	}
+	storeSystemCenterCertificateForTest(t, store, "center.vastora.old.example.com")
+	oldNamespace := "vastora.old.example.com"
+	site, err := store.CreateSite(ctx, SiteInput{Name: "Home", Code: "home", Timezone: "UTC", DomainSuffix: oldNamespace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	statements := []struct {
+		query string
+		args  []any
+	}{
+		{`INSERT INTO settings(key, value) VALUES(?, ?), (?, ?), (?, ?)`, []any{agentConnectionModeSetting, "headscale", agentConnectURLSetting, "https://center." + oldNamespace, setupGatewayBindingSetting, `{"publicAddress":"203.0.113.10","bindAddress":"203.0.113.10"}`}},
+		{`INSERT INTO network_integrations(kind, mode, endpoint, status, created_at, updated_at) VALUES('headscale', 'builtin', ?, 'configured', ?, ?)`, []any{"https://headscale." + oldNamespace, now, now}},
+		{`INSERT INTO agents(id, name, credential_hash, version, status, enrolled_at, last_seen_at, site_id) VALUES('center-node', 'Center', X'01', 'test', 'active', ?, ?, ?)`, []any{now, now, site.ID}},
+		{`INSERT INTO agent_network_candidates(agent_id, address, interface_name, family, kind, observed_at) VALUES('center-node', '100.64.0.1', 'tailscale0', 'ipv4', 'headscale', ?)`, []any{now}},
+		{`INSERT INTO agent_network_profiles(agent_id, service_address, headscale_address, enabled_kinds_json, confirmed_at, candidate_observed_at) VALUES('center-node', '100.64.0.1', '100.64.0.1', '["headscale"]', ?, ?)`, []any{now, now}},
+	}
+	for _, statement := range statements {
+		if _, err := store.db.ExecContext(ctx, statement.query, statement.args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	installer := &fakeBuiltinHeadscaleInstaller{}
+	server := NewServer(store, "", false).WithInfrastructureManager(installer)
+	result, err := server.SwitchSystemDomain(ctx, SystemDomainSwitchInput{SessionID: "switch-session", ZoneID: "new-zone", Confirm: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CenterURL != "https://center.vastora.new.example.com" || result.HeadscaleURL != "https://headscale.vastora.new.example.com" || result.Namespace != "vastora.new.example.com" || !result.BackupCreated {
+		t.Fatalf("unexpected domain result: %#v", result)
+	}
+	if installer.reconcileInput.CenterURL != result.CenterURL || installer.reconcileInput.HeadscaleURL != result.HeadscaleURL || len(installer.reconcileInput.CenterAliases) != 1 || installer.reconcileInput.CenterAliases[0].URL != "https://center."+oldNamespace || len(installer.reconcileInput.HeadscaleAliases) != 1 {
+		t.Fatalf("unexpected deployment request: %#v", installer.reconcileInput)
+	}
+	updatedSite, err := store.Site(ctx, site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedSite.DomainSuffix != result.Namespace {
+		t.Fatalf("site namespace = %q", updatedSite.DomainSuffix)
+	}
+	aliases, err := store.ListSystemEndpointAliases(ctx)
+	if err != nil || len(aliases) != 2 {
+		t.Fatalf("aliases = %#v, err = %v", aliases, err)
+	}
+	var encoded string
+	if err := store.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = 'cloudflare_setup_dns_records'`).Scan(&encoded); err != nil {
+		t.Fatal(err)
+	}
+	var records []SetupDNSRecord
+	if json.Unmarshal([]byte(encoded), &records) != nil || len(records) != 1 || records[0].ID != "new-headscale-record" {
+		t.Fatalf("tracked DNS records = %s", encoded)
+	}
+	backups, err := filepath.Glob(filepath.Join(directory, "domain-switch-backups", "*.db"))
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("domain backups = %v, err = %v", backups, err)
+	}
+	if _, exists := store.cloudflareOAuthSessions["switch-session"]; exists {
+		t.Fatal("completed domain-switch OAuth session was retained")
+	}
+}
+
+func TestSwitchSystemDomainRequiresStoppedAccessPoints(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	storeSystemCenterCertificateForTest(t, store, "center.vastora.old.example.com")
+	siteID := testSiteID(t, store)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, statement := range []string{
+		`INSERT INTO settings(key, value) VALUES('agent_connection_mode', 'headscale'), ('agent_connect_url', 'https://center.vastora.old.example.com')`,
+		`INSERT INTO network_integrations(kind, mode, endpoint, status, created_at, updated_at) VALUES('headscale', 'builtin', 'https://headscale.vastora.old.example.com', 'configured', '` + now + `', '` + now + `')`,
+		`INSERT INTO agents(id, name, credential_hash, version, status, enrolled_at, last_seen_at, site_id) VALUES('node', 'Node', X'01', 'test', 'active', '` + now + `', '` + now + `', '` + siteID + `')`,
+		`INSERT INTO applications(id, name, node_id, site_id, app_key, status, created_at, updated_at) VALUES('app', 'App', 'node', '` + siteID + `', 'test/app', 'running', '` + now + `', '` + now + `')`,
+		`INSERT INTO services(id, application_id, site_id, name, protocol, container_port, host_port, endpoint, source, status, created_at, updated_at) VALUES('service', 'app', '` + siteID + `', 'web', 'http', 80, 8080, '127.0.0.1:8080', 'catalog', 'ready', '` + now + `', '` + now + `')`,
+		`INSERT INTO publications(id, service_id, kind, hostname, dns_provider, status, created_at, updated_at) VALUES('publication', 'service', 'headscale_gateway', 'app.example.com', 'headscale', 'ready', '` + now + `', '` + now + `')`,
+	} {
+		if _, err := store.db.ExecContext(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	server := NewServer(store, "", false).WithInfrastructureManager(&fakeBuiltinHeadscaleInstaller{})
+	_, err = server.SwitchSystemDomain(ctx, SystemDomainSwitchInput{SessionID: "missing", ZoneID: "missing", Confirm: true})
+	if err == nil || !strings.Contains(err.Error(), "stop all access points") {
+		t.Fatalf("active publication was accepted: %v", err)
+	}
+}

--- a/internal/center/system_endpoints.go
+++ b/internal/center/system_endpoints.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/petauron/vastora/internal/deployapi"
@@ -70,15 +69,6 @@ func (s *Store) ListSystemEndpointAliases(ctx context.Context) ([]SystemEndpoint
 		}
 	}
 	return values, nil
-}
-
-func normalizeSystemEndpoint(value string) (string, error) {
-	value = strings.TrimSpace(value)
-	normalized, err := normalizeHeadscaleEndpoint(value)
-	if err != nil {
-		return "", err
-	}
-	return normalized, nil
 }
 
 func (s *Store) deploymentEndpointAliases(ctx context.Context) ([]deployapi.CenterEndpointAlias, []string, error) {

--- a/internal/center/system_endpoints.go
+++ b/internal/center/system_endpoints.go
@@ -1,0 +1,114 @@
+package center
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/petauron/vastora/internal/deployapi"
+)
+
+type SystemEndpointAliasView struct {
+	Kind                string     `json:"kind"`
+	Endpoint            string     `json:"endpoint"`
+	CertificateNotAfter *time.Time `json:"certificateNotAfter,omitempty"`
+}
+
+type systemEndpointAlias struct {
+	Kind                string
+	Endpoint            string
+	CertificateSecretID string
+	CertificateNotAfter time.Time
+}
+
+type systemEndpointAliasQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func readSystemEndpointAliases(ctx context.Context, queryer systemEndpointAliasQuerier, kind string) ([]systemEndpointAlias, error) {
+	rows, err := queryer.QueryContext(ctx, `SELECT kind, endpoint, COALESCE(certificate_secret_id, ''), certificate_not_after
+		FROM system_endpoint_aliases WHERE kind = ? ORDER BY created_at, endpoint`, kind)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := []systemEndpointAlias{}
+	for rows.Next() {
+		var value systemEndpointAlias
+		var notAfter string
+		if err := rows.Scan(&value.Kind, &value.Endpoint, &value.CertificateSecretID, &notAfter); err != nil {
+			return nil, err
+		}
+		if notAfter != "" {
+			value.CertificateNotAfter, err = time.Parse(time.RFC3339Nano, notAfter)
+			if err != nil {
+				return nil, errors.New("center: stored system endpoint certificate expiry is invalid")
+			}
+		}
+		result = append(result, value)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) ListSystemEndpointAliases(ctx context.Context) ([]SystemEndpointAliasView, error) {
+	values := []SystemEndpointAliasView{}
+	for _, kind := range []string{"center", "headscale"} {
+		aliases, err := readSystemEndpointAliases(ctx, s.db, kind)
+		if err != nil {
+			return nil, fmt.Errorf("center: list %s endpoint aliases: %w", kind, err)
+		}
+		for _, alias := range aliases {
+			value := SystemEndpointAliasView{Kind: alias.Kind, Endpoint: alias.Endpoint}
+			if !alias.CertificateNotAfter.IsZero() {
+				notAfter := alias.CertificateNotAfter
+				value.CertificateNotAfter = &notAfter
+			}
+			values = append(values, value)
+		}
+	}
+	return values, nil
+}
+
+func normalizeSystemEndpoint(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	normalized, err := normalizeHeadscaleEndpoint(value)
+	if err != nil {
+		return "", err
+	}
+	return normalized, nil
+}
+
+func (s *Store) deploymentEndpointAliases(ctx context.Context) ([]deployapi.CenterEndpointAlias, []string, error) {
+	centerValues, err := readSystemEndpointAliases(ctx, s.db, "center")
+	if err != nil {
+		return nil, nil, fmt.Errorf("center: read Center endpoint aliases: %w", err)
+	}
+	centerAliases := make([]deployapi.CenterEndpointAlias, 0, len(centerValues))
+	for _, value := range centerValues {
+		hostname, err := gatewayEndpointHostname(value.Endpoint)
+		if err != nil {
+			return nil, nil, err
+		}
+		certificate, err := s.loadSystemCenterCertificate(ctx, s.db, value.CertificateSecretID, hostname)
+		if err != nil {
+			return nil, nil, fmt.Errorf("center: load Center endpoint alias certificate: %w", err)
+		}
+		centerAliases = append(centerAliases, deployapi.CenterEndpointAlias{
+			URL:               value.Endpoint,
+			CertificatePEM:    certificate.CertificatePEM,
+			CertificateKeyPEM: certificate.PrivateKeyPEM,
+		})
+	}
+	headscaleValues, err := readSystemEndpointAliases(ctx, s.db, "headscale")
+	if err != nil {
+		return nil, nil, fmt.Errorf("center: read Headscale endpoint aliases: %w", err)
+	}
+	headscaleAliases := make([]string, 0, len(headscaleValues))
+	for _, value := range headscaleValues {
+		headscaleAliases = append(headscaleAliases, value.Endpoint)
+	}
+	return centerAliases, headscaleAliases, nil
+}

--- a/internal/center/system_gateway.go
+++ b/internal/center/system_gateway.go
@@ -104,9 +104,48 @@ func (s *Store) appendSystemGatewayRoutes(ctx context.Context, tx *sql.Tx, gatew
 		gateway.Route{ID: "system-center", Hostname: centerHostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "headscale", System: true},
 		gateway.Route{ID: "system-headscale", Hostname: headscaleHostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8081}}, TLSEnabled: true, ListenerKind: "public", System: true},
 		gateway.Route{ID: "system-agent-bootstrap", Hostname: headscaleHostname, Path: "/install/agent.sh", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "public", System: true},
+		gateway.Route{ID: "system-agent-binary-bootstrap", Hostname: headscaleHostname, Path: "/api/v1/agent-binaries/*", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "public", System: true},
 		gateway.Route{ID: "system-center-local", Hostname: centerHostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "system", System: true},
 		gateway.Route{ID: "system-headscale-local", Hostname: headscaleHostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8081}}, TLSEnabled: true, ListenerKind: "system", System: true},
 	)
+	centerAliases, err := readSystemEndpointAliases(ctx, tx, "center")
+	if err != nil {
+		return fmt.Errorf("center: read Center endpoint aliases: %w", err)
+	}
+	for _, alias := range centerAliases {
+		hostname, err := gatewayEndpointHostname(alias.Endpoint)
+		if err != nil {
+			return fmt.Errorf("center: stored Center endpoint alias: %w", err)
+		}
+		if hostname == centerHostname {
+			continue
+		}
+		key := strings.ReplaceAll(hostname, ".", "-")
+		state.Routes = append(state.Routes,
+			gateway.Route{ID: "system-center-alias-" + key, Hostname: hostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "headscale", System: true},
+			gateway.Route{ID: "system-center-alias-local-" + key, Hostname: hostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "system", System: true},
+		)
+	}
+	headscaleAliases, err := readSystemEndpointAliases(ctx, tx, "headscale")
+	if err != nil {
+		return fmt.Errorf("center: read Headscale endpoint aliases: %w", err)
+	}
+	for _, alias := range headscaleAliases {
+		hostname, err := gatewayEndpointHostname(alias.Endpoint)
+		if err != nil {
+			return fmt.Errorf("center: stored Headscale endpoint alias: %w", err)
+		}
+		if hostname == headscaleHostname {
+			continue
+		}
+		key := strings.ReplaceAll(hostname, ".", "-")
+		state.Routes = append(state.Routes,
+			gateway.Route{ID: "system-headscale-alias-" + key, Hostname: hostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8081}}, TLSEnabled: true, ListenerKind: "public", System: true},
+			gateway.Route{ID: "system-agent-bootstrap-alias-" + key, Hostname: hostname, Path: "/install/agent.sh", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "public", System: true},
+			gateway.Route{ID: "system-agent-binary-bootstrap-alias-" + key, Hostname: hostname, Path: "/api/v1/agent-binaries/*", Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8080}}, TLSEnabled: true, ListenerKind: "public", System: true},
+			gateway.Route{ID: "system-headscale-alias-local-" + key, Hostname: hostname, Protocol: "http", Upstreams: []gateway.Upstream{{Address: "127.0.0.1", Port: 8081}}, TLSEnabled: true, ListenerKind: "system", System: true},
+		)
+	}
 	return nil
 }
 
@@ -124,6 +163,13 @@ func (s *Store) queueAllGatewayStates(ctx context.Context) error {
 		return err
 	}
 	defer tx.Rollback()
+	if err := s.queueAllGatewayStatesTx(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) queueAllGatewayStatesTx(ctx context.Context, tx *sql.Tx) error {
 	rows, err := tx.QueryContext(ctx, `SELECT gateway_node_id FROM gateway_components WHERE desired_status = 'running' ORDER BY gateway_node_id`)
 	if err != nil {
 		return err
@@ -145,5 +191,5 @@ func (s *Store) queueAllGatewayStates(ctx context.Context) error {
 			return err
 		}
 	}
-	return tx.Commit()
+	return nil
 }

--- a/internal/deployapi/headscale.go
+++ b/internal/deployapi/headscale.go
@@ -14,12 +14,20 @@ import (
 )
 
 type HeadscaleInstallRequest struct {
-	CenterURL               string `json:"centerUrl"`
-	HeadscaleURL            string `json:"headscaleUrl"`
-	PublicAddress           string `json:"publicAddress,omitempty"`
-	GatewayBindAddress      string `json:"gatewayBindAddress,omitempty"`
-	CenterCertificatePEM    string `json:"centerCertificatePem"`
-	CenterCertificateKeyPEM string `json:"centerCertificateKeyPem"`
+	CenterURL               string                `json:"centerUrl"`
+	HeadscaleURL            string                `json:"headscaleUrl"`
+	CenterAliases           []CenterEndpointAlias `json:"centerAliases,omitempty"`
+	HeadscaleAliases        []string              `json:"headscaleAliases,omitempty"`
+	PublicAddress           string                `json:"publicAddress,omitempty"`
+	GatewayBindAddress      string                `json:"gatewayBindAddress,omitempty"`
+	CenterCertificatePEM    string                `json:"centerCertificatePem"`
+	CenterCertificateKeyPEM string                `json:"centerCertificateKeyPem"`
+}
+
+type CenterEndpointAlias struct {
+	URL               string `json:"url"`
+	CertificatePEM    string `json:"certificatePem"`
+	CertificateKeyPEM string `json:"certificateKeyPem"`
 }
 
 type HeadscaleInstallResult struct {

--- a/internal/deployer/config.go
+++ b/internal/deployer/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/petauron/vastora/internal/deployapi"
 	"github.com/petauron/vastora/internal/gatewayruntime"
 	"github.com/petauron/vastora/internal/networking"
 )
@@ -22,6 +23,13 @@ const (
 	centerCertificatePath = "/etc/caddy/system/center.crt"
 	centerPrivateKeyPath  = "/etc/caddy/system/center.key"
 )
+
+func centerAliasCertificatePath(index int) string {
+	return fmt.Sprintf("/etc/caddy/system/center-alias-%d.crt", index+1)
+}
+func centerAliasPrivateKeyPath(index int) string {
+	return fmt.Sprintf("/etc/caddy/system/center-alias-%d.key", index+1)
+}
 
 type gatewayResolution struct {
 	hostname  string
@@ -255,15 +263,28 @@ func formatGatewayBindAddresses(addresses []netip.Addr) []string {
 	return result
 }
 
-func renderCaddyfile(centerURL, centerOrigin, headscaleURL string, bindAddresses []string) []byte {
-	centerHTTP := "http://" + strings.TrimPrefix(centerURL, "https://")
-	headscaleHTTP := "http://" + strings.TrimPrefix(headscaleURL, "https://")
-	return []byte(fmt.Sprintf(`{
+func renderCaddyfile(centerURL, centerOrigin, headscaleURL string, bindAddresses []string, centerAliases []deployapi.CenterEndpointAlias, headscaleAliases []string) []byte {
+	var result strings.Builder
+	result.WriteString(fmt.Sprintf(`{
 	admin unix/%s|0600
 	persist_config off
 }
 
-%s {
+`, gatewayruntime.CaddyAdminSocket))
+	writeCenterGatewaySite(&result, centerURL, centerOrigin, centerCertificatePath, centerPrivateKeyPath)
+	for index, alias := range centerAliases {
+		writeCenterGatewaySite(&result, alias.URL, centerOrigin, centerAliasCertificatePath(index), centerAliasPrivateKeyPath(index))
+	}
+	writeHeadscaleGatewaySite(&result, headscaleURL, centerOrigin, bindAddresses)
+	for _, alias := range headscaleAliases {
+		writeHeadscaleGatewaySite(&result, alias, centerOrigin, bindAddresses)
+	}
+	return []byte(result.String())
+}
+
+func writeCenterGatewaySite(result *strings.Builder, endpoint, centerOrigin, certificatePath, privateKeyPath string) {
+	httpEndpoint := "http://" + strings.TrimPrefix(endpoint, "https://")
+	result.WriteString(fmt.Sprintf(`%s {
 	bind 127.0.0.1
 	redir https://{host}{uri} 308
 }
@@ -274,7 +295,13 @@ func renderCaddyfile(centerURL, centerOrigin, headscaleURL string, bindAddresses
 	reverse_proxy %s
 }
 
-%s {
+`, httpEndpoint, endpoint, certificatePath, privateKeyPath, centerOrigin))
+}
+
+func writeHeadscaleGatewaySite(result *strings.Builder, endpoint, centerOrigin string, bindAddresses []string) {
+	httpEndpoint := "http://" + strings.TrimPrefix(endpoint, "https://")
+	addresses := strings.Join(bindAddresses, " ")
+	result.WriteString(fmt.Sprintf(`%s {
 	bind 127.0.0.1 %s
 	redir https://{host}{uri} 308
 }
@@ -284,9 +311,12 @@ func renderCaddyfile(centerURL, centerOrigin, headscaleURL string, bindAddresses
 	handle /install/agent.sh {
 		reverse_proxy %s
 	}
+	handle /api/v1/agent-binaries/* {
+		reverse_proxy %s
+	}
 	handle {
 		reverse_proxy 127.0.0.1:8081
 	}
 }
-`, gatewayruntime.CaddyAdminSocket, centerHTTP, centerURL, centerCertificatePath, centerPrivateKeyPath, centerOrigin, headscaleHTTP, strings.Join(bindAddresses, " "), headscaleURL, strings.Join(bindAddresses, " "), centerOrigin))
+`, httpEndpoint, addresses, endpoint, addresses, centerOrigin, centerOrigin))
 }

--- a/internal/deployer/config_test.go
+++ b/internal/deployer/config_test.go
@@ -49,8 +49,8 @@ func TestGeneratedConfigurationUsesStandardHTTPSAndKeepsSecretsOut(t *testing.T)
 	if !strings.Contains(headscale, "listen_addr: 0.0.0.0:8081") || !strings.Contains(headscale, "override_local_dns: true") || !strings.Contains(headscale, "      - 1.1.1.1") || strings.Contains(headscale, "tls_key_path") || strings.Contains(headscale, "extra_records:") {
 		t.Fatalf("unexpected Headscale configuration:\n%s", headscale)
 	}
-	caddy := string(renderCaddyfile("https://center.example.com", "127.0.0.1:8080", "https://headscale.example.com", []string{"203.0.113.10"}))
-	if !strings.Contains(caddy, "admin unix//run/vastora/caddy-admin.sock|0600") || !strings.Contains(caddy, "bind 127.0.0.1 203.0.113.10") || !strings.Contains(caddy, "tls /etc/caddy/system/center.crt /etc/caddy/system/center.key") || !strings.Contains(caddy, "handle /install/agent.sh") || !strings.Contains(caddy, "redir https://{host}{uri} 308") || !strings.Contains(caddy, "https://center.example.com") || !strings.Contains(caddy, "https://headscale.example.com") || strings.Contains(caddy, ":8443") {
+	caddy := string(renderCaddyfile("https://center.example.com", "127.0.0.1:8080", "https://headscale.example.com", []string{"203.0.113.10"}, nil, nil))
+	if !strings.Contains(caddy, "admin unix//run/vastora/caddy-admin.sock|0600") || !strings.Contains(caddy, "bind 127.0.0.1 203.0.113.10") || !strings.Contains(caddy, "tls /etc/caddy/system/center.crt /etc/caddy/system/center.key") || !strings.Contains(caddy, "handle /install/agent.sh") || !strings.Contains(caddy, "handle /api/v1/agent-binaries/*") || !strings.Contains(caddy, "redir https://{host}{uri} 308") || !strings.Contains(caddy, "https://center.example.com") || !strings.Contains(caddy, "https://headscale.example.com") || strings.Contains(caddy, ":8443") {
 		t.Fatalf("unexpected Caddy configuration:\n%s", caddy)
 	}
 	policy := string(renderHeadscalePolicy())

--- a/internal/deployer/gateway.go
+++ b/internal/deployer/gateway.go
@@ -111,6 +111,21 @@ func (installer DockerHeadscaleInstaller) replaceGateway(ctx context.Context, do
 			return gatewayReplacement{}, err
 		}
 	}
+	for index, alias := range installer.CenterAliases {
+		for _, file := range []struct {
+			name    string
+			content string
+		}{
+			{filepath.Base(centerAliasCertificatePath(index)), alias.CertificatePEM},
+			{filepath.Base(centerAliasPrivateKeyPath(index)), alias.CertificateKeyPEM},
+		} {
+			if err := copyFile(ctx, docker, created.ID, "/etc/caddy", "system/"+file.name, []byte(file.content)); err != nil {
+				_, _ = docker.ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{Force: true})
+				_ = replacement.rollback(ctx, docker)
+				return gatewayReplacement{}, err
+			}
+		}
+	}
 	if replacement.legacyWasRunning {
 		if _, err := docker.ContainerStop(ctx, legacy.Container.ID, client.ContainerStopOptions{}); err != nil {
 			_, _ = docker.ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{Force: true})

--- a/internal/deployer/headscale.go
+++ b/internal/deployer/headscale.go
@@ -50,6 +50,8 @@ type DockerHeadscaleInstaller struct {
 	CaddyImage            string
 	CenterCertificatePEM  string
 	CenterPrivateKeyPEM   string
+	CenterAliases         []deployapi.CenterEndpointAlias
+	HeadscaleAliases      []string
 	HTTPClient            *http.Client
 }
 
@@ -71,7 +73,8 @@ func (installer DockerHeadscaleInstaller) applyHeadscale(ctx context.Context, in
 	if err != nil {
 		return "", "", err
 	}
-	bindAddresses, err := gatewayBindAddresses(ctx, input.PublicAddress, input.GatewayBindAddress, headscaleURL)
+	publicEndpoints := append([]string{headscaleURL}, settings.HeadscaleAliases...)
+	bindAddresses, err := gatewayBindAddresses(ctx, input.PublicAddress, input.GatewayBindAddress, publicEndpoints...)
 	if err != nil {
 		return "", "", err
 	}
@@ -125,7 +128,7 @@ func (installer DockerHeadscaleInstaller) applyHeadscale(ctx context.Context, in
 			return "", "", err
 		}
 	}
-	replacement, err := settings.replaceGateway(ctx, docker, renderCaddyfile(centerURL, settings.CenterOrigin, headscaleURL, bindAddresses))
+	replacement, err := settings.replaceGateway(ctx, docker, renderCaddyfile(centerURL, settings.CenterOrigin, headscaleURL, bindAddresses, settings.CenterAliases, settings.HeadscaleAliases))
 	if err != nil {
 		return "", "", err
 	}
@@ -159,16 +162,43 @@ func (installer DockerHeadscaleInstaller) settings(input deployapi.HeadscaleInst
 	if centerURL == headscaleURL {
 		return DockerHeadscaleInstaller{}, "", "", errors.New("deployer: Center and Headscale require different hostnames")
 	}
-	certificatePair, err := tls.X509KeyPair([]byte(input.CenterCertificatePEM), []byte(input.CenterCertificateKeyPEM))
-	if err != nil || len(certificatePair.Certificate) == 0 {
-		return DockerHeadscaleInstaller{}, "", "", errors.New("deployer: a valid Center HTTPS certificate and key are required")
+	if err := validateCenterCertificate(centerURL, input.CenterCertificatePEM, input.CenterCertificateKeyPEM); err != nil {
+		return DockerHeadscaleInstaller{}, "", "", err
 	}
-	leaf, err := x509.ParseCertificate(certificatePair.Certificate[0])
-	if err != nil || leaf.VerifyHostname(strings.TrimPrefix(centerURL, "https://")) != nil || time.Now().Before(leaf.NotBefore) || !time.Now().Before(leaf.NotAfter) {
-		return DockerHeadscaleInstaller{}, "", "", errors.New("deployer: Center HTTPS certificate is invalid for its private hostname")
+	seenCenter := map[string]struct{}{centerURL: {}}
+	centerAliases := make([]deployapi.CenterEndpointAlias, 0, len(input.CenterAliases))
+	for _, alias := range input.CenterAliases {
+		aliasURL, normalizeErr := normalizePublicURL(alias.URL)
+		if normalizeErr != nil {
+			return DockerHeadscaleInstaller{}, "", "", fmt.Errorf("deployer: Center alias URL: %w", normalizeErr)
+		}
+		if _, exists := seenCenter[aliasURL]; exists {
+			continue
+		}
+		if certificateErr := validateCenterCertificate(aliasURL, alias.CertificatePEM, alias.CertificateKeyPEM); certificateErr != nil {
+			return DockerHeadscaleInstaller{}, "", "", certificateErr
+		}
+		seenCenter[aliasURL] = struct{}{}
+		alias.URL = aliasURL
+		centerAliases = append(centerAliases, alias)
+	}
+	seenHeadscale := map[string]struct{}{headscaleURL: {}}
+	headscaleAliases := make([]string, 0, len(input.HeadscaleAliases))
+	for _, alias := range input.HeadscaleAliases {
+		aliasURL, normalizeErr := normalizePublicURL(alias)
+		if normalizeErr != nil {
+			return DockerHeadscaleInstaller{}, "", "", fmt.Errorf("deployer: Headscale alias URL: %w", normalizeErr)
+		}
+		if _, exists := seenHeadscale[aliasURL]; exists {
+			continue
+		}
+		seenHeadscale[aliasURL] = struct{}{}
+		headscaleAliases = append(headscaleAliases, aliasURL)
 	}
 	installer.CenterCertificatePEM = input.CenterCertificatePEM
 	installer.CenterPrivateKeyPEM = input.CenterCertificateKeyPEM
+	installer.CenterAliases = centerAliases
+	installer.HeadscaleAliases = headscaleAliases
 	if installer.Socket == "" {
 		installer.Socket = "unix:///var/run/docker.sock"
 	}
@@ -206,6 +236,18 @@ func (installer DockerHeadscaleInstaller) settings(input deployapi.HeadscaleInst
 		installer.HTTPClient = &http.Client{Timeout: 8 * time.Second}
 	}
 	return installer, centerURL, headscaleURL, nil
+}
+
+func validateCenterCertificate(endpoint, certificatePEM, privateKeyPEM string) error {
+	certificatePair, err := tls.X509KeyPair([]byte(certificatePEM), []byte(privateKeyPEM))
+	if err != nil || len(certificatePair.Certificate) == 0 {
+		return errors.New("deployer: a valid Center HTTPS certificate and key are required")
+	}
+	leaf, err := x509.ParseCertificate(certificatePair.Certificate[0])
+	if err != nil || leaf.VerifyHostname(strings.TrimPrefix(endpoint, "https://")) != nil || time.Now().Before(leaf.NotBefore) || !time.Now().Before(leaf.NotAfter) {
+		return errors.New("deployer: Center HTTPS certificate is invalid for its private hostname")
+	}
+	return nil
 }
 
 func (installer DockerHeadscaleInstaller) replaceHeadscale(ctx context.Context, docker *client.Client) error {

--- a/scripts/classify-ci-changes.sh
+++ b/scripts/classify-ci-changes.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  echo "usage: classify-ci-changes.sh --git <ci|codeql> <base-sha> <head-sha>" >&2
+  echo "       classify-ci-changes.sh --files <ci|codeql>" >&2
+  exit 2
+}
+
+mode="${1:-}"
+profile="${2:-}"
+case "$profile" in
+  ci|codeql) ;;
+  *) usage ;;
+esac
+
+case "$mode" in
+  --git)
+    [ "$#" -eq 4 ] || usage
+    paths="$(git diff --name-only "$3" "$4")"
+    ;;
+  --files)
+    [ "$#" -eq 2 ] || usage
+    paths="$(cat)"
+    ;;
+  *) usage ;;
+esac
+
+go=false
+web=false
+deployment=false
+security=false
+container=false
+release_metadata=false
+javascript=false
+full=false
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+
+  case "$path" in
+    cmd/*|internal/*|go.mod|go.sum) go=true ;;
+  esac
+  case "$path" in
+    web/*) web=true ;;
+  esac
+  case "$path" in
+    deploy/*|scripts/*|install.sh|catalog/*|Dockerfile*|release-please-config.json) deployment=true ;;
+  esac
+  case "$path" in
+    Dockerfile.center|.dockerignore|go.mod|go.sum|web/package.json|web/package-lock.json|catalog/catalog.json) container=true ;;
+  esac
+  case "$path" in
+    CHANGELOG.md|.release-please-manifest.json|version.txt) release_metadata=true ;;
+    *) security=true ;;
+  esac
+  case "$path" in
+    web/*|deploy/installer-worker/*|scripts/*.mjs|scripts/*.js) javascript=true ;;
+  esac
+  case "$path" in
+    .github/workflows/*|.github/dependabot.yml|Makefile|release-please-config.json) full=true ;;
+  esac
+
+  case "$path" in
+    cmd/*|internal/*|web/*|deploy/*|scripts/*|catalog/*|.github/*|docs/*|*.md|Dockerfile*|.dockerignore|go.mod|go.sum|install.sh|version.txt|.release-please-manifest.json|release-please-config.json|LICENSE) ;;
+    *) full=true ;;
+  esac
+done <<EOF
+$paths
+EOF
+
+if [ "$profile" = codeql ]; then
+  printf 'go=%s\njavascript=%s\nfull=%s\n' "$go" "$javascript" "$full"
+  exit 0
+fi
+
+printf 'go=%s\nweb=%s\ndeployment=%s\nsecurity=%s\ncontainer=%s\nrelease_metadata=%s\nfull=%s\n' \
+  "$go" "$web" "$deployment" "$security" "$container" "$release_metadata" "$full"

--- a/scripts/compare-semver.awk
+++ b/scripts/compare-semver.awk
@@ -1,0 +1,81 @@
+function compare_number(left, right) {
+  left += 0
+  right += 0
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function is_numeric(value) {
+  return value ~ /^(0|[1-9][0-9]*)$/
+}
+
+function compare_identifier(left, right, left_numeric, right_numeric) {
+  left_numeric = is_numeric(left)
+  right_numeric = is_numeric(right)
+  if (left_numeric && right_numeric) {
+    return compare_number(left, right)
+  }
+  if (left_numeric != right_numeric) {
+    return left_numeric ? -1 : 1
+  }
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function compare_version(left, right, left_core, right_core, left_pre, right_pre,
+                         dash, count, part, result, left_count, right_count) {
+  sub(/\+.*/, "", left)
+  sub(/\+.*/, "", right)
+
+  dash = index(left, "-")
+  left_core = dash ? substr(left, 1, dash - 1) : left
+  left_pre = dash ? substr(left, dash + 1) : ""
+  dash = index(right, "-")
+  right_core = dash ? substr(right, 1, dash - 1) : right
+  right_pre = dash ? substr(right, dash + 1) : ""
+
+  split(left_core, left_parts, ".")
+  split(right_core, right_parts, ".")
+  for (part = 1; part <= 3; part++) {
+    result = compare_number(left_parts[part], right_parts[part])
+    if (result) {
+      return result
+    }
+  }
+
+  if (left_pre == right_pre) {
+    return 0
+  }
+  if (left_pre == "") {
+    return 1
+  }
+  if (right_pre == "") {
+    return -1
+  }
+
+  delete left_parts
+  delete right_parts
+  left_count = split(left_pre, left_parts, ".")
+  right_count = split(right_pre, right_parts, ".")
+  count = left_count > right_count ? left_count : right_count
+  for (part = 1; part <= count; part++) {
+    if (part > left_count) {
+      return -1
+    }
+    if (part > right_count) {
+      return 1
+    }
+    result = compare_identifier(left_parts[part], right_parts[part])
+    if (result) {
+      return result
+    }
+  }
+  return 0
+}
+
+BEGIN {
+  if (ARGC != 3) {
+    print "usage: awk -f compare-semver.awk LEFT RIGHT" > "/dev/stderr"
+    exit 2
+  }
+  print compare_version(ARGV[1], ARGV[2])
+  exit
+}

--- a/scripts/test-ci-workflows.sh
+++ b/scripts/test-ci-workflows.sh
@@ -5,7 +5,7 @@ script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 ci_workflow="$project_dir/.github/workflows/ci.yml"
 codeql_workflow="$project_dir/.github/workflows/codeql.yml"
-container_filter="$(sed -n '/^            container:/,/^            non_release:/p' "$ci_workflow")"
+classifier="$project_dir/scripts/classify-ci-changes.sh"
 
 require_line() {
   file="$1"
@@ -19,11 +19,12 @@ require_line() {
 require_line "$ci_workflow" '    name: CI / gate'
 require_line "$ci_workflow" '    name: Release metadata'
 require_line "$ci_workflow" '        run: scripts/validate-release-metadata.sh "$BASE_SHA"'
-require_line "$ci_workflow" '        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3'
-require_line "$ci_workflow" '          predicate-quantifier: some-with-excludes'
+require_line "$ci_workflow" '        run: scripts/classify-ci-changes.sh --git ci "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"'
+require_line "$codeql_workflow" '        run: scripts/classify-ci-changes.sh --git codeql "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"'
 require_line "$ci_workflow" '    name: Warm dependency caches'
 require_line "$ci_workflow" '      DOCKER_BUILD_RECORD_UPLOAD: "false"'
 require_line "$ci_workflow" '        run: scripts/check-runtime-image-platforms.sh'
+require_line "$ci_workflow" '        run: go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --redact --verbose .'
 require_line "$codeql_workflow" '    name: CodeQL / gate'
 require_line "$codeql_workflow" '  group: codeql-${{ github.workflow }}-${{ github.ref }}'
 require_line "$codeql_workflow" "  cancel-in-progress: \${{ github.event_name == 'pull_request' }}"
@@ -32,12 +33,23 @@ if grep -Fq 'cache-to: type=gha' "$ci_workflow"; then
   echo 'Pull-request image builds must not write GitHub Actions caches.' >&2
   exit 1
 fi
-if printf '%s\n' "$container_filter" | grep -Fq "              - 'web/**'"; then
-  echo 'Ordinary frontend source changes must not trigger both image builds.' >&2
+ci_frontend="$(printf '%s\n' 'web/src/App.tsx' | "$classifier" --files ci)"
+ci_lockfile="$(printf '%s\n' 'web/package-lock.json' | "$classifier" --files ci)"
+codeql_go="$(printf '%s\n' 'internal/center/server.go' | "$classifier" --files codeql)"
+if ! printf '%s\n' "$ci_frontend" | grep -Fq 'web=true' || ! printf '%s\n' "$ci_frontend" | grep -Fq 'container=false'; then
+  echo 'Ordinary frontend source changes were classified incorrectly.' >&2
   exit 1
 fi
-if ! printf '%s\n' "$container_filter" | grep -Fq "              - 'web/package-lock.json'"; then
-  echo 'Container dependency changes must trigger both image builds.' >&2
+if ! printf '%s\n' "$ci_lockfile" | grep -Fq 'web=true' || ! printf '%s\n' "$ci_lockfile" | grep -Fq 'container=true'; then
+  echo 'Container dependency changes were classified incorrectly.' >&2
+  exit 1
+fi
+if ! printf '%s\n' "$codeql_go" | grep -Fq 'go=true' || ! printf '%s\n' "$codeql_go" | grep -Fq 'javascript=false'; then
+  echo 'CodeQL language changes were classified incorrectly.' >&2
+  exit 1
+fi
+if grep -Fq 'dorny/paths-filter' "$ci_workflow" "$codeql_workflow" || grep -Fq 'gitleaks/gitleaks-action' "$ci_workflow"; then
+  echo 'CI must not require additional third-party Actions permissions.' >&2
   exit 1
 fi
 if grep -Fq 'runtime-image-platforms:' "$ci_workflow"; then

--- a/scripts/test-ci-workflows.sh
+++ b/scripts/test-ci-workflows.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
+ci_workflow="$project_dir/.github/workflows/ci.yml"
+codeql_workflow="$project_dir/.github/workflows/codeql.yml"
+container_filter="$(sed -n '/^            container:/,/^            non_release:/p' "$ci_workflow")"
+
+require_line() {
+  file="$1"
+  expected="$2"
+  if ! grep -Fq "$expected" "$file"; then
+    echo "$file is missing: $expected" >&2
+    exit 1
+  fi
+}
+
+require_line "$ci_workflow" '    name: CI / gate'
+require_line "$ci_workflow" '    name: Release metadata'
+require_line "$ci_workflow" '        run: scripts/validate-release-metadata.sh "$BASE_SHA"'
+require_line "$ci_workflow" '        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3'
+require_line "$ci_workflow" '          predicate-quantifier: some-with-excludes'
+require_line "$ci_workflow" '    name: Warm dependency caches'
+require_line "$ci_workflow" '      DOCKER_BUILD_RECORD_UPLOAD: "false"'
+require_line "$ci_workflow" '        run: scripts/check-runtime-image-platforms.sh'
+require_line "$codeql_workflow" '    name: CodeQL / gate'
+require_line "$codeql_workflow" '  group: codeql-${{ github.workflow }}-${{ github.ref }}'
+require_line "$codeql_workflow" "  cancel-in-progress: \${{ github.event_name == 'pull_request' }}"
+
+if grep -Fq 'cache-to: type=gha' "$ci_workflow"; then
+  echo 'Pull-request image builds must not write GitHub Actions caches.' >&2
+  exit 1
+fi
+if printf '%s\n' "$container_filter" | grep -Fq "              - 'web/**'"; then
+  echo 'Ordinary frontend source changes must not trigger both image builds.' >&2
+  exit 1
+fi
+if ! printf '%s\n' "$container_filter" | grep -Fq "              - 'web/package-lock.json'"; then
+  echo 'Container dependency changes must trigger both image builds.' >&2
+  exit 1
+fi
+if grep -Fq 'runtime-image-platforms:' "$ci_workflow"; then
+  echo 'Runtime image validation should share the deployment runner.' >&2
+  exit 1
+fi
+for workflow in "$ci_workflow" "$codeql_workflow"; do
+  if ! grep -Fq 'timeout-minutes:' "$workflow"; then
+    echo "$workflow has no job timeouts." >&2
+    exit 1
+  fi
+done
+
+echo "CI workflow policy test passed"

--- a/scripts/test-release-metadata.sh
+++ b/scripts/test-release-metadata.sh
@@ -16,6 +16,19 @@ git -C "$temporary_dir" add -- .release-please-manifest.json CHANGELOG.md versio
 git -C "$temporary_dir" commit -qm baseline
 base_sha="$(git -C "$temporary_dir" rev-parse HEAD)"
 
+assert_compare() {
+  actual="$(awk -f "$script_dir/compare-semver.awk" "$1" "$2")"
+  if [ "$actual" != "$3" ]; then
+    echo "Unexpected SemVer ordering for $1 and $2: $actual" >&2
+    exit 1
+  fi
+}
+
+assert_compare 0.1.0-alpha.9 0.1.0-alpha.10 -1
+assert_compare 0.1.0-alpha.10 0.1.0-alpha.10 0
+assert_compare 1.0.0-alpha 1.0.0 -1
+assert_compare 2.0.0 1.99.99 1
+
 printf '%s\n' '0.1.0-alpha.16' > "$temporary_dir/version.txt"
 printf '%s\n' '{".":"0.1.0-alpha.16"}' > "$temporary_dir/.release-please-manifest.json"
 printf '%s\n' '# Changelog' '## [0.1.0-alpha.16](https://example.invalid)' '## [0.1.0-alpha.15](https://example.invalid)' > "$temporary_dir/CHANGELOG.md"
@@ -33,6 +46,14 @@ git -C "$temporary_dir" reset -q -- unexpected.txt
 printf '%s\n' '{".":"0.1.0-alpha.99"}' > "$temporary_dir/.release-please-manifest.json"
 if "$script_dir/validate-release-metadata.sh" "$base_sha" "$temporary_dir" >/dev/null 2>&1; then
   echo "Release metadata validator accepted mismatched versions." >&2
+  exit 1
+fi
+
+printf '%s\n' '0.1.0-alpha.14' > "$temporary_dir/version.txt"
+printf '%s\n' '{".":"0.1.0-alpha.14"}' > "$temporary_dir/.release-please-manifest.json"
+printf '%s\n' '# Changelog' '## [0.1.0-alpha.14](https://example.invalid)' > "$temporary_dir/CHANGELOG.md"
+if "$script_dir/validate-release-metadata.sh" "$base_sha" "$temporary_dir" >/dev/null 2>&1; then
+  echo "Release metadata validator accepted a version downgrade." >&2
   exit 1
 fi
 

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -5,39 +5,36 @@ script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 workflow="$project_dir/.github/workflows/release.yml"
 prepare_job="$(sed -n '/^  prepare:/,/^  publish:/p' "$workflow")"
-publish_job="$(sed -n '/^  publish:/,$p' "$workflow")"
+publish_job="$(sed -n '/^  publish:/,/^  release-pr:/p' "$workflow")"
+release_pr_job="$(sed -n '/^  release-pr:/,$p' "$workflow")"
 
-require_line() {
-  if ! printf '%s\n' "$prepare_job" | grep -Fq "$1"; then
-    echo "Release workflow is missing: $1" >&2
+require_in() {
+  section="$1"
+  expected="$2"
+  if ! printf '%s\n' "$section" | grep -Fq "$expected"; then
+    echo "Release workflow is missing: $expected" >&2
     exit 1
   fi
 }
 
-require_line '      checks: write'
-require_line '      - name: Start release metadata check'
-require_line '          GH_TOKEN: ${{ github.token }}'
-require_line "              -f name='Release metadata'"
-require_line '            gh api --method POST "/repos/$GITHUB_REPOSITORY/check-runs"'
-require_line '              -f details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"'
-require_line '        id: validate_release_metadata'
-require_line '      - name: Finish release metadata check'
-require_line '          CHECK_CONCLUSION: ${{ steps.validate_release_metadata.outcome == '\''success'\'' && '\''success'\'' || '\''failure'\'' }}'
-require_line '          gh api --method PATCH "/repos/$GITHUB_REPOSITORY/check-runs/$CHECK_ID"'
+require_in "$prepare_job" '          skip-github-pull-request: true'
+require_in "$publish_job" '      artifact-metadata: write'
+require_in "$publish_job" '          platforms: linux/amd64,linux/arm64'
+require_in "$publish_job" '          DOCKER_CONFIG="$anonymous_config" scripts/assert-image-platforms.sh "$VASTORA_CENTER_IMAGE"'
+require_in "$release_pr_job" '    needs: [prepare, publish]'
+require_in "$release_pr_job" "    if: always() && needs.prepare.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped')"
+require_in "$release_pr_job" '          skip-github-release: true'
+require_in "$release_pr_job" "            echo \"ci_id=\$(start_check 'CI / gate')\""
+require_in "$release_pr_job" "            echo \"codeql_id=\$(start_check 'CodeQL / gate')\""
+require_in "$release_pr_job" '        run: scripts/validate-release-metadata.sh "$BASE_SHA"'
 
-for required in \
-  '          platforms: linux/amd64,linux/arm64' \
-  '          DOCKER_CONFIG="$anonymous_config" scripts/assert-image-platforms.sh "$VASTORA_CENTER_IMAGE"'
-do
-  if ! printf '%s\n' "$publish_job" | grep -Fq "$required"; then
-    echo "Release publish workflow is missing: $required" >&2
-    exit 1
-  fi
-done
-
-if printf '%s\n' "$prepare_job" | grep -Fq 'gh workflow run'; then
-  echo 'Release metadata pull requests must not duplicate source workflows' >&2
+if printf '%s\n' "$prepare_job" | grep -Fq 'skip-github-release: true'; then
+  echo 'Release creation must not update the next release pull request.' >&2
+  exit 1
+fi
+if printf '%s\n' "$release_pr_job" | grep -Fq 'skip-github-pull-request: true'; then
+  echo 'Release pull request preparation must not publish a release.' >&2
   exit 1
 fi
 
-echo "Release metadata check workflow test passed"
+echo "Release workflow sequencing test passed"

--- a/scripts/validate-release-metadata.sh
+++ b/scripts/validate-release-metadata.sh
@@ -2,7 +2,8 @@
 set -eu
 
 base_ref="${1:-}"
-project_dir="${2:-$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)}"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+project_dir="${2:-$(CDPATH='' cd -- "$script_dir/.." && pwd)}"
 
 usage() {
   echo "Usage: validate-release-metadata.sh BASE_REF [PROJECT_DIR]" >&2
@@ -37,14 +38,24 @@ if [ "$actual_files" != "$expected_files" ]; then
   exit 1
 fi
 
+semver_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
 version="$(sed -n '1p' "$project_dir/version.txt")"
 version_lines="$(awk 'END {print NR}' "$project_dir/version.txt")"
 if [ -z "$version" ] || [ "$version_lines" -ne 1 ]; then
   echo "version.txt must contain exactly one non-empty line." >&2
   exit 1
 fi
-if ! printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+if ! printf '%s\n' "$version" | grep -Eq "$semver_pattern"; then
   echo "Release version is not valid SemVer: $version" >&2
+  exit 1
+fi
+base_version="$(git -C "$project_dir" show "$base_ref:version.txt")"
+if ! printf '%s\n' "$base_version" | grep -Eq "$semver_pattern"; then
+  echo "Base release version is not valid SemVer: $base_version" >&2
+  exit 1
+fi
+if [ "$(awk -f "$script_dir/compare-semver.awk" "$base_version" "$version")" != '-1' ]; then
+  echo "Release version must be greater than the base version: $version <= $base_version" >&2
   exit 1
 fi
 if ! jq -e --arg version "$version" \

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { Action, AgentEnrollment, AgentView, ApplicationCommand, ApplicationCommandKind, AppView, Application, CatalogSource, CloudflareOAuthPoll, CloudflareOAuthStart, CenterStatus, CenterUpdateStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Region, RegionSuggestion, Route, Service, SetupStatus, Site, SiteInput, ThreeXUIClientCommandInput, ThreeXUIControllerMigration } from "./types";
+import type { Action, AgentEnrollment, AgentView, ApplicationCommand, ApplicationCommandKind, AppView, Application, CatalogSource, CloudflareOAuthPoll, CloudflareOAuthStart, CenterStatus, CenterUpdateStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Region, RegionSuggestion, Route, Service, SetupStatus, Site, SiteInput, SystemDomain, SystemDomainSwitchResult, ThreeXUIClientCommandInput, ThreeXUIControllerMigration } from "./types";
 
 export class APIError extends Error {
   constructor(
@@ -72,6 +72,8 @@ export const api = {
   status: () => request<CenterStatus>("/api/v1/status"),
   centerUpdate: () => request<CenterUpdateStatus>("/api/v1/system/update"),
   startCenterUpdate: () => request<CenterUpdateStatus>("/api/v1/system/update", { method: "POST", body: "{}" }),
+  systemDomain: () => request<SystemDomain>("/api/v1/system/domain"),
+  switchSystemDomain: (sessionId: string, zoneId: string) => request<SystemDomainSwitchResult>("/api/v1/system/domain", { method: "POST", body: JSON.stringify({ sessionId, zoneId, confirm: true }) }),
   diagnostics: () => request<Diagnostics>("/api/v1/diagnostics"),
   downloadDiagnostics: () => download("/api/v1/diagnostics", `vastora-diagnostics-${new Date().toISOString().slice(0, 10)}.json`),
   downloadBackup: (password: string) => download("/api/v1/backups", "vastora-center.vastora", { method: "POST", body: JSON.stringify({ password }) }),

--- a/web/src/app-data.ts
+++ b/web/src/app-data.ts
@@ -19,7 +19,8 @@ export function emptyAppData(status: CenterStatus): AppData {
     routes: [],
     integrations: [],
     actions: [],
-    threeXUIControllerMigrations: []
+    threeXUIControllerMigrations: [],
+    systemDomain: { namespace: "", centerUrl: status.agentConnectUrl, headscaleUrl: "", cloudflareZone: "", aliases: [], activePublications: 0, pendingCleanup: 0, builtinHeadscale: false, cloudflareOAuthAvailable: false }
   };
 }
 
@@ -106,19 +107,21 @@ export async function loadScreenData(screen: Screen): Promise<AppDataPatch> {
       return { status, actions: actions.actions, agents: agents.agents };
     }
     case "settings": {
-      const [status, centerUpdate, sources, applications, agents] = await Promise.all([
+      const [status, centerUpdate, sources, applications, agents, systemDomain] = await Promise.all([
         statusPromise,
         api.centerUpdate(),
         api.sources(),
         api.applications(),
-        api.agents()
+        api.agents(),
+        api.systemDomain()
       ]);
       return {
         status,
         centerUpdate,
         sources: sources.sources,
         applications: applications.applications,
-        agents: agents.agents
+        agents: agents.agents,
+        systemDomain
       };
     }
   }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -38,6 +38,25 @@ export type AppData = {
   integrations: Integration[];
   actions: Action[];
   threeXUIControllerMigrations: ThreeXUIControllerMigration[];
+  systemDomain: SystemDomain;
+};
+
+export type SystemEndpointAlias = { kind: "center" | "headscale"; endpoint: string; certificateNotAfter?: string };
+export type SystemDomain = {
+  namespace: string;
+  centerUrl: string;
+  headscaleUrl: string;
+  cloudflareZone: string;
+  aliases: SystemEndpointAlias[];
+  activePublications: number;
+  pendingCleanup: number;
+  builtinHeadscale: boolean;
+  cloudflareOAuthAvailable: boolean;
+};
+export type SystemDomainSwitchResult = SystemDomain & {
+  previousCenterUrl: string;
+  previousHeadscaleUrl: string;
+  backupCreated: boolean;
 };
 
 export type CenterUpdateStatus = {

--- a/web/src/views/CloudflareOAuthConnect.tsx
+++ b/web/src/views/CloudflareOAuthConnect.tsx
@@ -16,9 +16,10 @@ type Props = {
   language: Language;
   zoneName?: string;
   onConnected: (zone: CloudflareZone) => void | Promise<void>;
+  onAuthorized?: (sessionID: string, zone: CloudflareZone) => void | Promise<void>;
 };
 
-export function CloudflareOAuthConnect({ available, connected, language, zoneName, onConnected }: Props) {
+export function CloudflareOAuthConnect({ available, connected, language, zoneName, onConnected, onAuthorized }: Props) {
   const cancelled = useRef(false);
   const authorizationWindow = useRef<Window | null>(null);
   const [sessionID, setSessionID] = useState("");
@@ -120,8 +121,12 @@ export function CloudflareOAuthConnect({ available, connected, language, zoneNam
     setStage("saving");
     setError("");
     try {
-      await api.completeCloudflareOAuth(sessionID, zone.id);
-      await onConnected(zone);
+      if (onAuthorized) {
+        await onAuthorized(sessionID, zone);
+      } else {
+        await api.completeCloudflareOAuth(sessionID, zone.id);
+        await onConnected(zone);
+      }
       setZones([]);
       setSessionID("");
       setStage("idle");

--- a/web/src/views/SettingsView.tsx
+++ b/web/src/views/SettingsView.tsx
@@ -14,6 +14,7 @@ import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetT
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { CenterUpdateCard } from "./CenterUpdateCard";
+import { SystemDomainSettings } from "./SystemDomainSettings";
 
 export function SettingsView({ data, language, mutate, onLogout }: { data: AppData; language: Language; mutate: Mutate; onLogout: () => Promise<void> }) {
   const [adding, setAdding] = useState(false);
@@ -30,6 +31,7 @@ export function SettingsView({ data, language, mutate, onLogout }: { data: AppDa
         <CardContent><dl className="grid gap-4 text-sm sm:grid-cols-3"><div><dt className="text-muted-foreground">{copy(language, "版本", "Version")}</dt><dd className="mt-1 font-medium">{data.status.version}</dd></div><div><dt className="text-muted-foreground">{copy(language, "节点", "Nodes")}</dt><dd className="mt-1 font-medium">{data.agents.filter((agent) => agent.status === "active").length}</dd></div><div><dt className="text-muted-foreground">{copy(language, "应用", "Apps")}</dt><dd className="mt-1 font-medium">{data.applications.length}</dd></div></dl></CardContent>
         <CardFooter className="justify-end"><Button onClick={() => setPasswordOpen(true)} size="sm" variant="outline"><KeyRoundIcon data-icon="inline-start" />{copy(language, "修改管理员密码", "Change administrator password")}</Button></CardFooter>
       </Card>
+      <SystemDomainSettings domain={data.systemDomain} language={language} />
       <CenterUpdateCard initial={data.centerUpdate} language={language} />
       <Card>
         <CardHeader><CardTitle className="flex items-center gap-2"><ShieldCheckIcon />{copy(language, "数据与故障排查", "Data & troubleshooting")}</CardTitle><CardDescription>{copy(language, "备份 Center 配置，或下载不含密钥的诊断信息。", "Back up Center configuration or download diagnostics that contain no secret values.")}</CardDescription></CardHeader>

--- a/web/src/views/SystemDomainSettings.tsx
+++ b/web/src/views/SystemDomainSettings.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { ArrowRightIcon, CheckCircle2Icon, Globe2Icon, ShieldAlertIcon } from "lucide-react";
+import { api } from "../api";
+import type { CloudflareZone, SystemDomain } from "../types";
+import type { Language } from "../translations";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field, FieldDescription, FieldError, FieldLabel } from "@/components/ui/field";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import { CloudflareOAuthConnect } from "./CloudflareOAuthConnect";
+import { copy, userError } from "./shared";
+
+export function SystemDomainSettings({ domain, language }: { domain: SystemDomain; language: Language }) {
+  const [open, setOpen] = useState(false);
+  const blocked = !domain.builtinHeadscale || domain.activePublications > 0 || domain.pendingCleanup > 0;
+  return <>
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><Globe2Icon aria-hidden="true" />{copy(language, "Vastora 域名", "Vastora domain")}</CardTitle>
+        <CardDescription>{copy(language, "Center、Headscale 和应用入口使用同一域名空间。", "Center, Headscale, and app access points share one domain namespace.")}</CardDescription>
+        <CardAction><Button disabled={blocked} onClick={() => setOpen(true)} size="sm" variant="outline">{copy(language, "切换域名", "Switch domain")}</Button></CardAction>
+      </CardHeader>
+      <CardContent className="grid gap-4 text-sm sm:grid-cols-3">
+        <DomainValue label={copy(language, "域名空间", "Namespace")} value={domain.namespace || "—"} />
+        <DomainValue label="Center" value={domain.centerUrl} />
+        <DomainValue label="Headscale" value={domain.headscaleUrl || "—"} />
+        {blocked ? <p className="sm:col-span-3 text-sm text-amber-600 dark:text-amber-400">{!domain.builtinHeadscale ? copy(language, "外部 Headscale 暂不支持自动迁移域名。", "Automatic domain migration is not available with external Headscale.") : domain.activePublications > 0 ? copy(language, `请先停止 ${domain.activePublications} 个访问入口。`, `Stop ${domain.activePublications} access point(s) first.`) : copy(language, `请等待 ${domain.pendingCleanup} 个入口完成清理。`, `Wait for ${domain.pendingCleanup} access point cleanup(s).`)}</p> : null}
+        {domain.aliases.length > 0 ? <p className="sm:col-span-3 text-xs text-muted-foreground">{copy(language, `仍保留 ${domain.aliases.length} 个旧系统地址作为迁移过渡。`, `${domain.aliases.length} previous system address(es) remain available during transition.`)}</p> : null}
+      </CardContent>
+    </Card>
+    <DomainSwitchSheet domain={domain} language={language} onClose={() => setOpen(false)} open={open} />
+  </>;
+}
+
+function DomainValue({ label, value }: { label: string; value: string }) {
+  return <div className="min-w-0"><p className="text-muted-foreground">{label}</p><p className="mt-1 truncate font-medium" title={value}>{value}</p></div>;
+}
+
+function DomainSwitchSheet({ domain, language, onClose, open }: { domain: SystemDomain; language: Language; onClose: () => void; open: boolean }) {
+  const [sessionID, setSessionID] = useState("");
+  const [zone, setZone] = useState<CloudflareZone | null>(null);
+  const [confirmed, setConfirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const namespace = zone ? `vastora.${zone.name}` : "";
+  const resetAndClose = () => {
+    if (busy) return;
+    setSessionID(""); setZone(null); setConfirmed(false); setError(""); onClose();
+  };
+  const submit = async () => {
+    if (!zone || !sessionID || !confirmed) return;
+    setBusy(true); setError("");
+    try {
+      const result = await api.switchSystemDomain(sessionID, zone.id);
+      window.location.assign(new URL("/settings", result.centerUrl));
+    } catch (switchError) {
+      setError(userError(language, switchError));
+      setBusy(false);
+    }
+  };
+  return <Sheet onOpenChange={(next) => { if (!next) resetAndClose(); }} open={open}>
+    <SheetContent className="sm:max-w-xl">
+      <SheetHeader><SheetTitle>{copy(language, "切换 Vastora 域名", "Switch Vastora domain")}</SheetTitle><SheetDescription>{copy(language, "一次迁移 Center、Headscale 和默认应用域名空间。", "Move Center, Headscale, and the default app namespace together.")}</SheetDescription></SheetHeader>
+      <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-4 pb-4">
+        <Alert><ShieldAlertIcon aria-hidden="true" /><AlertTitle>{copy(language, "旧地址不会立即失效", "Previous addresses remain available")}</AlertTitle><AlertDescription>{copy(language, "Vastora 会先创建数据库快照，再启用新域名。在线节点会在下一次心跳验证新地址后自动切换；离线节点仍可通过旧地址恢复。应用访问入口需在切换后重新创建。", "Vastora creates a database snapshot before enabling the new domain. Online nodes verify and switch to the new address on their next heartbeat; offline nodes can still recover through the previous address. Recreate app access points after the switch.")}</AlertDescription></Alert>
+        {!zone ? <CloudflareOAuthConnect available={domain.cloudflareOAuthAvailable} connected={false} language={language} onAuthorized={async (authorizedSession, selected) => { setSessionID(authorizedSession); setZone(selected); }} onConnected={() => undefined} /> : <div className="rounded-2xl border bg-muted/20 p-4">
+          <div className="flex items-center gap-2 font-medium"><CheckCircle2Icon aria-hidden="true" className="size-5 text-emerald-500" />{zone.name}</div>
+          <div className="mt-4 grid gap-3 text-sm">
+            <Preview oldValue={domain.centerUrl} value={`https://center.${namespace}`} />
+            <Preview oldValue={domain.headscaleUrl} value={`https://headscale.${namespace}`} />
+            <Preview oldValue={domain.namespace} value={namespace} />
+          </div>
+          <Button className="mt-3" disabled={busy} onClick={() => { setSessionID(""); setZone(null); setConfirmed(false); }} size="sm" variant="ghost">{copy(language, "重新选择", "Choose another")}</Button>
+        </div>}
+        {busy ? <Alert><Spinner /><AlertTitle>{copy(language, "正在安全切换域名", "Switching domain safely")}</AlertTitle><AlertDescription>{copy(language, "正在依次完成备份、DNS、证书和网关更新。证书签发可能需要几分钟，请不要关闭页面。", "Completing backup, DNS, certificate, and gateway updates in order. Certificate issuance can take a few minutes; keep this page open.")}</AlertDescription></Alert> : null}
+        {zone ? <Field orientation="horizontal"><div className="flex flex-1 flex-col gap-1"><FieldLabel htmlFor="confirm-domain-switch">{copy(language, "确认迁移全部系统域名", "Confirm the system-domain migration")}</FieldLabel><FieldDescription>{copy(language, "新建入口将使用新域名空间；旧应用入口不会自动复制。", "New access points use the new namespace; old app access points are not copied automatically.")}</FieldDescription></div><Switch checked={confirmed} disabled={busy} id="confirm-domain-switch" onCheckedChange={setConfirmed} /></Field> : null}
+        {error ? <FieldError role="alert">{error}</FieldError> : null}
+      </div>
+      <SheetFooter><Button disabled={busy} onClick={resetAndClose} type="button" variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy || !zone || !confirmed} onClick={() => void submit()} type="button">{busy ? <Spinner data-icon="inline-start" /> : <ArrowRightIcon data-icon="inline-start" />}{copy(language, "切换域名", "Switch domain")}</Button></SheetFooter>
+    </SheetContent>
+  </Sheet>;
+}
+
+function Preview({ oldValue, value }: { oldValue: string; value: string }) {
+  return <div className="grid min-w-0 gap-1 sm:grid-cols-[1fr_auto_1fr] sm:items-center"><span className="truncate text-muted-foreground" title={oldValue}>{oldValue || "—"}</span><ArrowRightIcon aria-hidden="true" className="hidden size-4 text-muted-foreground sm:block" /><span className="truncate font-medium" title={value}>{value}</span></div>;
+}

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -35,6 +35,7 @@ const dashboard = (): AppData => ({
   status: { version: "test", agentInstallerAvailable: true, agentConnectionMode: "lan", agentConnectUrl: "https://center.example.com" },
   centerUpdate: { currentVersion: "test", latestVersion: "test", updateAvailable: false, automatic: true, state: "idle", checkedAt: "2026-08-18T00:00:00Z" },
   sources: [], organizations: [], routes: [], actions: [], integrations: [], threeXUIControllerMigrations: [],
+  systemDomain: { namespace: "vastora.example.com", centerUrl: "https://center.vastora.example.com", headscaleUrl: "https://headscale.vastora.example.com", cloudflareZone: "example.com", aliases: [], activePublications: 0, pendingCleanup: 0, builtinHeadscale: true, cloudflareOAuthAvailable: true },
   sites: [{ id: "site", organizationId: "org", name: "Home", code: "home", description: "", timezone: "Asia/Singapore", domainSuffix: "home.example", status: "active", gatewayNodes: ["agent"], gatewayStatus: "ready", createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" }],
   agents: [{ id: "agent", name: "home-server", version: "test", operatingSystem: "linux", architecture: "amd64", status: "active", appliedInstallations: 1, enrolledAt: "2026-08-18T00:00:00Z", lastSeenAt: "2026-08-18T00:00:00Z", connected: true, siteId: "site", roles: ["worker", "gateway"], capabilities: { docker: true, gateway: true, tunnel: true, metrics: false, logs: false }, networkCandidates: [{ address: "192.168.1.2", interface: "eth0", family: "ipv4", kind: "lan", observedAt: "2026-08-18T00:00:00Z" }], networkProfile: { serviceAddress: "192.168.1.2", lanAddress: "192.168.1.2", enabledKinds: ["lan"], directPublic: false }, gatewayHealthy: true }],
   apps: [{ key: "vastora-official/komari-agent", sourceId: "vastora-official", fetchedAt: "2026-08-18T00:00:00Z", app: { id: "komari-agent", version: "1.2.60", name: { en: "Komari Agent", "zh-CN": "Komari 探针" }, description: { en: "Monitoring", "zh-CN": "监控探针" }, hostAccess: true, config: [] } }],
@@ -1175,6 +1176,18 @@ describe("network and app views", () => {
     act(() => changePassword?.click());
     expect(document.querySelector<HTMLInputElement>("#new-password")?.minLength).toBe(10);
     expect(document.body.textContent).toContain("至少 10 个字符。");
+  });
+
+  it("offers one safe workflow for switching the Vastora domain", () => {
+    const container = render(<SettingsView data={dashboard()} language="zh-CN" mutate={async () => undefined} onLogout={async () => undefined} />);
+    expect(container.textContent).toContain("Vastora 域名");
+    expect(container.textContent).toContain("https://center.vastora.example.com");
+    const changeDomain = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("切换域名"));
+    act(() => changeDomain?.click());
+    expect(document.body.textContent).toContain("旧地址不会立即失效");
+    expect(document.body.textContent).toContain("登录 Cloudflare");
+    expect(document.body.textContent).toContain("下一次心跳验证新地址后自动切换");
+    expect(document.body.textContent).toContain("应用访问入口需在切换后重新创建");
   });
 
   it("shows a confirmed Center update instead of exposing Docker access", () => {


### PR DESCRIPTION
## Summary
- add confirmation-gated migration for an Agent already enrolled with another Center
- add backed-up system-domain switching for Center, bundled Headscale, certificates, DNS, gateways, and sites
- preserve previous system endpoints as transition aliases and let Agents switch only after verifying the new Center
- reduce routine GitHub Actions minutes with path classification, caching, concurrency, and release workflow hardening

## Validation
- `go test ./internal/agent ./internal/center ./internal/deployer ./internal/deployapi`
- `npm run build`
- `npm test -- src/views/views.test.tsx` (62 tests)
- `make deployment-check`
- `scripts/test-ci-workflows.sh`
- `scripts/test-release-workflow.sh`
- `scripts/test-release-metadata.sh`
- `GOCACHE=/tmp/vastora-go-cache make agent-binaries`
- staged diff public-content scan and `git diff --check`

## Release scope
Publish the next prerelease after required checks pass. Do not update any existing deployment.