### PR TITLE
fix: keep Center settings consistent after changes

### DIFF
--- a/internal/center/cloudflare.go
+++ b/internal/center/cloudflare.go
@@ -127,6 +127,21 @@ func (s *Store) cloudflare(ctx context.Context) (cloudflareClient, error) {
 	return cloudflareClient{accountID: accountID, zoneID: zoneID, token: token.AccessToken, baseURL: s.cloudflareOAuth.APIURL, http: s.cloudflareOAuth.HTTPClient}, nil
 }
 
+func (s *Store) CloudflareZones(ctx context.Context) ([]CloudflareZone, error) {
+	client, err := s.cloudflare(ctx)
+	if err != nil {
+		return nil, err
+	}
+	zones, err := s.listCloudflareZones(ctx, client.token)
+	if err != nil {
+		return nil, err
+	}
+	if len(zones) == 0 {
+		return nil, errors.New("center: Cloudflare authorization has no accessible zones")
+	}
+	return zones, nil
+}
+
 func (s *Store) ensureCloudflareTunnel(ctx context.Context, agentID string) error {
 	var existing int
 	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cloudflare_tunnels WHERE agent_id = ?`, agentID).Scan(&existing); err != nil {

--- a/internal/center/server.go
+++ b/internal/center/server.go
@@ -120,6 +120,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/v1/integrations/cloudflare/oauth/start", s.requireAuth(true, s.handleStartCloudflareOAuth))
 	mux.HandleFunc("POST /api/v1/integrations/cloudflare/oauth/poll", s.requireAuth(true, s.handlePollCloudflareOAuth))
 	mux.HandleFunc("POST /api/v1/integrations/cloudflare/oauth/complete", s.requireAuth(true, s.handleCompleteCloudflareOAuth))
+	mux.HandleFunc("GET /api/v1/integrations/cloudflare/zones", s.requireAuth(false, s.handleListCloudflareZones))
 	mux.HandleFunc("POST /api/v1/setup/cloudflare/dns", s.requireAuth(true, s.handleConfigureSetupDNS))
 	mux.HandleFunc("POST /api/v1/setup/public-entry/verify", s.requireAuth(true, s.handleVerifySetupPublicEntry))
 	mux.HandleFunc("PUT /api/v1/integrations/headscale", s.requireAuth(true, s.handleConfigureHeadscale))

--- a/internal/center/server_integrations.go
+++ b/internal/center/server_integrations.go
@@ -61,6 +61,15 @@ func (s *Server) handleCompleteCloudflareOAuth(writer http.ResponseWriter, reque
 	writeJSON(writer, http.StatusOK, value)
 }
 
+func (s *Server) handleListCloudflareZones(writer http.ResponseWriter, request *http.Request) {
+	values, err := s.store.CloudflareZones(request.Context())
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"zones": values})
+}
+
 func (s *Server) handleSystemDomain(writer http.ResponseWriter, request *http.Request) {
 	value, err := s.store.SystemDomain(request.Context())
 	if err != nil {

--- a/internal/center/system_domain.go
+++ b/internal/center/system_domain.go
@@ -28,9 +28,8 @@ type SystemDomainView struct {
 }
 
 type SystemDomainSwitchInput struct {
-	SessionID string `json:"sessionId"`
-	ZoneID    string `json:"zoneId"`
-	Confirm   bool   `json:"confirm"`
+	ZoneID  string `json:"zoneId"`
+	Confirm bool   `json:"confirm"`
 }
 
 type SystemDomainSwitchResult struct {
@@ -104,11 +103,10 @@ func (s *Server) SwitchSystemDomain(ctx context.Context, input SystemDomainSwitc
 	if current.ActivePublications != 0 || current.PendingCleanup != 0 {
 		return SystemDomainSwitchResult{}, errors.New("center: stop all access points and wait for cleanup before switching the system domain")
 	}
-	sessionID, selected, token, err := s.store.cloudflareOAuthSelection(input.SessionID, input.ZoneID)
+	cloudflare, selected, err := s.store.cloudflareForZone(ctx, input.ZoneID)
 	if err != nil {
 		return SystemDomainSwitchResult{}, err
 	}
-	cloudflare := cloudflareClient{accountID: selected.AccountID, zoneID: selected.ID, token: token.AccessToken, baseURL: s.store.cloudflareOAuth.APIURL, http: s.store.cloudflareOAuth.HTTPClient}
 	zoneName, err := cloudflare.verify(ctx)
 	if err != nil {
 		return SystemDomainSwitchResult{}, err
@@ -180,7 +178,7 @@ func (s *Server) SwitchSystemDomain(ctx context.Context, input SystemDomainSwitc
 		restoreErr := s.store.reconcileHeadscaleDNS(context.WithoutCancel(ctx))
 		return SystemDomainSwitchResult{}, errors.Join(fmt.Errorf("center: apply the new system domain: %w", err), restoreErr)
 	}
-	if err := s.store.commitSystemDomainSwitch(ctx, current, selected, token, zoneName, centerURL, headscaleURL, newCertificate, newDNS); err != nil {
+	if err := s.store.commitSystemDomainSwitch(ctx, current, selected, zoneName, centerURL, headscaleURL, newCertificate, newDNS); err != nil {
 		rollback := deployapi.HeadscaleInstallRequest{
 			CenterURL: current.CenterURL, HeadscaleURL: current.HeadscaleURL,
 			CenterAliases:    append(centerAliases[:len(centerAliases)-1], deployapi.CenterEndpointAlias{URL: centerURL, CertificatePEM: newCertificate.CertificatePEM, CertificateKeyPEM: newCertificate.PrivateKeyPEM}),
@@ -193,14 +191,34 @@ func (s *Server) SwitchSystemDomain(ctx context.Context, input SystemDomainSwitc
 		restoreErr := s.store.reconcileHeadscaleDNS(context.WithoutCancel(ctx))
 		return SystemDomainSwitchResult{}, errors.Join(err, rollbackErr, restoreErr)
 	}
-	s.store.cloudflareOAuthMu.Lock()
-	delete(s.store.cloudflareOAuthSessions, sessionID)
-	s.store.cloudflareOAuthMu.Unlock()
 	updated, err := s.store.SystemDomain(ctx)
 	if err != nil {
 		return SystemDomainSwitchResult{}, err
 	}
 	return SystemDomainSwitchResult{SystemDomainView: updated, PreviousCenterURL: current.CenterURL, PreviousHeadscaleURL: current.HeadscaleURL, BackupCreated: true}, nil
+}
+
+func (s *Store) cloudflareForZone(ctx context.Context, zoneID string) (cloudflareClient, CloudflareZone, error) {
+	zoneID = strings.TrimSpace(zoneID)
+	if zoneID == "" {
+		return cloudflareClient{}, CloudflareZone{}, errors.New("center: select a Cloudflare zone")
+	}
+	client, err := s.cloudflare(ctx)
+	if err != nil {
+		return cloudflareClient{}, CloudflareZone{}, err
+	}
+	zones, err := s.listCloudflareZones(ctx, client.token)
+	if err != nil {
+		return cloudflareClient{}, CloudflareZone{}, err
+	}
+	for _, zone := range zones {
+		if zone.ID == zoneID {
+			client.accountID = zone.AccountID
+			client.zoneID = zone.ID
+			return client, zone, nil
+		}
+	}
+	return cloudflareClient{}, CloudflareZone{}, errors.New("center: selected Cloudflare zone is not available to the saved authorization")
 }
 
 func ensureSystemDNSRecord(ctx context.Context, client cloudflareClient, endpoint, address string) (SetupDNSRecord, bool, error) {
@@ -248,7 +266,7 @@ func (s *Store) createSystemDomainBackup(ctx context.Context) (string, error) {
 	return path, nil
 }
 
-func (s *Store) commitSystemDomainSwitch(ctx context.Context, current SystemDomainView, selected CloudflareZone, token cloudflareOAuthToken, zoneName, centerURL, headscaleURL string, certificate managedCertificate, dns SetupDNSRecord) error {
+func (s *Store) commitSystemDomainSwitch(ctx context.Context, current SystemDomainView, selected CloudflareZone, zoneName, centerURL, headscaleURL string, certificate managedCertificate, dns SetupDNSRecord) error {
 	encodedCertificate, err := json.Marshal(certificate)
 	if err != nil {
 		return err
@@ -309,8 +327,10 @@ func (s *Store) commitSystemDomainSwitch(ctx context.Context, current SystemDoma
 	if _, err := tx.ExecContext(ctx, `UPDATE network_integrations SET endpoint = ?, updated_at = ? WHERE kind = 'headscale' AND mode = 'builtin' AND status = 'configured'`, headscaleURL, now); err != nil {
 		return err
 	}
-	if err := s.saveCloudflareOAuthIntegrationTx(ctx, tx, selected, token, zoneName); err != nil {
+	if result, err := tx.ExecContext(ctx, `UPDATE network_integrations SET endpoint = ?, account_id = ?, zone_id = ?, last_error = '', updated_at = ? WHERE kind = 'cloudflare' AND mode = 'oauth' AND status = 'configured'`, zoneName, selected.AccountID, selected.ID, now); err != nil {
 		return err
+	} else if changed, _ := result.RowsAffected(); changed != 1 {
+		return errors.New("center: Cloudflare authorization changed during the domain switch")
 	}
 	oldNamespace := domainNamespaceFromCenterURL(current.CenterURL)
 	newNamespace := domainNamespaceFromCenterURL(centerURL)

--- a/internal/center/system_domain_test.go
+++ b/internal/center/system_domain_test.go
@@ -18,6 +18,11 @@ func TestSwitchSystemDomainMovesPrimaryEndpointsAndKeepsAliases(t *testing.T) {
 	cloudflare := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/zones":
+			if request.Header.Get("Authorization") != "Bearer saved-access-token" {
+				t.Fatalf("domain switch did not reuse the saved Cloudflare token")
+			}
+			_, _ = writer.Write([]byte(`{"success":true,"errors":[],"result":[{"id":"zone","name":"old.example.com","account":{"id":"account","name":"Old account"}},{"id":"new-zone","name":"new.example.com","account":{"id":"new-account","name":"New account"}}],"result_info":{"total_pages":1}}`))
 		case request.Method == http.MethodGet && request.URL.Path == "/accounts/new-account/cfd_tunnel":
 			_, _ = writer.Write([]byte(`{"success":true,"errors":[],"result":[]}`))
 		case request.Method == http.MethodGet && request.URL.Path == "/zones/new-zone":
@@ -39,13 +44,9 @@ func TestSwitchSystemDomainMovesPrimaryEndpointsAndKeepsAliases(t *testing.T) {
 	}
 	defer store.Close()
 	store.cloudflareOAuth = cloudflareOAuthConfig{APIURL: cloudflare.URL, HTTPClient: cloudflare.Client()}
+	storeCloudflareOAuthIntegration(t, store, cloudflareOAuthToken{AccessToken: "saved-access-token", RefreshToken: "saved-refresh-token", ExpiresAt: time.Now().Add(time.Hour)})
 	store.discoverNetworkCandidates = func(time.Time) ([]networking.Candidate, error) {
 		return []networking.Candidate{{Address: "100.64.0.1", Interface: "tailscale0", Family: "ipv4", Kind: networking.KindHeadscale}}, nil
-	}
-	store.cloudflareOAuthSessions["switch-session"] = &cloudflareOAuthSession{
-		Token:     cloudflareOAuthToken{AccessToken: "new-access-token", RefreshToken: "new-refresh-token", ExpiresAt: time.Now().Add(time.Hour)},
-		Zones:     []CloudflareZone{{ID: "new-zone", Name: "new.example.com", AccountID: "new-account"}},
-		ExpiresAt: time.Now().Add(time.Hour),
 	}
 	store.issueDomainCertificate = func(_ context.Context, _ cloudflareClient, zone string, names ...string) (managedCertificate, error) {
 		if zone != "new.example.com" || len(names) != 1 || names[0] != "center.vastora.new.example.com" {
@@ -77,7 +78,11 @@ func TestSwitchSystemDomainMovesPrimaryEndpointsAndKeepsAliases(t *testing.T) {
 	}
 	installer := &fakeBuiltinHeadscaleInstaller{}
 	server := NewServer(store, "", false).WithInfrastructureManager(installer)
-	result, err := server.SwitchSystemDomain(ctx, SystemDomainSwitchInput{SessionID: "switch-session", ZoneID: "new-zone", Confirm: true})
+	var previousSecretID string
+	if err := store.db.QueryRowContext(ctx, `SELECT secret_id FROM network_integrations WHERE kind = 'cloudflare'`).Scan(&previousSecretID); err != nil {
+		t.Fatal(err)
+	}
+	result, err := server.SwitchSystemDomain(ctx, SystemDomainSwitchInput{ZoneID: "new-zone", Confirm: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,8 +115,12 @@ func TestSwitchSystemDomainMovesPrimaryEndpointsAndKeepsAliases(t *testing.T) {
 	if err != nil || len(backups) != 1 {
 		t.Fatalf("domain backups = %v, err = %v", backups, err)
 	}
-	if _, exists := store.cloudflareOAuthSessions["switch-session"]; exists {
-		t.Fatal("completed domain-switch OAuth session was retained")
+	var endpoint, accountID, zoneID, currentSecretID string
+	if err := store.db.QueryRowContext(ctx, `SELECT endpoint, account_id, zone_id, secret_id FROM network_integrations WHERE kind = 'cloudflare'`).Scan(&endpoint, &accountID, &zoneID, &currentSecretID); err != nil {
+		t.Fatal(err)
+	}
+	if endpoint != "new.example.com" || accountID != "new-account" || zoneID != "new-zone" || currentSecretID != previousSecretID {
+		t.Fatalf("Cloudflare selection did not preserve the saved authorization: endpoint=%q account=%q zone=%q secret_changed=%v", endpoint, accountID, zoneID, currentSecretID != previousSecretID)
 	}
 }
 
@@ -138,7 +147,7 @@ func TestSwitchSystemDomainRequiresStoppedAccessPoints(t *testing.T) {
 		}
 	}
 	server := NewServer(store, "", false).WithInfrastructureManager(&fakeBuiltinHeadscaleInstaller{})
-	_, err = server.SwitchSystemDomain(ctx, SystemDomainSwitchInput{SessionID: "missing", ZoneID: "missing", Confirm: true})
+	_, err = server.SwitchSystemDomain(ctx, SystemDomainSwitchInput{ZoneID: "missing", Confirm: true})
 	if err == nil || !strings.Contains(err.Error(), "stop all access points") {
 		t.Fatalf("active publication was accepted: %v", err)
 	}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import { AppWindowIcon, CircleAlertIcon, CircleCheckIcon, HistoryIcon, HomeIcon,
 import { APIError, api } from "./api";
 import { emptyAppData, loadScreenData, pathForScreen, screenFromPath } from "./app-data";
 import { administratorPasswordMinLength } from "./lib/security";
-import type { AppData, Screen, SetupStatus } from "./types";
+import type { AppData, CenterUpdateStatus, Screen, SetupStatus } from "./types";
 import type { Language } from "./translations";
 import { Brand, PageHeading, copy, userError } from "./views/shared";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -207,6 +207,10 @@ export function App() {
       }
     }
   }, [language, screen, loadScreen]);
+  const updateCenterStatus = useCallback((centerUpdate: CenterUpdateStatus) => {
+    setData((current) => current ? { ...current, centerUpdate, status: { ...current.status, version: centerUpdate.currentVersion } } : current);
+  }, []);
+  const refreshSettings = useCallback(() => loadScreen("settings"), [loadScreen]);
 
   if (phase === "loading") return <CenteredState language={language} loading />;
   if (phase === "unavailable") return <CenteredState language={language} message={notice?.message} onRetry={initialize} />;
@@ -290,7 +294,7 @@ export function App() {
               {loadedScreens.has(screen) && screen === "apps" ? <AppsView data={data} language={language} mutate={mutate} /> : null}
               {loadedScreens.has(screen) && screen === "network" ? <NetworkView data={data} language={language} mutate={mutate} /> : null}
               {loadedScreens.has(screen) && screen === "activity" ? <ActivityView actions={data.actions} agents={data.agents} language={language} /> : null}
-              {loadedScreens.has(screen) && screen === "settings" ? <SettingsView data={data} language={language} mutate={mutate} onLogout={async () => { await api.logout(); setData(null); setLoadedScreens(new Set()); setPhase("login"); }} /> : null}
+              {loadedScreens.has(screen) && screen === "settings" ? <SettingsView data={data} language={language} mutate={mutate} onCenterUpdateStatus={updateCenterStatus} onLogout={async () => { await api.logout(); setData(null); setLoadedScreens(new Set()); setPhase("login"); }} onRefresh={refreshSettings} /> : null}
             </Suspense>
           </div>
         </SidebarInset>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { Action, AgentEnrollment, AgentView, ApplicationCommand, ApplicationCommandKind, AppView, Application, CatalogSource, CloudflareOAuthPoll, CloudflareOAuthStart, CenterStatus, CenterUpdateStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Region, RegionSuggestion, Route, Service, SetupStatus, Site, SiteInput, SystemDomain, SystemDomainSwitchResult, ThreeXUIClientCommandInput, ThreeXUIControllerMigration } from "./types";
+import type { Action, AgentEnrollment, AgentView, ApplicationCommand, ApplicationCommandKind, AppView, Application, CatalogSource, CloudflareOAuthPoll, CloudflareOAuthStart, CloudflareZone, CenterStatus, CenterUpdateStatus, Deployment, Diagnostics, HeadscaleJoin, InitialSetupInput, Integration, NetworkProfile, Organization, Publication, PublicationKind, Region, RegionSuggestion, Route, Service, SetupStatus, Site, SiteInput, SystemDomain, SystemDomainSwitchResult, ThreeXUIClientCommandInput, ThreeXUIControllerMigration } from "./types";
 
 export class APIError extends Error {
   constructor(
@@ -73,7 +73,7 @@ export const api = {
   centerUpdate: () => request<CenterUpdateStatus>("/api/v1/system/update"),
   startCenterUpdate: () => request<CenterUpdateStatus>("/api/v1/system/update", { method: "POST", body: "{}" }),
   systemDomain: () => request<SystemDomain>("/api/v1/system/domain"),
-  switchSystemDomain: (sessionId: string, zoneId: string) => request<SystemDomainSwitchResult>("/api/v1/system/domain", { method: "POST", body: JSON.stringify({ sessionId, zoneId, confirm: true }) }),
+  switchSystemDomain: (zoneId: string) => request<SystemDomainSwitchResult>("/api/v1/system/domain", { method: "POST", body: JSON.stringify({ zoneId, confirm: true }) }),
   diagnostics: () => request<Diagnostics>("/api/v1/diagnostics"),
   downloadDiagnostics: () => download("/api/v1/diagnostics", `vastora-diagnostics-${new Date().toISOString().slice(0, 10)}.json`),
   downloadBackup: (password: string) => download("/api/v1/backups", "vastora-center.vastora", { method: "POST", body: JSON.stringify({ password }) }),
@@ -118,6 +118,7 @@ export const api = {
   startCloudflareOAuth: () => request<CloudflareOAuthStart>("/api/v1/integrations/cloudflare/oauth/start", { method: "POST", body: "{}" }),
   pollCloudflareOAuth: (sessionId: string) => request<CloudflareOAuthPoll>("/api/v1/integrations/cloudflare/oauth/poll", { method: "POST", body: JSON.stringify({ sessionId }) }),
   completeCloudflareOAuth: (sessionId: string, zoneId: string) => request<Integration>("/api/v1/integrations/cloudflare/oauth/complete", { method: "POST", body: JSON.stringify({ sessionId, zoneId }) }),
+  cloudflareZones: () => request<{ zones: CloudflareZone[] }>("/api/v1/integrations/cloudflare/zones"),
   configureSetupDNS: (input: { centerUrl: string; headscaleUrl?: string; publicAddress: string; gatewayAddress: string; natConfirmed: boolean }) => request<{ records: Array<{ id: string; type: "A" | "AAAA"; name: string; content: string }> }>("/api/v1/setup/cloudflare/dns", { method: "POST", body: JSON.stringify(input) }),
   verifySetupPublicEntry: (input: { publicAddress: string; gatewayAddress: string; natConfirmed: boolean }) => request<{ status: "ready"; publicAddress: string; gatewayAddress: string; ports: number[] }>("/api/v1/setup/public-entry/verify", { method: "POST", body: JSON.stringify(input) }),
   configureHeadscale: (input: { mode: "builtin" | "external"; url: string; apiKey?: string }) => request<Integration>("/api/v1/integrations/headscale", { method: "PUT", body: JSON.stringify(input) }),

--- a/web/src/views/CenterUpdateCard.tsx
+++ b/web/src/views/CenterUpdateCard.tsx
@@ -13,37 +13,41 @@ import { Spinner } from "@/components/ui/spinner";
 
 const manualCommand = "curl -LsSf https://vastora.petauron.com/install.sh | sudo sh -s -- center";
 
-export function CenterUpdateCard({ initial, language }: { initial: CenterUpdateStatus; language: Language }) {
-  const [status, setStatus] = useState(initial);
+export function CenterUpdateCard({ language, onRefresh, onStatusChange, status }: { language: Language; onRefresh: () => Promise<void>; onStatusChange: (status: CenterUpdateStatus) => void; status: CenterUpdateStatus }) {
   const [confirming, setConfirming] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const running = status.state === "queued" || status.state === "applying";
 
-  useEffect(() => { setStatus(initial); }, [initial]);
   useEffect(() => {
     if (!running) return;
     let stopped = false;
+    let timer = 0;
     const poll = async () => {
       try {
         const next = await api.centerUpdate();
-        if (!stopped) setStatus(next);
+        if (stopped) return;
+        if (next.state === "succeeded") {
+          await onRefresh();
+          return;
+        }
+        onStatusChange(next);
       } catch {
         // Center restarts during a normal update. Keep the progress state and retry.
       }
+      if (!stopped) timer = window.setTimeout(() => void poll(), 2000);
     };
-    const timer = window.setInterval(() => void poll(), 2000);
     void poll();
-    return () => { stopped = true; window.clearInterval(timer); };
-  }, [running]);
+    return () => { stopped = true; window.clearTimeout(timer); };
+  }, [onRefresh, onStatusChange, running]);
 
   const refresh = async () => {
     setBusy(true); setError("");
-    try { setStatus(await api.centerUpdate()); } catch (refreshError) { setError(userError(language, refreshError)); } finally { setBusy(false); }
+    try { onStatusChange(await api.centerUpdate()); } catch (refreshError) { setError(userError(language, refreshError)); } finally { setBusy(false); }
   };
   const start = async () => {
     setBusy(true); setError("");
-    try { setStatus(await api.startCenterUpdate()); setConfirming(false); } catch (updateError) { setError(userError(language, updateError)); } finally { setBusy(false); }
+    try { onStatusChange(await api.startCenterUpdate()); setConfirming(false); } catch (updateError) { setError(userError(language, updateError)); } finally { setBusy(false); }
   };
 
   return <>

--- a/web/src/views/SettingsView.tsx
+++ b/web/src/views/SettingsView.tsx
@@ -3,7 +3,7 @@ import { ChevronDownIcon, DatabaseBackupIcon, DatabaseIcon, DownloadIcon, KeyRou
 import { api } from "../api";
 import { SignOutButton, type AppData, type Mutate } from "../App";
 import { administratorPasswordMinLength } from "../lib/security";
-import type { CatalogSource } from "../types";
+import type { CatalogSource, CenterUpdateStatus } from "../types";
 import type { Language } from "../translations";
 import { PageHeading, StateBadge, TechnicalError, copy, formatDate, userError } from "./shared";
 import { Button } from "@/components/ui/button";
@@ -16,7 +16,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { CenterUpdateCard } from "./CenterUpdateCard";
 import { SystemDomainSettings } from "./SystemDomainSettings";
 
-export function SettingsView({ data, language, mutate, onLogout }: { data: AppData; language: Language; mutate: Mutate; onLogout: () => Promise<void> }) {
+export function SettingsView({ data, language, mutate, onCenterUpdateStatus, onLogout, onRefresh }: { data: AppData; language: Language; mutate: Mutate; onCenterUpdateStatus: (status: CenterUpdateStatus) => void; onLogout: () => Promise<void>; onRefresh: () => Promise<void> }) {
   const [adding, setAdding] = useState(false);
   const [backupOpen, setBackupOpen] = useState(false);
   const [passwordOpen, setPasswordOpen] = useState(false);
@@ -28,11 +28,11 @@ export function SettingsView({ data, language, mutate, onLogout }: { data: AppDa
       <PageHeading title={copy(language, "设置", "Settings")} description={copy(language, "管理 Center、数据保护、应用目录和登录会话。网络集成位于“网络”页面。", "Manage Center, data protection, app catalogs, and your session. Network integrations live on the Network page.")} action={<SignOutButton language={language} onLogout={onLogout} />} />
       <Card>
         <CardHeader><CardTitle className="flex items-center gap-2"><SettingsIcon />Center</CardTitle><CardDescription>{copy(language, "当前运行信息", "Current runtime information")}</CardDescription></CardHeader>
-        <CardContent><dl className="grid gap-4 text-sm sm:grid-cols-3"><div><dt className="text-muted-foreground">{copy(language, "版本", "Version")}</dt><dd className="mt-1 font-medium">{data.status.version}</dd></div><div><dt className="text-muted-foreground">{copy(language, "节点", "Nodes")}</dt><dd className="mt-1 font-medium">{data.agents.filter((agent) => agent.status === "active").length}</dd></div><div><dt className="text-muted-foreground">{copy(language, "应用", "Apps")}</dt><dd className="mt-1 font-medium">{data.applications.length}</dd></div></dl></CardContent>
+        <CardContent><dl className="grid gap-4 text-sm sm:grid-cols-3"><div><dt className="text-muted-foreground">{copy(language, "版本", "Version")}</dt><dd className="mt-1 font-medium">{data.centerUpdate.currentVersion}</dd></div><div><dt className="text-muted-foreground">{copy(language, "节点", "Nodes")}</dt><dd className="mt-1 font-medium">{data.agents.filter((agent) => agent.status === "active").length}</dd></div><div><dt className="text-muted-foreground">{copy(language, "应用", "Apps")}</dt><dd className="mt-1 font-medium">{data.applications.length}</dd></div></dl></CardContent>
         <CardFooter className="justify-end"><Button onClick={() => setPasswordOpen(true)} size="sm" variant="outline"><KeyRoundIcon data-icon="inline-start" />{copy(language, "修改管理员密码", "Change administrator password")}</Button></CardFooter>
       </Card>
       <SystemDomainSettings domain={data.systemDomain} language={language} />
-      <CenterUpdateCard initial={data.centerUpdate} language={language} />
+      <CenterUpdateCard language={language} onRefresh={onRefresh} onStatusChange={onCenterUpdateStatus} status={data.centerUpdate} />
       <Card>
         <CardHeader><CardTitle className="flex items-center gap-2"><ShieldCheckIcon />{copy(language, "数据与故障排查", "Data & troubleshooting")}</CardTitle><CardDescription>{copy(language, "备份 Center 配置，或下载不含密钥的诊断信息。", "Back up Center configuration or download diagnostics that contain no secret values.")}</CardDescription></CardHeader>
         <CardContent>

--- a/web/src/views/SystemDomainSettings.tsx
+++ b/web/src/views/SystemDomainSettings.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { ArrowRightIcon, CheckCircle2Icon, Globe2Icon, ShieldAlertIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ArrowRightIcon, CheckCircle2Icon, CircleAlertIcon, CloudIcon, Globe2Icon, RefreshCwIcon, ShieldAlertIcon } from "lucide-react";
 import { api } from "../api";
 import type { CloudflareZone, SystemDomain } from "../types";
 import type { Language } from "../translations";
@@ -10,7 +10,7 @@ import { Field, FieldDescription, FieldError, FieldLabel } from "@/components/ui
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { CloudflareOAuthConnect } from "./CloudflareOAuthConnect";
+import { SelectControl } from "@/components/SelectControl";
 import { copy, userError } from "./shared";
 
 export function SystemDomainSettings({ domain, language }: { domain: SystemDomain; language: Language }) {
@@ -40,21 +40,48 @@ function DomainValue({ label, value }: { label: string; value: string }) {
 }
 
 function DomainSwitchSheet({ domain, language, onClose, open }: { domain: SystemDomain; language: Language; onClose: () => void; open: boolean }) {
-  const [sessionID, setSessionID] = useState("");
-  const [zone, setZone] = useState<CloudflareZone | null>(null);
+  const [zones, setZones] = useState<CloudflareZone[]>([]);
+  const [zoneID, setZoneID] = useState("");
+  const [loadingZones, setLoadingZones] = useState(false);
+  const [zoneError, setZoneError] = useState("");
+  const [reloadZones, setReloadZones] = useState(0);
   const [confirmed, setConfirmed] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const zone = zones.find((candidate) => candidate.id === zoneID) ?? null;
   const namespace = zone ? `vastora.${zone.name}` : "";
+
+  useEffect(() => {
+    if (!open) return;
+    let active = true;
+    setLoadingZones(true);
+    setZoneError("");
+    setZones([]);
+    setZoneID("");
+    setConfirmed(false);
+    setError("");
+    void api.cloudflareZones().then(({ zones: available }) => {
+      if (!active) return;
+      const alternatives = available.filter((candidate) => candidate.name !== domain.cloudflareZone);
+      setZones(alternatives);
+      setZoneID(alternatives[0]?.id ?? "");
+    }).catch((loadError) => {
+      if (active) setZoneError(loadError instanceof Error ? loadError.message : "Request failed");
+    }).finally(() => {
+      if (active) setLoadingZones(false);
+    });
+    return () => { active = false; };
+  }, [domain.cloudflareZone, open, reloadZones]);
+
   const resetAndClose = () => {
     if (busy) return;
-    setSessionID(""); setZone(null); setConfirmed(false); setError(""); onClose();
+    setZones([]); setZoneID(""); setConfirmed(false); setError(""); setZoneError(""); onClose();
   };
   const submit = async () => {
-    if (!zone || !sessionID || !confirmed) return;
+    if (!zone || !confirmed) return;
     setBusy(true); setError("");
     try {
-      const result = await api.switchSystemDomain(sessionID, zone.id);
+      const result = await api.switchSystemDomain(zone.id);
       window.location.assign(new URL("/settings", result.centerUrl));
     } catch (switchError) {
       setError(userError(language, switchError));
@@ -66,15 +93,14 @@ function DomainSwitchSheet({ domain, language, onClose, open }: { domain: System
       <SheetHeader><SheetTitle>{copy(language, "切换 Vastora 域名", "Switch Vastora domain")}</SheetTitle><SheetDescription>{copy(language, "一次迁移 Center、Headscale 和默认应用域名空间。", "Move Center, Headscale, and the default app namespace together.")}</SheetDescription></SheetHeader>
       <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-4 pb-4">
         <Alert><ShieldAlertIcon aria-hidden="true" /><AlertTitle>{copy(language, "旧地址不会立即失效", "Previous addresses remain available")}</AlertTitle><AlertDescription>{copy(language, "Vastora 会先创建数据库快照，再启用新域名。在线节点会在下一次心跳验证新地址后自动切换；离线节点仍可通过旧地址恢复。应用访问入口需在切换后重新创建。", "Vastora creates a database snapshot before enabling the new domain. Online nodes verify and switch to the new address on their next heartbeat; offline nodes can still recover through the previous address. Recreate app access points after the switch.")}</AlertDescription></Alert>
-        {!zone ? <CloudflareOAuthConnect available={domain.cloudflareOAuthAvailable} connected={false} language={language} onAuthorized={async (authorizedSession, selected) => { setSessionID(authorizedSession); setZone(selected); }} onConnected={() => undefined} /> : <div className="rounded-2xl border bg-muted/20 p-4">
-          <div className="flex items-center gap-2 font-medium"><CheckCircle2Icon aria-hidden="true" className="size-5 text-emerald-500" />{zone.name}</div>
-          <div className="mt-4 grid gap-3 text-sm">
-            <Preview oldValue={domain.centerUrl} value={`https://center.${namespace}`} />
-            <Preview oldValue={domain.headscaleUrl} value={`https://headscale.${namespace}`} />
-            <Preview oldValue={domain.namespace} value={namespace} />
-          </div>
-          <Button className="mt-3" disabled={busy} onClick={() => { setSessionID(""); setZone(null); setConfirmed(false); }} size="sm" variant="ghost">{copy(language, "重新选择", "Choose another")}</Button>
-        </div>}
+        <div className="rounded-2xl border bg-background p-4 shadow-xs sm:p-5">
+          <div className="flex items-start gap-3"><span className="grid size-11 shrink-0 place-items-center rounded-xl bg-orange-500/10 text-orange-600 dark:text-orange-400"><CloudIcon aria-hidden="true" className="size-6" /></span><div><div className="flex items-center gap-2 font-medium">{copy(language, "使用现有 Cloudflare 授权", "Use the saved Cloudflare authorization")}<CheckCircle2Icon aria-label={copy(language, "已连接", "Connected")} className="size-4 text-emerald-500" /></div><p className="mt-1 text-sm text-muted-foreground">{copy(language, `当前连接 ${domain.cloudflareZone || "Cloudflare"}，切换域名无需重新登录。`, `Connected to ${domain.cloudflareZone || "Cloudflare"}. Switching domains does not require signing in again.`)}</p></div></div>
+          {loadingZones ? <div className="mt-4 flex items-center gap-2 border-t pt-4 text-sm text-muted-foreground"><Spinner />{copy(language, "正在读取可用域名…", "Loading available domains…")}</div> : null}
+          {!loadingZones && zoneError ? <Alert className="mt-4" variant="destructive"><CircleAlertIcon /><AlertTitle>{copy(language, "无法读取已有授权", "Could not use the saved authorization")}</AlertTitle><AlertDescription><p>{userError(language, zoneError)}</p><div className="mt-3 flex flex-wrap gap-2"><Button onClick={() => setReloadZones((value) => value + 1)} size="sm" type="button" variant="outline"><RefreshCwIcon data-icon="inline-start" />{copy(language, "重试", "Retry")}</Button><Button onClick={() => window.location.assign("/network")} size="sm" type="button" variant="outline">{copy(language, "管理 Cloudflare 连接", "Manage Cloudflare connection")}</Button></div></AlertDescription></Alert> : null}
+          {!loadingZones && !zoneError && zones.length === 0 ? <Alert className="mt-4"><CircleAlertIcon /><AlertTitle>{copy(language, "没有其他可用域名", "No other domains are available")}</AlertTitle><AlertDescription>{copy(language, "当前授权中只有正在使用的域名。新域名加入这个 Cloudflare 账号后，点击重试即可。", "The saved authorization only exposes the domain already in use. Add the new domain to this Cloudflare account, then retry.")}<Button className="mt-3" onClick={() => setReloadZones((value) => value + 1)} size="sm" type="button" variant="outline"><RefreshCwIcon data-icon="inline-start" />{copy(language, "重新读取", "Reload")}</Button></AlertDescription></Alert> : null}
+          {!loadingZones && zones.length > 0 ? <Field className="mt-4 border-t pt-4"><FieldLabel htmlFor="system-domain-zone">{copy(language, "选择新域名", "Choose the new domain")}</FieldLabel><SelectControl disabled={busy} id="system-domain-zone" onValueChange={(value) => { setZoneID(value); setConfirmed(false); }} options={zones.map((candidate) => ({ value: candidate.id, label: `${candidate.name}${candidate.accountName ? ` — ${candidate.accountName}` : ""}` }))} value={zoneID} /><FieldDescription>{copy(language, "这里只显示当前授权可以管理的域名，并已隐藏正在使用的域名。", "Only domains available to the saved authorization are shown; the current domain is hidden.")}</FieldDescription></Field> : null}
+        </div>
+        {zone ? <div className="rounded-2xl border bg-muted/20 p-4"><div className="flex items-center gap-2 font-medium"><CheckCircle2Icon aria-hidden="true" className="size-5 text-emerald-500" />{copy(language, "迁移预览", "Migration preview")}</div><div className="mt-4 grid gap-3 text-sm"><Preview oldValue={domain.centerUrl} value={`https://center.${namespace}`} /><Preview oldValue={domain.headscaleUrl} value={`https://headscale.${namespace}`} /><Preview oldValue={domain.namespace} value={namespace} /></div></div> : null}
         {busy ? <Alert><Spinner /><AlertTitle>{copy(language, "正在安全切换域名", "Switching domain safely")}</AlertTitle><AlertDescription>{copy(language, "正在依次完成备份、DNS、证书和网关更新。证书签发可能需要几分钟，请不要关闭页面。", "Completing backup, DNS, certificate, and gateway updates in order. Certificate issuance can take a few minutes; keep this page open.")}</AlertDescription></Alert> : null}
         {zone ? <Field orientation="horizontal"><div className="flex flex-1 flex-col gap-1"><FieldLabel htmlFor="confirm-domain-switch">{copy(language, "确认迁移全部系统域名", "Confirm the system-domain migration")}</FieldLabel><FieldDescription>{copy(language, "新建入口将使用新域名空间；旧应用入口不会自动复制。", "New access points use the new namespace; old app access points are not copied automatically.")}</FieldDescription></div><Switch checked={confirmed} disabled={busy} id="confirm-domain-switch" onCheckedChange={setConfirmed} /></Field> : null}
         {error ? <FieldError role="alert">{error}</FieldError> : null}

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -14,6 +14,7 @@ import { NodesView, agentInstallCommand, validCenterURL } from "./NodesView";
 import { SettingsView } from "./SettingsView";
 import { SetupWizard } from "./SetupWizard";
 import { CloudflareOAuthConnect } from "./CloudflareOAuthConnect";
