### PR TITLE
fix(ci): allow release PR comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.retry.outputs.release_created || steps.release.outputs.release_created }}
       release_sha: ${{ steps.retry.outputs.release_sha || steps.release.outputs.sha }}

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -18,6 +18,7 @@ require_in() {
 }
 
 require_in "$prepare_job" '          skip-github-pull-request: true'
+require_in "$prepare_job" '      pull-requests: write'
 require_in "$publish_job" '      artifact-metadata: write'
 require_in "$publish_job" '          platforms: linux/amd64,linux/arm64'
 require_in "$publish_job" '          DOCKER_CONFIG="$anonymous_config" scripts/assert-image-platforms.sh "$VASTORA_CENTER_IMAGE"'


### PR DESCRIPTION
## Summary
- grant the Release Please prepare job only `pull-requests: write` in addition to its existing content permission
- enforce that permission in the release workflow policy test

This fixes the comment step that required a draft-release retry for v0.1.0-alpha.51. It does not publish or deploy anything by itself.

## Validation
- `actionlint .github/workflows/release.yml`
- `scripts/test-release-workflow.sh`
- `make deployment-check`
- `git diff --check`