+import { CenterUpdateCard } from "./CenterUpdateCard";
 import { ThemeProvider } from "../components/theme";
 import { defaultPublicationHostname, defaultRealityHostname } from "./appAccess";
 import { CopyButton, userError } from "./shared";
@@ -1166,7 +1167,7 @@ describe("network and app views", () => {
   });
 
   it("makes backup and diagnostics discoverable without the CLI", () => {
-    const container = render(<SettingsView data={dashboard()} language="zh-CN" mutate={async () => undefined} onLogout={async () => undefined} />);
+    const container = render(<SettingsView data={dashboard()} language="zh-CN" mutate={async () => undefined} onCenterUpdateStatus={() => undefined} onLogout={async () => undefined} onRefresh={async () => undefined} />);
     expect(container.textContent).toContain("数据与故障排查");
     expect(container.textContent).toContain("下载加密备份");
     expect(container.textContent).toContain("下载诊断报告");
@@ -1178,27 +1179,61 @@ describe("network and app views", () => {
     expect(document.body.textContent).toContain("至少 10 个字符。");
   });
 
-  it("offers one safe workflow for switching the Vastora domain", () => {
-    const container = render(<SettingsView data={dashboard()} language="zh-CN" mutate={async () => undefined} onLogout={async () => undefined} />);
+  it("offers one safe workflow for switching the Vastora domain", async () => {
+    const startOAuth = vi.spyOn(api, "startCloudflareOAuth");
+    const listZones = vi.spyOn(api, "cloudflareZones").mockResolvedValue({ zones: [
+      { id: "current", name: "example.com", accountId: "account", accountName: "Personal" },
+      { id: "new", name: "new.example", accountId: "account", accountName: "Personal" }
+    ] });
+    const container = render(<SettingsView data={dashboard()} language="zh-CN" mutate={async () => undefined} onCenterUpdateStatus={() => undefined} onLogout={async () => undefined} onRefresh={async () => undefined} />);
     expect(container.textContent).toContain("Vastora 域名");
     expect(container.textContent).toContain("https://center.vastora.example.com");
     const changeDomain = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("切换域名"));
-    act(() => changeDomain?.click());
+    await act(async () => {
+      changeDomain?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     expect(document.body.textContent).toContain("旧地址不会立即失效");
-    expect(document.body.textContent).toContain("登录 Cloudflare");
+    expect(document.body.textContent).toContain("使用现有 Cloudflare 授权");
+    expect(document.body.textContent).toContain("切换域名无需重新登录");
+    expect(document.body.textContent).toContain("new.example");
+    expect(document.body.textContent).not.toContain("登录 Cloudflare");
     expect(document.body.textContent).toContain("下一次心跳验证新地址后自动切换");
     expect(document.body.textContent).toContain("应用访问入口需在切换后重新创建");
+    expect(listZones).toHaveBeenCalledOnce();
+    expect(startOAuth).not.toHaveBeenCalled();
   });
 
   it("shows a confirmed Center update instead of exposing Docker access", () => {
     const data = dashboard();
     data.centerUpdate = { currentVersion: "0.1.0-alpha.47", latestVersion: "0.1.0-alpha.48", updateAvailable: true, automatic: true, state: "idle", checkedAt: "2026-08-25T00:00:00Z" };
-    const container = render(<SettingsView data={data} language="zh-CN" mutate={async () => undefined} onLogout={async () => undefined} />);
+    const container = render(<SettingsView data={data} language="zh-CN" mutate={async () => undefined} onCenterUpdateStatus={() => undefined} onLogout={async () => undefined} onRefresh={async () => undefined} />);
     expect(container.textContent).toContain("Center 更新");
     expect(container.textContent).toContain("0.1.0-alpha.48");
     const update = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("更新 Center"));
     act(() => update?.click());
     expect(document.body.textContent).toContain("预计短暂断开连接");
     expect(document.body.textContent).toContain("开始更新");
+  });
+
+  it("uses the update status as the single displayed Center version", () => {
+    const data = dashboard();
+    data.status.version = "0.1.0-alpha.50";
+    data.centerUpdate.currentVersion = "0.1.0-alpha.51";
+    const container = render(<SettingsView data={data} language="zh-CN" mutate={async () => undefined} onCenterUpdateStatus={() => undefined} onLogout={async () => undefined} onRefresh={async () => undefined} />);
+    expect(container.textContent).not.toContain("0.1.0-alpha.50");
+    expect(container.textContent?.match(/0\.1\.0-alpha\.51/g)).toHaveLength(2);
+  });
+
+  it("refreshes the complete settings data as soon as a Center update succeeds", async () => {
+    const status = { ...dashboard().centerUpdate, latestVersion: "0.1.0-alpha.51", updateAvailable: true, state: "applying" as const };
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const onStatusChange = vi.fn();
+    vi.spyOn(api, "centerUpdate").mockResolvedValue({ ...status, currentVersion: "0.1.0-alpha.51", updateAvailable: false, state: "succeeded" });
+    render(<CenterUpdateCard language="zh-CN" onRefresh={onRefresh} onStatusChange={onStatusChange} status={status} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(onStatusChange).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- reuse the saved Cloudflare OAuth authorization when switching the Vastora domain
- preserve the encrypted Cloudflare token while changing the selected zone
- refresh the full Settings data after a Center update completes
- use the update status as the single source of truth for the displayed Center version

## Validation
- `GOCACHE=/tmp/vastora-go-build go test ./internal/center -run 'TestSwitchSystemDomain' -count=1`\n- `cd web && npm test -- --run src/views/views.test.tsx`\n- `cd web && npm run build`\n- `cd web && npm run lint`