### PR TITLE
feat: harden network and host lifecycle

### DIFF
--- a/cmd/vastora/agent_cmd.go
+++ b/cmd/vastora/agent_cmd.go
@@ -203,6 +203,28 @@ func runAgent(arguments []string) error {
 		}
 		fmt.Printf("Agent updated to %s and restarted\n", version)
 		return nil
+	case "uninstall":
+		flags := flag.NewFlagSet("agent uninstall", flag.ContinueOnError)
+		flags.SetOutput(os.Stderr)
+		purge := flags.Bool("purge", false, "remove the local Agent and Vastora-owned host dependencies")
+		deleteData := flags.Bool("delete-data", false, "permanently delete managed application data")
+		runtimeCleaned := flags.Bool("runtime-cleaned", false, "internal: managed runtime was already removed")
+		keepBinary := flags.Bool("keep-binary", false, "internal: keep the shared host command")
+		dataDir := flags.String("data-dir", "/var/lib/vastora/agent", "Agent state directory")
+		if err := flags.Parse(arguments[1:]); err != nil {
+			return err
+		}
+		if flags.NArg() != 0 || !*purge {
+			return errors.New("usage: vastora agent uninstall --purge")
+		}
+		if err := requireLinuxRoot("agent uninstall"); err != nil {
+			return err
+		}
+		if err := uninstallAgentHost(context.Background(), *dataDir, *deleteData, *runtimeCleaned, *keepBinary); err != nil {
+			return err
+		}
+		fmt.Println("Vastora Agent and its managed host state were removed")
+		return nil
 	case "enroll":
 		flags := flag.NewFlagSet("agent enroll", flag.ContinueOnError)
 		flags.SetOutput(os.Stderr)
@@ -284,6 +306,15 @@ func runAgent(arguments []string) error {
 		if capabilities.Tunnel && !containsValue(roles, "worker") {
 			return errors.New("tunnel capability requires the worker role")
 		}
+		if runtime.GOOS == "linux" {
+			if _, lookupErr := exec.LookPath("tailscale"); lookupErr == nil {
+				if err := reconcileTailscalePrivacy("/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf", runHostCommand); err != nil {
+					return err
+				}
+			} else if !errors.Is(lookupErr, exec.ErrNotFound) {
+				return fmt.Errorf("locate Tailscale: %w", lookupErr)
+			}
+		}
 		store, err := agent.Open(*dataDir)
 		if err != nil {
 			return err
@@ -293,6 +324,11 @@ func runAgent(arguments []string) error {
 			return err
 		}
 		client := agent.Client{Roles: roles, Capabilities: capabilities}
+		executable, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("locate vastora executable: %w", err)
+		}
+		client.Decommissioner = systemHostDecommissioner{dataDir: *dataDir, executable: executable}
 		if capabilities.Docker {
 			client.Executor = agent.DockerExecutor{}
 		}

--- a/cmd/vastora/agent_uninstall.go
+++ b/cmd/vastora/agent_uninstall.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/petauron/vastora/internal/agent"
+)
+
+type systemHostDecommissioner struct {
+	dataDir    string
+	executable string
+}
+
+func (d systemHostDecommissioner) Prepare(ctx context.Context, deleteData bool) error {
+	return agent.PurgeManagedRuntime(ctx, deleteData)
+}
+
+func (d systemHostDecommissioner) ScheduleFinalRemoval(ctx context.Context, deleteData bool) error {
+	executable, err := filepath.Abs(d.executable)
+	if err != nil {
+		return fmt.Errorf("agent: resolve decommission executable: %w", err)
+	}
+	arguments := []string{"--unit=vastora-agent-decommission-" + strconv.FormatInt(time.Now().UnixNano(), 10), "--collect", "--on-active=15s", executable, "agent", "uninstall", "--purge", "--runtime-cleaned", "--data-dir", d.dataDir}
+	if deleteData {
+		arguments = append(arguments, "--delete-data")
+	}
+	output, err := exec.CommandContext(ctx, "systemd-run", arguments...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("agent: schedule final host cleanup: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+func uninstallAgentHost(ctx context.Context, dataDir string, deleteData, runtimeCleaned, keepBinary bool) error {
+	dataDir, err := safeAgentDataDir(dataDir)
+	if err != nil {
+		return err
+	}
+	return uninstallAgentHostWithEnvironment(ctx, deleteData, runtimeCleaned, keepBinary, agentUninstallEnvironment{
+		dataDir:              dataDir,
+		unitPath:             vastoraAgentUnitPath,
+		binaryPaths:          []string{"/usr/local/bin/vastora", "/usr/local/bin/vastora.previous"},
+		tailscalePaths:       []string{"/etc/apt/sources.list.d/tailscale.list", "/usr/share/keyrings/tailscale-archive-keyring.gpg", "/var/lib/tailscale"},
+		tailscalePrivacyPath: "/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf",
+		purgeRuntime:         agent.PurgeManagedRuntime,
+		run:                  runHostCommand,
+	})
+}
+
+func safeAgentDataDir(value string) (string, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(value))
+	if err != nil {
+		return "", fmt.Errorf("resolve Agent state directory: %w", err)
+	}
+	absolute = filepath.Clean(absolute)
+	for _, unsafe := range []string{"/", "/tmp", "/var", "/var/lib", "/var/lib/vastora"} {
+		if absolute == unsafe {
+			return "", fmt.Errorf("refusing unsafe Agent state directory: %s", absolute)
+		}
+	}
+	if info, err := os.Lstat(absolute); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("refusing an Agent state directory reached through a symbolic link")
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect Agent state directory: %w", err)
+	}
+	return absolute, nil
+}
+
+type agentUninstallEnvironment struct {
+	dataDir              string
+	unitPath             string
+	binaryPaths          []string
+	tailscalePaths       []string
+	tailscalePrivacyPath string
+	purgeRuntime         func(context.Context, bool) error
+	run                  func(context.Context, string, ...string) ([]byte, error)
+}
+
+func runHostCommand(ctx context.Context, name string, arguments ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, arguments...).CombinedOutput()
+}
+
+func uninstallAgentHostWithEnvironment(ctx context.Context, deleteData, runtimeCleaned, keepBinary bool, environment agentUninstallEnvironment) error {
+	state, err := agent.ReadHostInstallState(environment.dataDir)
+	if err != nil {
+		return err
+	}
+	statePath := filepath.Join(environment.dataDir, agent.HostInstallStateName)
+	_, stateFileErr := os.Stat(statePath)
+	stateRecorded := stateFileErr == nil
+	if stateFileErr != nil && !errors.Is(stateFileErr, os.ErrNotExist) {
+		return fmt.Errorf("inspect Agent host ownership state: %w", stateFileErr)
+	}
+	if !runtimeCleaned {
+		if err := environment.purgeRuntime(ctx, deleteData); err != nil {
+			return fmt.Errorf("remove managed Agent runtime: %w", err)
+		}
+	}
+	if state.TailscaleEnrolled {
+		output, logoutErr := environment.run(ctx, "tailscale", "logout")
+		if logoutErr != nil && state.TailscaleOwnership != "managed" && !errors.Is(logoutErr, exec.ErrNotFound) {
+			return fmt.Errorf("disconnect the external Tailscale installation from Vastora: %s: %w", strings.TrimSpace(string(output)), logoutErr)
+		}
+	}
+	if state.TailscaleOwnership == "managed" {
+		_, _ = environment.run(ctx, "systemctl", "disable", "--now", "tailscaled.service")
+		if output, err := environment.run(ctx, "apt-get", "purge", "-y", "tailscale", "tailscale-archive-keyring"); err != nil {
+			return fmt.Errorf("remove Vastora-managed Tailscale: %s: %w", strings.TrimSpace(string(output)), err)
+		}
+		for _, path := range environment.tailscalePaths {
+			if err := os.RemoveAll(path); err != nil {
+				return fmt.Errorf("remove Vastora-managed Tailscale state %s: %w", path, err)
+			}
+		}
+	}
+	if environment.tailscalePrivacyPath != "" {
+		privacyStateRemoved := false
+		for _, path := range []string{environment.tailscalePrivacyPath, tailscalePrivacyAppliedPath(environment.tailscalePrivacyPath)} {
+			if err := os.Remove(path); err == nil {
+				privacyStateRemoved = true
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove Vastora Tailscale privacy state %s: %w", path, err)
+			}
+		}
+		_ = os.Remove(filepath.Dir(environment.tailscalePrivacyPath))
+		if privacyStateRemoved {
+			if output, err := environment.run(ctx, "systemctl", "daemon-reload"); err != nil {
+				return fmt.Errorf("reload systemd after removing the Tailscale privacy override: %s: %w", strings.TrimSpace(string(output)), err)
+			}
+		}
+	}
+	unitOwned, err := stopAndRemoveAgentUnit(ctx, environment)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(environment.dataDir); err != nil {
+		return fmt.Errorf("remove Agent state: %w", err)
+	}
+	if !keepBinary && (unitOwned || stateRecorded) {
+		for _, path := range environment.binaryPaths {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove Agent command %s: %w", path, err)
+			}
+		}
+	}
+	return nil
+}
+
+func stopAndRemoveAgentUnit(ctx context.Context, environment agentUninstallEnvironment) (bool, error) {
+	raw, err := os.ReadFile(environment.unitPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect Agent service: %w", err)
+	}
+	if !strings.Contains(string(raw), "Description=Vastora Agent") || !strings.Contains(string(raw), " agent serve ") {
+		return false, errors.New("refusing to remove an unrecognized vastora-agent.service")
+	}
+	if output, err := environment.run(ctx, "systemctl", "disable", "--now", "vastora-agent.service"); err != nil {
+		return false, fmt.Errorf("stop Agent service: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	if err := os.Remove(environment.unitPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("remove Agent service: %w", err)
+	}
+	if output, err := environment.run(ctx, "systemctl", "daemon-reload"); err != nil {
+		return false, fmt.Errorf("reload systemd after Agent removal: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return true, nil
+}

--- a/cmd/vastora/center_cmd.go
+++ b/cmd/vastora/center_cmd.go
@@ -19,11 +19,44 @@ func runCenter(arguments []string) error {
 		return errors.New("center command is required")
 	}
 	switch arguments[0] {
+	case "capabilities":
+		if len(arguments) != 1 {
+			return errors.New("center capabilities does not accept arguments")
+		}
+		fmt.Println("decommission-applications")
+		fmt.Println("agent-host-decommission")
+		return nil
+	case "offline-agent-cleanups":
+		flags := flag.NewFlagSet("center offline-agent-cleanups", flag.ContinueOnError)
+		flags.SetOutput(os.Stderr)
+		dataDir := flags.String("data-dir", "", "Center state directory")
+		deferredAgentID := flags.String("deferred-agent-id", "", "Agent on the Center host, cleaned locally last")
+		if err := flags.Parse(arguments[1:]); err != nil {
+			return err
+		}
+		if *dataDir == "" || flags.NArg() != 0 {
+			return errors.New("--data-dir is required")
+		}
+		store, err := center.Open(*dataDir)
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+		cleanups, err := store.OfflineAgentCleanups(context.Background(), strings.TrimSpace(*deferredAgentID))
+		if err != nil {
+			return err
+		}
+		for _, cleanup := range cleanups {
+			fmt.Printf("%s (%s)\n  %s\n", cleanup.Name, cleanup.ID, cleanup.Command)
+		}
+		return nil
 	case "decommission-applications":
 		flags := flag.NewFlagSet("center decommission-applications", flag.ContinueOnError)
 		flags.SetOutput(os.Stderr)
 		dataDir := flags.String("data-dir", "", "Center state directory")
 		deleteData := flags.Bool("delete-data", false, "permanently delete application data")
+		forceOffline := flags.Bool("force-offline", false, "continue after explicitly acknowledging unreachable Agents")
+		deferredAgentID := flags.String("deferred-agent-id", "", "Agent on the Center host, cleaned locally last")
 		if err := flags.Parse(arguments[1:]); err != nil {
 			return err
 		}
@@ -40,7 +73,7 @@ func runCenter(arguments []string) error {
 		defer store.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
-		if err := store.DecommissionApplications(ctx, *deleteData, func(message string) {
+		if err := store.DecommissionApplications(ctx, *deleteData, *forceOffline, strings.TrimSpace(*deferredAgentID), func(message string) {
 			fmt.Println(message)
 		}); err != nil {
 			return err

--- a/cmd/vastora/local_management.go
+++ b/cmd/vastora/local_management.go
@@ -53,7 +53,7 @@ func runLocalManagement(arguments []string) error {
 			return runLocalCenterScript(localCenterInstallDir, "uninstall.sh", "--install-dir", localCenterInstallDir)
 		}
 		if !localAgentInstalled(localAgentDataDir) {
-			return errors.New("Vastora Center or Agent is not installed on this host")
+			return errors.New("no Vastora Center or Agent is installed on this host")
 		}
 		deleteData, cancelled, err := chooseLocalAgentUninstall(os.Stdin, os.Stdout)
 		if err != nil {
@@ -125,7 +125,7 @@ func runLocalCenterScript(installDir, name string, arguments ...string) error {
 	path := filepath.Join(installDir, name)
 	info, err := os.Lstat(path)
 	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
-		return fmt.Errorf("Center management script is unavailable: %s", path)
+		return fmt.Errorf("center management script is unavailable: %s", path)
 	}
 	command := exec.Command(path, arguments...)
 	command.Stdin = os.Stdin
@@ -185,7 +185,7 @@ func reportLocalStatus(installDir, agentDataDir string, writer io.Writer, client
 		fmt.Fprintln(writer, "Agent: unavailable")
 	}
 	if !found {
-		return errors.New("Vastora Center or Agent is not installed on this host")
+		return errors.New("no Vastora Center or Agent is installed on this host")
 	}
 	if !healthy {
 		return errors.New("one or more local Vastora services are unavailable")

--- a/cmd/vastora/local_management.go
+++ b/cmd/vastora/local_management.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/petauron/vastora/internal/agent"
+)
+
+const (
+	localCenterInstallDir = "/opt/vastora/center"
+	localAgentDataDir     = "/var/lib/vastora/agent"
+)
+
+func runLocalManagement(arguments []string) error {
+	if runtime.GOOS != "linux" {
+		return errors.New("local Vastora management currently supports Linux hosts")
+	}
+	switch arguments[0] {
+	case "status":
+		if len(arguments) != 1 {
+			return errors.New("usage: vastora status")
+		}
+		return reportLocalStatus(localCenterInstallDir, localAgentDataDir, os.Stdout, &http.Client{Timeout: 3 * time.Second})
+	case "update":
+		if len(arguments) != 1 {
+			return errors.New("usage: vastora update")
+		}
+		if os.Geteuid() != 0 {
+			return errors.New("vastora update must run as root")
+		}
+		if localCenterInstalled(localCenterInstallDir) {
+			return runLocalCenterScript(localCenterInstallDir, "install.sh", "center", "--install-dir", localCenterInstallDir)
+		}
+		return runAgent([]string{"update", "--data-dir", localAgentDataDir})
+	case "uninstall":
+		if len(arguments) != 1 {
+			return errors.New("usage: vastora uninstall")
+		}
+		if os.Geteuid() != 0 {
+			return errors.New("vastora uninstall must run as root")
+		}
+		if localCenterInstalled(localCenterInstallDir) {
+			return runLocalCenterScript(localCenterInstallDir, "uninstall.sh", "--install-dir", localCenterInstallDir)
+		}
+		if !localAgentInstalled(localAgentDataDir) {
+			return errors.New("Vastora Center or Agent is not installed on this host")
+		}
+		deleteData, cancelled, err := chooseLocalAgentUninstall(os.Stdin, os.Stdout)
+		if err != nil {
+			return err
+		}
+		if cancelled {
+			fmt.Println("Cancelled; nothing was changed.")
+			return nil
+		}
+		arguments := []string{"uninstall", "--purge"}
+		if deleteData {
+			arguments = append(arguments, "--delete-data")
+		}
+		return runAgent(arguments)
+	default:
+		return errors.New("unsupported local management command")
+	}
+}
+
+func localAgentInstalled(dataDir string) bool {
+	if info, err := os.Stat(filepath.Join(dataDir, "agent.db")); err == nil && info.Mode().IsRegular() {
+		return true
+	}
+	raw, err := os.ReadFile(vastoraAgentUnitPath)
+	return err == nil && strings.Contains(string(raw), "Description=Vastora Agent")
+}
+
+func chooseLocalAgentUninstall(input io.Reader, output io.Writer) (deleteData, cancelled bool, err error) {
+	reader := bufio.NewReader(input)
+	fmt.Fprintln(output, "\nVastora Agent uninstall")
+	fmt.Fprintln(output, "  1) Remove Agent and applications; keep application data")
+	fmt.Fprintln(output, "  2) Remove Agent, applications, and application data")
+	fmt.Fprintln(output, "  3) Cancel")
+	fmt.Fprint(output, "Choose [1-3]: ")
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, false, err
+	}
+	switch strings.TrimSpace(line) {
+	case "1":
+		return false, false, nil
+	case "2":
+		fmt.Fprint(output, "Type DELETE to permanently remove application data: ")
+		confirmation, readErr := reader.ReadString('\n')
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return false, false, readErr
+		}
+		if strings.TrimSpace(confirmation) != "DELETE" {
+			return false, true, nil
+		}
+		return true, false, nil
+	case "3":
+		return false, true, nil
+	default:
+		return false, false, errors.New("choose 1, 2, or 3")
+	}
+}
+
+func localCenterInstalled(installDir string) bool {
+	for _, name := range []string{".env", "compose.yaml", "release.env"} {
+		if info, err := os.Lstat(filepath.Join(installDir, name)); err != nil || !info.Mode().IsRegular() {
+			return false
+		}
+	}
+	return true
+}
+
+func runLocalCenterScript(installDir, name string, arguments ...string) error {
+	path := filepath.Join(installDir, name)
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("Center management script is unavailable: %s", path)
+	}
+	command := exec.Command(path, arguments...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("run %s: %w", name, err)
+	}
+	return nil
+}
+
+func reportLocalStatus(installDir, agentDataDir string, writer io.Writer, client *http.Client) error {
+	found := false
+	healthy := true
+	if localCenterInstalled(installDir) {
+		found = true
+		version, err := localEnvironmentValue(filepath.Join(installDir, "release.env"), "VASTORA_VERSION")
+		if err != nil {
+			return err
+		}
+		port, err := localEnvironmentValue(filepath.Join(installDir, ".env"), "VASTORA_CENTER_BOOTSTRAP_PORT")
+		if err != nil {
+			return err
+		}
+		if port == "" {
+			port = "8080"
+		}
+		endpoint := "http://127.0.0.1:" + port + "/healthz"
+		state := "running"
+		if !localHTTPHealthy(client, endpoint) {
+			state = "unavailable"
+			healthy = false
+		}
+		if version == "" {
+			version = "unknown"
+		}
+		fmt.Fprintf(writer, "Center: %s\nVersion: %s\nLocal address: http://127.0.0.1:%s\n", state, version, port)
+	}
+	agentDatabase := filepath.Join(agentDataDir, "agent.db")
+	if _, err := os.Stat(agentDatabase); err == nil {
+		found = true
+		state := "running"
+		if !localHTTPHealthy(client, "http://127.0.0.1:8090/healthz") {
+			state = "unavailable"
+			healthy = false
+		}
+		connection, inspectErr := agent.InspectConnection(agentDataDir)
+		if inspectErr != nil {
+			fmt.Fprintln(writer, "Agent: unavailable")
+			healthy = false
+		} else {
+			fmt.Fprintf(writer, "Agent: %s\nNode: %s\nAgent Center: %s\n", state, connection.Name, connection.CenterURL)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		found = true
+		healthy = false
+		fmt.Fprintln(writer, "Agent: unavailable")
+	}
+	if !found {
+		return errors.New("Vastora Center or Agent is not installed on this host")
+	}
+	if !healthy {
+		return errors.New("one or more local Vastora services are unavailable")
+	}
+	return nil
+}
+
+func localHTTPHealthy(client *http.Client, endpoint string) bool {
+	response, err := client.Get(endpoint)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	return response.StatusCode == http.StatusOK
+}
+
+func localEnvironmentValue(path, key string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		name, value, ok := strings.Cut(line, "=")
+		if ok && name == key {
+			return strings.TrimSpace(value), nil
+		}
+	}
+	return "", nil
+}

--- a/cmd/vastora/main.go
+++ b/cmd/vastora/main.go
@@ -26,6 +26,8 @@ func run(arguments []string) error {
 	case "version":
 		fmt.Println(center.Version)
 		return nil
+	case "status", "update", "uninstall":
+		return runLocalManagement(arguments)
 	case "catalog":
 		return runCatalog(arguments[1:])
 	case "center":
@@ -64,6 +66,9 @@ func printUsage(writer *os.File) {
 
 Usage:
   vastora version
+  vastora status
+  vastora update
+  vastora uninstall
   vastora center serve --data-dir DIR [--agent-connect-url URL] [--headscale-allowed-url URL] [--listen 127.0.0.1:8080] [--tls-cert CERT --tls-key KEY]
   vastora center agent-token create --data-dir DIR --site-id SITE --name NAME --center-url URL [--gateway] [--tunnel] [--headscale]
   vastora center backup --data-dir DIR --output FILE --password-file FILE
@@ -75,6 +80,7 @@ Usage:
   vastora agent status [--data-dir /var/lib/vastora/agent]
   vastora agent configure --roles worker[,gateway] --capabilities docker[,gateway,tunnel]
   vastora agent update [--data-dir /var/lib/vastora/agent] [--center-url URL]
+  vastora agent uninstall --purge
   vastora agent serve --data-dir DIR [--listen 127.0.0.1:8090]
   vastora catalog keygen --out-dir DIR
   vastora catalog validate --catalog FILE

--- a/cmd/vastora/main_test.go
+++ b/cmd/vastora/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +16,128 @@ import (
 
 	"github.com/petauron/vastora/internal/agent"
 )
+
+func TestLocalCenterStatusReportsVersionAndHealth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/healthz" {
+			t.Fatalf("unexpected health path %q", request.URL.Path)
+		}
+		response.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	installDir := t.TempDir()
+	port := strings.TrimPrefix(server.URL, "http://127.0.0.1:")
+	for name, content := range map[string]string{
+		".env":         "VASTORA_CENTER_BOOTSTRAP_PORT=" + port + "\n",
+		"compose.yaml": "name: vastora\n",
+		"release.env":  "VASTORA_VERSION=0.1.0-test\n",
+	} {
+		if err := os.WriteFile(filepath.Join(installDir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var output bytes.Buffer
+	if err := reportLocalStatus(installDir, filepath.Join(t.TempDir(), "agent"), &output, server.Client()); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{"Center: running", "Version: 0.1.0-test", "Local address: " + server.URL} {
+		if !strings.Contains(output.String(), expected) {
+			t.Fatalf("status is missing %q:\n%s", expected, output.String())
+		}
+	}
+}
+
+func TestLocalAgentUninstallUsesSimpleMenuAndDestructiveConfirmation(t *testing.T) {
+	var output bytes.Buffer
+	deleteData, cancelled, err := chooseLocalAgentUninstall(strings.NewReader("2\nDELETE\n"), &output)
+	if err != nil || !deleteData || cancelled {
+		t.Fatalf("delete-data selection = delete=%v cancelled=%v err=%v", deleteData, cancelled, err)
+	}
+	if !strings.Contains(output.String(), "keep application data") || !strings.Contains(output.String(), "Type DELETE") {
+		t.Fatalf("uninstall menu was not explicit: %q", output.String())
+	}
+	deleteData, cancelled, err = chooseLocalAgentUninstall(strings.NewReader("2\nno\n"), &output)
+	if err != nil || deleteData || !cancelled {
+		t.Fatalf("mismatched destructive confirmation was accepted: delete=%v cancelled=%v err=%v", deleteData, cancelled, err)
+	}
+}
+
+func TestAgentUninstallRemovesOnlyVastoraManagedTailscale(t *testing.T) {
+	for _, ownership := range []string{"external", "managed"} {
+		t.Run(ownership, func(t *testing.T) {
+			root := t.TempDir()
+			dataDir := filepath.Join(root, "agent")
+			if err := os.MkdirAll(dataDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			state := "HOST_STATE_VERSION=1\nTAILSCALE_OWNERSHIP=" + ownership + "\nTAILSCALE_ENROLLED=1\n"
+			if err := os.WriteFile(filepath.Join(dataDir, agent.HostInstallStateName), []byte(state), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			unitPath := filepath.Join(root, "vastora-agent.service")
+			if err := os.WriteFile(unitPath, []byte("Description=Vastora Agent\nExecStart=/usr/local/bin/vastora agent serve --data-dir /var/lib/vastora/agent\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			binaryPath := filepath.Join(root, "vastora")
+			if err := os.WriteFile(binaryPath, []byte("managed"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			tailscalePaths := []string{filepath.Join(root, "tailscale.list"), filepath.Join(root, "tailscale.key"), filepath.Join(root, "tailscale-state")}
+			for _, path := range tailscalePaths {
+				if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			tailscalePrivacyPath := filepath.Join(root, "tailscaled.service.d", "90-vastora-privacy.conf")
+			if err := os.MkdirAll(filepath.Dir(tailscalePrivacyPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(tailscalePrivacyPath, []byte("[Service]\nEnvironment=TS_NO_LOGS_NO_SUPPORT=true\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(tailscalePrivacyAppliedPath(tailscalePrivacyPath), []byte(tailscalePrivacyAppliedMarker), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			commands := []string{}
+			environment := agentUninstallEnvironment{
+				dataDir: dataDir, unitPath: unitPath, binaryPaths: []string{binaryPath}, tailscalePaths: tailscalePaths, tailscalePrivacyPath: tailscalePrivacyPath,
+				purgeRuntime: func(context.Context, bool) error { return nil },
+				run: func(_ context.Context, name string, arguments ...string) ([]byte, error) {
+					commands = append(commands, name+" "+strings.Join(arguments, " "))
+					return nil, nil
+				},
+			}
+			if err := uninstallAgentHostWithEnvironment(context.Background(), true, true, false, environment); err != nil {
+				t.Fatal(err)
+			}
+			if err := uninstallAgentHostWithEnvironment(context.Background(), true, true, false, environment); err != nil {
+				t.Fatalf("repeated uninstall was not idempotent: %v", err)
+			}
+			joined := strings.Join(commands, "\n")
+			if !strings.Contains(joined, "tailscale logout") {
+				t.Fatalf("Headscale identity was not disconnected: %s", joined)
+			}
+			for _, path := range tailscalePaths {
+				_, err := os.Stat(path)
+				if ownership == "managed" && !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("managed Tailscale state remained at %s", path)
+				}
+				if ownership == "external" && err != nil {
+					t.Fatalf("external Tailscale state was removed at %s: %v", path, err)
+				}
+			}
+			if got := strings.Contains(joined, "apt-get purge"); got != (ownership == "managed") {
+				t.Fatalf("Tailscale package cleanup for %s = %v; commands:\n%s", ownership, got, joined)
+			}
+			for _, path := range []string{tailscalePrivacyPath, tailscalePrivacyAppliedPath(tailscalePrivacyPath)} {
+				if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("Vastora Tailscale privacy state remained at %s: %v", path, err)
+				}
+			}
+		})
+	}
+}
 
 func TestNodeRolesAndCapabilitiesAreIndependent(t *testing.T) {
 	roles, err := parseNodeRoles("worker,gateway")
@@ -56,6 +180,59 @@ func TestSystemdAgentUnitUsesPersistentServiceConfiguration(t *testing.T) {
 		if !strings.Contains(unit, expected) {
 			t.Fatalf("systemd unit is missing %q:\n%s", expected, unit)
 		}
+	}
+}
+
+func TestTailscalePrivacyOverrideIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tailscaled.service.d", "90-vastora-privacy.conf")
+	commands := []string{}
+	run := func(_ context.Context, name string, arguments ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(arguments, " "))
+		return nil, nil
+	}
+	if err := reconcileTailscalePrivacy(path, run); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconcileTailscalePrivacy(path, run); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil || string(raw) != tailscalePrivacyOverride {
+		t.Fatalf("Tailscale privacy override = %q, err=%v", raw, err)
+	}
+	applied, err := os.ReadFile(tailscalePrivacyAppliedPath(path))
+	if err != nil || string(applied) != tailscalePrivacyAppliedMarker {
+		t.Fatalf("Tailscale privacy marker = %q, err=%v", applied, err)
+	}
+	joined := strings.Join(commands, "\n")
+	if strings.Count(joined, "systemctl daemon-reload") != 1 || strings.Count(joined, "systemctl restart tailscaled.service") != 1 {
+		t.Fatalf("privacy reconciliation was not idempotent:\n%s", joined)
+	}
+}
+
+func TestTailscalePrivacyReconciliationRetriesAfterRestartFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tailscaled.service.d", "90-vastora-privacy.conf")
+	restarts := 0
+	run := func(_ context.Context, name string, arguments ...string) ([]byte, error) {
+		if name == "systemctl" && strings.Join(arguments, " ") == "restart tailscaled.service" {
+			restarts++
+			if restarts == 1 {
+				return []byte("temporary restart failure"), errors.New("restart failed")
+			}
+		}
+		return nil, nil
+	}
+	if err := reconcileTailscalePrivacy(path, run); err == nil {
+		t.Fatal("failed Tailscale restart was accepted")
+	}
+	if _, err := os.Stat(tailscalePrivacyAppliedPath(path)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed reconciliation was marked applied: %v", err)
+	}
+	if err := reconcileTailscalePrivacy(path, run); err != nil {
+		t.Fatal(err)
+	}
+	if restarts != 2 {
+		t.Fatalf("Tailscale restart attempts = %d, want 2", restarts)
 	}
 }
 

--- a/cmd/vastora/tailscale_privacy.go
+++ b/cmd/vastora/tailscale_privacy.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	tailscalePrivacyOverride      = "[Service]\nEnvironment=TS_NO_LOGS_NO_SUPPORT=true\n"
+	tailscalePrivacyAppliedMarker = "v1\n"
+)
+
+func tailscalePrivacyAppliedPath(path string) string {
+	return path + ".applied"
+}
+
+func reconcileTailscalePrivacy(path string, run func(context.Context, string, ...string) ([]byte, error)) error {
+	appliedPath := tailscalePrivacyAppliedPath(path)
+	current, fileErr := os.ReadFile(path)
+	applied, markerErr := os.ReadFile(appliedPath)
+	if fileErr == nil && markerErr == nil && string(current) == tailscalePrivacyOverride && string(applied) == tailscalePrivacyAppliedMarker {
+		return nil
+	}
+	if fileErr != nil && !errors.Is(fileErr, os.ErrNotExist) {
+		return fmt.Errorf("inspect Tailscale privacy override: %w", fileErr)
+	}
+	if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
+		return fmt.Errorf("inspect Tailscale privacy reconciliation marker: %w", markerErr)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create Tailscale systemd override directory: %w", err)
+	}
+	if string(current) != tailscalePrivacyOverride {
+		if err := writeAtomicHostFile(path, tailscalePrivacyOverride, 0o644); err != nil {
+			return fmt.Errorf("install Tailscale privacy override: %w", err)
+		}
+	}
+	_ = os.Remove(appliedPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if output, err := run(ctx, "systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("reload systemd for Tailscale privacy: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	if output, err := run(ctx, "systemctl", "restart", "tailscaled.service"); err != nil {
+		return fmt.Errorf("restart Tailscale with log uploads disabled: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	if err := writeAtomicHostFile(appliedPath, tailscalePrivacyAppliedMarker, 0o644); err != nil {
+		return fmt.Errorf("record applied Tailscale privacy state: %w", err)
+	}
+	return nil
+}
+
+func writeAtomicHostFile(path, content string, mode os.FileMode) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".vastora-host-state-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(mode); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.WriteString(content); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -62,9 +62,37 @@ curl -LsSf https://vastora.petauron.com/install.sh | sudo sh -s -- center uninst
 
 The same menu is available from an already updated installation as
 `sudo /opt/vastora/center/uninstall.sh`. Application cleanup is sent through
-the normal Center-to-Agent task lifecycle. Center is not removed if any node is
-offline or fails to confirm application removal. The Center database, Agents,
-Headscale, Caddy, and HAProxy are always preserved for safe recovery.
+the normal Center-to-Agent task lifecycle. Reachable Agents remove their apps,
+host state, service, and Vastora-owned dependencies before Center is removed.
+If an Agent is offline, the menu prints its exact local cleanup command and
+requires an explicit `FORCE` confirmation; the result remains marked as
+incomplete. The migration option preserves the existing runtime and data,
+while the two full-removal options also remove bundled Headscale, the shared
+gateway, and the Center database. Application data is deleted only by the
+destructive option.
+
+Every Center installation also installs the release binary at
+`/usr/local/bin/vastora` as a local management command:
+
+```sh
+vastora status
+sudo vastora update
+sudo vastora uninstall
+```
+
+The same executable manages a co-located Agent, so installing an Agent never
+adds a competing command or wrapper.
+
+On an Agent-only host, `sudo vastora uninstall` uses a small dependency-free
+terminal menu. Emergency cleanup remains available without Center:
+
+```sh
+sudo vastora agent uninstall --purge
+```
+
+Tailscale is removed only when the Agent installer recorded it as
+Vastora-managed. A Tailscale installation that already existed on the host is
+disconnected from Vastora but its package and repository are preserved.
 
 ## Release packaging
 

--- a/deploy/center/install-host-cli.sh
+++ b/deploy/center/install-host-cli.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+set -eu
+
+image=""
+version=""
+install_dir="/opt/vastora/center"
+target="${VASTORA_HOST_CLI_PATH:-/usr/local/bin/vastora}"
+systemd_unit_dir="${VASTORA_SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+agent_unit="$systemd_unit_dir/vastora-agent.service"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --image) image="$2"; shift 2 ;;
+    --version) version="$2"; shift 2 ;;
+    --install-dir) install_dir="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Installing the Vastora host command requires root." >&2
+  exit 1
+fi
+case "$image" in
+  *@sha256:????????????????????????????????????????????????????????????????) ;;
+  *) echo "The host command image must be pinned by a complete sha256 digest." >&2; exit 2 ;;
+esac
+image_digest="${image##*@sha256:}"
+case "$image_digest" in
+  *[!0-9a-fA-F]*) echo "The host command image digest is invalid." >&2; exit 2 ;;
+esac
+case "$target" in
+  /*/vastora) ;;
+  *) echo "The Vastora host command path must be an absolute path ending in /vastora." >&2; exit 2 ;;
+esac
+case "$target" in
+  /vastora|/bin/vastora|/sbin/vastora|/usr/vastora|/var/vastora|*/../*|*/..|*/./*|*/.|*/|*//*)
+    echo "Refusing unsafe Vastora host command path: $target" >&2
+    exit 2
+    ;;
+esac
+for required in docker grep install mktemp mv; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    echo "Required command is not installed: $required" >&2
+    exit 1
+  fi
+done
+
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-host-cli.XXXXXX")"
+container=""
+had_previous=no
+cleanup() {
+  status=$?
+  if [ -n "$container" ]; then
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$temporary_dir"
+  exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+container="$(docker create "$image")"
+docker cp "$container:/usr/local/bin/vastora" "$temporary_dir/vastora"
+docker rm -f "$container" >/dev/null
+container=""
+chmod 0755 "$temporary_dir/vastora"
+candidate_version="$("$temporary_dir/vastora" version)"
+if [ -z "$version" ]; then
+  version="$candidate_version"
+fi
+if [ "$candidate_version" != "$version" ]; then
+  echo "The Center image contains an unexpected Vastora command version." >&2
+  exit 1
+fi
+if [ -e "$target" ]; then
+  if [ ! -f "$target" ] || [ -L "$target" ] || ! "$target" help 2>&1 | grep -Fq 'Vastora control-plane tools'; then
+    echo "Refusing to replace an unrecognized executable at $target." >&2
+    exit 1
+  fi
+  install -m 0755 "$target" "$target.previous"
+  had_previous=yes
+fi
+
+target_dir="$(dirname "$target")"
+install -d -m 0755 "$target_dir"
+staged="$(mktemp "$target_dir/.vastora-install.XXXXXX")"
+install -m 0755 "$temporary_dir/vastora" "$staged"
+mv "$staged" "$target"
+
+if [ -f "$agent_unit" ] && grep -Fq 'Description=Vastora Agent' "$agent_unit"; then
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "systemctl is required to restart the co-located Vastora Agent." >&2
+    exit 1
+  fi
+  if ! systemctl restart vastora-agent.service || ! systemctl is-active --quiet vastora-agent.service; then
+    echo "The Agent did not accept the new Vastora executable; restoring the previous command." >&2
+    if [ "$had_previous" = yes ]; then
+      staged="$(mktemp "$target_dir/.vastora-rollback.XXXXXX")"
+      install -m 0755 "$target.previous" "$staged"
+      mv "$staged" "$target"
+      systemctl restart vastora-agent.service || true
+    else
+      rm -f "$target"
+    fi
+    exit 1
+  fi
+fi
+
+install -m 0644 /dev/null "$install_dir/.host-cli-installed"
+echo "Installed local management command: vastora status | update | uninstall"

--- a/deploy/center/setup.sh
+++ b/deploy/center/setup.sh
@@ -114,6 +114,9 @@ until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
   sleep 2
 done
 
+"$script_dir/install-host-cli.sh" \
+  --image "$image" --version "$release_version" --install-dir "$script_dir"
+
 echo "Enabling verified Center updates..."
 "$script_dir/install-update-service.sh" --install-dir "$script_dir"
 

--- a/deploy/center/uninstall.sh
+++ b/deploy/center/uninstall.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 
+source_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 install_dir="/opt/vastora/center"
 systemd_unit_dir="${VASTORA_SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
 center_data_volume="vastora_center-data"
@@ -9,7 +10,11 @@ input_device="${VASTORA_UNINSTALL_INPUT:-/dev/tty}"
 output_device="${VASTORA_UNINSTALL_OUTPUT:-/dev/tty}"
 application_cleanup="keep"
 delete_application_data=no
+force_offline=no
+local_agent_id=""
 update_path_paused=no
+host_cli="${VASTORA_HOST_CLI_PATH:-/usr/local/bin/vastora}"
+agent_unit="$systemd_unit_dir/vastora-agent.service"
 
 resume_center_updates() {
   if [ "$update_path_paused" = yes ]; then
@@ -61,11 +66,15 @@ case "$systemd_unit_dir" in
   /*) ;;
   *) echo "The systemd unit directory must be absolute." >&2; exit 2 ;;
 esac
+case "$host_cli" in
+  /*/vastora) ;;
+  *) echo "The Vastora host command path must be an absolute path ending in /vastora." >&2; exit 2 ;;
+esac
 if [ "$(id -u)" -ne 0 ]; then
   echo "Run the Center uninstaller with sudo." >&2
   exit 1
 fi
-for required in cat docker grep id rm systemctl; do
+for required in awk cat docker grep id rm systemctl; do
   if ! command -v "$required" >/dev/null 2>&1; then
     echo "Required command is not installed: $required" >&2
     exit 1
@@ -113,11 +122,56 @@ verify_managed_volume() {
   fi
 }
 
+verify_managed_runtime_volume() {
+  volume_name="$1"
+  compose_volume="$2"
+  container_name="$3"
+  component="$4"
+  if ! volume_exists "$volume_name"; then
+    return 0
+  fi
+  project_label="$(docker volume inspect --format '{{ index .Labels "com.docker.compose.project" }}' "$volume_name")"
+  volume_label="$(docker volume inspect --format '{{ index .Labels "com.docker.compose.volume" }}' "$volume_name")"
+  managed_label="$(docker volume inspect --format '{{ index .Labels "io.vastora.managed" }}' "$volume_name")"
+  component_label="$(docker volume inspect --format '{{ index .Labels "io.vastora.component" }}' "$volume_name")"
+  if { [ "$project_label" = "vastora" ] && [ "$volume_label" = "$compose_volume" ]; } || \
+     { [ "$managed_label" = "true" ] && [ "$component_label" = "center-headscale-storage" ]; }; then
+    return 0
+  fi
+  if ! docker container inspect "$container_name" >/dev/null 2>&1; then
+    echo "Refusing to delete legacy volume $volume_name because its owning Vastora container is unavailable." >&2
+    exit 1
+  fi
+  container_managed="$(docker container inspect --format '{{ index .Config.Labels "io.vastora.managed" }}' "$container_name")"
+  container_component="$(docker container inspect --format '{{ index .Config.Labels "io.vastora.component" }}' "$container_name")"
+  mounted_volumes="$(docker container inspect --format '{{ range .Mounts }}{{ println .Name }}{{ end }}' "$container_name")"
+  if [ "$container_managed" != "true" ] || [ "$container_component" != "$component" ] || \
+     ! printf '%s\n' "$mounted_volumes" | grep -Fqx "$volume_name"; then
+    echo "Refusing to delete legacy volume $volume_name because its runtime ownership could not be proven." >&2
+    exit 1
+  fi
+}
+
 if [ "$managed_install" = yes ] && ! docker compose version >/dev/null 2>&1; then
   echo "Docker Compose v2 is required to remove Center safely." >&2
   exit 1
 fi
 verify_managed_volume "$deployer_socket_volume" "deployer-socket"
+
+managed_container_remove() {
+  container_name="$1"
+  component="$2"
+  if ! docker container inspect "$container_name" >/dev/null 2>&1; then
+    return 0
+  fi
+  managed_label="$(docker container inspect --format '{{ index .Config.Labels "io.vastora.managed" }}' "$container_name")"
+  component_label="$(docker container inspect --format '{{ index .Config.Labels "io.vastora.component" }}' "$container_name")"
+  if [ "$managed_label" != "true" ] || [ "$component_label" != "$component" ]; then
+    echo "Refusing to remove container $container_name because its Vastora ownership labels do not match." >&2
+    exit 1
+  fi
+  docker rm -f "$container_name" >/dev/null
+}
 
 service_unit="$systemd_unit_dir/vastora-center-update.service"
 path_unit="$systemd_unit_dir/vastora-center-update.path"
@@ -197,11 +251,43 @@ EOF
       *) echo "已取消，没有修改任何内容。" >&4; exit 0 ;;
     esac
   fi
-  exec 3<&-
-  exec 4>&-
 fi
 
 if [ "$managed_install" = yes ] && [ "$application_cleanup" = "remove" ]; then
+  if [ -x "$host_cli" ] && [ -s /var/lib/vastora/agent/agent.db ]; then
+    local_agent_id="$($host_cli agent status --data-dir /var/lib/vastora/agent 2>/dev/null | awk -F ': ' '$1 == "Agent ID" {print $2; exit}')"
+  fi
+  if ! (
+    cd "$install_dir"
+    capabilities="$(docker compose exec -T center /usr/local/bin/vastora center capabilities 2>/dev/null)"
+    printf '%s\n' "$capabilities" | grep -Fqx 'decommission-applications' &&
+      printf '%s\n' "$capabilities" | grep -Fqx 'agent-host-decommission'
+  ); then
+    echo "Updating this older Center before managed application cleanup..."
+    "$source_dir/upgrade.sh" --install-dir "$install_dir"
+  fi
+  offline_report="$({
+    cd "$install_dir"
+    set -- --data-dir /var/lib/vastora
+    if [ -n "$local_agent_id" ]; then
+      set -- "$@" --deferred-agent-id "$local_agent_id"
+    fi
+    docker compose exec -T center /usr/local/bin/vastora center offline-agent-cleanups "$@"
+  })"
+  if [ -n "$offline_report" ]; then
+    echo >&4
+    echo "以下离线节点无法自动清理。请稍后在每台主机运行所列命令：" >&4
+    printf '%s\n' "$offline_report" >&4
+    echo "继续会把这些节点标记为未完成清理，不会声称清理成功。" >&4
+    printf '请输入 FORCE 继续卸载 Center: ' >&4
+    if ! IFS= read -r offline_confirmation <&3 || [ "$offline_confirmation" != "FORCE" ]; then
+      echo "卸载已取消；没有删除任何服务或数据。" >&4
+      exit 0
+    fi
+    force_offline=yes
+  fi
+  exec 3<&-
+  exec 4>&-
   if [ -e "$path_unit" ]; then
     echo "Pausing Center updates during application cleanup..."
     systemctl stop vastora-center-update.path >/dev/null
@@ -210,14 +296,23 @@ if [ "$managed_install" = yes ] && [ "$application_cleanup" = "remove" ]; then
   echo "Requesting application removal from every Agent..."
   (
     cd "$install_dir"
+    set -- --data-dir /var/lib/vastora
     if [ "$delete_application_data" = yes ]; then
-      docker compose exec -T center /usr/local/bin/vastora center decommission-applications \
-        --data-dir /var/lib/vastora --delete-data
-    else
-      docker compose exec -T center /usr/local/bin/vastora center decommission-applications \
-        --data-dir /var/lib/vastora
+      set -- "$@" --delete-data
     fi
+    if [ "$force_offline" = yes ]; then
+      set -- "$@" --force-offline
+    fi
+    if [ -n "$local_agent_id" ]; then
+      set -- "$@" --deferred-agent-id "$local_agent_id"
+    fi
+    docker compose exec -T center /usr/local/bin/vastora center decommission-applications "$@"
   )
+fi
+
+if [ "$managed_install" = yes ]; then
+  exec 3<&- 2>/dev/null || true
+  exec 4>&- 2>/dev/null || true
 fi
 
 if [ -e "$service_unit" ] || [ -e "$path_unit" ]; then
@@ -251,9 +346,57 @@ else
   done
 fi
 
+if [ "$managed_install" = yes ] && [ "$application_cleanup" = "remove" ]; then
+  echo "Removing bundled Headscale and the shared gateway..."
+  verify_managed_runtime_volume vastora_headscale-data headscale-data vastora-center-headscale center-headscale
+  verify_managed_runtime_volume vastora_headscale-config headscale-config vastora-center-headscale center-headscale
+  verify_managed_runtime_volume vastora_headscale-caddy-data headscale-caddy-data vastora-gateway-caddy gateway
+  verify_managed_runtime_volume vastora_headscale-caddy-config headscale-caddy-config vastora-gateway-caddy gateway
+  managed_container_remove vastora-center-headscale center-headscale
+  managed_container_remove vastora-gateway-haproxy layer4-gateway
+  managed_container_remove vastora-gateway-caddy gateway
+  if [ -n "$local_agent_id" ] && [ -x "$host_cli" ]; then
+    echo "Removing the Agent on the Center host..."
+    set -- agent uninstall --purge --runtime-cleaned --keep-binary
+    if [ "$delete_application_data" = yes ]; then
+      set -- "$@" --delete-data
+    fi
+    "$host_cli" "$@"
+  fi
+fi
+
 if volume_exists "$deployer_socket_volume"; then
   verify_managed_volume "$deployer_socket_volume" "deployer-socket"
   docker volume rm "$deployer_socket_volume" >/dev/null
+fi
+if [ "$managed_install" = yes ] && [ "$application_cleanup" = "remove" ]; then
+  for volume_spec in \
+    "vastora_headscale-data:headscale-data" \
+    "vastora_headscale-config:headscale-config" \
+    "vastora_headscale-caddy-data:headscale-caddy-data" \
+    "vastora_headscale-caddy-config:headscale-caddy-config"; do
+    volume_name="${volume_spec%%:*}"
+    compose_name="${volume_spec#*:}"
+    if volume_exists "$volume_name"; then
+      docker volume rm "$volume_name" >/dev/null
+    fi
+  done
+  if volume_exists "$center_data_volume"; then
+    verify_managed_volume "$center_data_volume" "center-data"
+    docker volume rm "$center_data_volume" >/dev/null
+  fi
+fi
+if [ "$managed_install" = yes ] && [ -f "$install_dir/.host-cli-installed" ]; then
+  if [ -f "$agent_unit" ] && grep -Fq 'Description=Vastora Agent' "$agent_unit"; then
+    echo "Keeping the Vastora command because this host still runs an Agent."
+  elif [ -f "$host_cli" ] && [ ! -L "$host_cli" ] && "$host_cli" help 2>&1 | grep -Fq 'Vastora control-plane tools'; then
+    rm -f "$host_cli"
+    if [ -f "$host_cli.previous" ] && "$host_cli.previous" help 2>&1 | grep -Fq 'Vastora control-plane tools'; then
+      rm -f "$host_cli.previous"
+    fi
+  else
+    echo "Keeping the unrecognized command at $host_cli." >&2
+  fi
 fi
 if [ "$managed_install" = yes ]; then
   rm -rf "$install_dir"
@@ -261,11 +404,16 @@ fi
 
 echo
 echo "Vastora Center has been uninstalled."
-echo "Preserved: Agent, Headscale, Caddy, HAProxy, and Center database volume $center_data_volume."
 if [ "$application_cleanup" = "keep" ]; then
+  echo "Preserved: Agent, Headscale, Caddy, HAProxy, Center database, applications, and application data."
   echo "Applications and application data: preserved"
 elif [ "$delete_application_data" = yes ]; then
+  echo "Center, bundled Headscale, gateway, reachable Agents, applications, and application data: removed"
   echo "Applications and application data: deleted"
 else
+  echo "Center, bundled Headscale, gateway, reachable Agents, and applications: removed"
   echo "Applications: removed; application data: preserved"
+fi
+if [ "$force_offline" = yes ]; then
+  echo "Offline Agents: cleanup incomplete; run the manual commands shown above on those hosts."
 fi

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -30,7 +30,7 @@ if [ ! -f "$install_dir/.env" ] || [ ! -f "$install_dir/compose.yaml" ]; then
   echo "$install_dir is not a complete Center installation." >&2
   exit 1
 fi
-for required_file in setup.sh upgrade.sh uninstall.sh install-update-service.sh update-center.sh compose.yaml release.env; do
+for required_file in install.sh setup.sh upgrade.sh uninstall.sh install-host-cli.sh install-update-service.sh update-center.sh compose.yaml release.env; do
   if [ ! -f "$source_dir/$required_file" ]; then
     echo "The upgrade bundle is incomplete: missing $required_file" >&2
     exit 1
@@ -75,7 +75,7 @@ if [ "$(docker inspect -f '{{.State.Running}}' vastora-gateway-haproxy 2>/dev/nu
 fi
 
 restore_files() {
-  for relative in setup.sh upgrade.sh uninstall.sh install-update-service.sh update-center.sh compose.yaml release.env .env; do
+  for relative in install.sh setup.sh upgrade.sh uninstall.sh install-host-cli.sh install-update-service.sh update-center.sh compose.yaml release.env .env; do
     if [ -f "$backup_dir/$relative" ]; then
       install -d -m 0755 "$(dirname "$install_dir/$relative")"
       install -m 0644 "$backup_dir/$relative" "$install_dir/$relative"
@@ -86,6 +86,7 @@ restore_files() {
   chmod 0755 "$install_dir/setup.sh"
   if [ -f "$install_dir/upgrade.sh" ]; then chmod 0755 "$install_dir/upgrade.sh"; fi
   if [ -f "$install_dir/uninstall.sh" ]; then chmod 0755 "$install_dir/uninstall.sh"; fi
+  if [ -f "$install_dir/install-host-cli.sh" ]; then chmod 0755 "$install_dir/install-host-cli.sh"; fi
   if [ -f "$install_dir/install-update-service.sh" ]; then chmod 0755 "$install_dir/install-update-service.sh"; fi
   if [ -f "$install_dir/update-center.sh" ]; then chmod 0755 "$install_dir/update-center.sh"; fi
 }
@@ -161,16 +162,18 @@ if [ -f "$agent_executable" ] && [ -f "$agent_unit" ] && grep -Fq 'Description=V
   echo "Co-located Agent updated to $new_version before Center reconciliation."
 fi
 
-for relative in setup.sh upgrade.sh uninstall.sh install-update-service.sh update-center.sh compose.yaml release.env .env; do
+for relative in install.sh setup.sh upgrade.sh uninstall.sh install-host-cli.sh install-update-service.sh update-center.sh compose.yaml release.env .env; do
   if [ -f "$install_dir/$relative" ]; then
     install -d -m 0755 "$(dirname "$backup_dir/$relative")"
     install -m 0644 "$install_dir/$relative" "$backup_dir/$relative"
   fi
 done
 
+install -m 0755 "$source_dir/install.sh" "$install_dir/install.sh"
 install -m 0755 "$source_dir/setup.sh" "$install_dir/setup.sh"
 install -m 0755 "$source_dir/upgrade.sh" "$install_dir/upgrade.sh"
 install -m 0755 "$source_dir/uninstall.sh" "$install_dir/uninstall.sh"
+install -m 0755 "$source_dir/install-host-cli.sh" "$install_dir/install-host-cli.sh"
 install -m 0755 "$source_dir/install-update-service.sh" "$install_dir/install-update-service.sh"
 install -m 0755 "$source_dir/update-center.sh" "$install_dir/update-center.sh"
 install -m 0644 "$source_dir/compose.yaml" "$install_dir/compose.yaml"
@@ -236,7 +239,12 @@ if [ "$agent_changed" = yes ]; then
     done
   fi
   echo "Co-located Agent reconciled successfully after Center startup."
+else
+  "$install_dir/install-host-cli.sh" \
+    --image "$new_image" --version "$new_version" --install-dir "$install_dir"
 fi
+
+install -m 0644 /dev/null "$install_dir/.host-cli-installed"
 
 files_changed=no
 agent_changed=no

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,21 @@ existing HTTPS Headscale API. Center creates Vastora users/tags and one-hour,
 single-use pre-auth keys, but it does not embed Headscale logic into the Center
 process.
 
+Bundled Headscale runs an authenticated embedded DERP relay and advertises no
+Tailscale-operated DERP regions. Direct peer-to-peer WireGuard paths remain the
+preferred data path; nodes fall back only to the bundled relay. Headscale
+update checks, remote DERP-map updates, Logtail, and client auto-update
+instructions are disabled. Vastora-managed Linux Tailscale services also opt
+out of Tailscale log upload through a systemd override that Agent install and
+upgrade reconcile idempotently. The embedded STUN listener uses UDP 3478, which
+operators must allow through both host and provider firewalls for effective NAT
+discovery.
+
+The strict no-external-telemetry boundary applies to Vastora-managed Linux
+`tailscaled`. Tailscale's macOS GUI clients do not support the equivalent opt-out;
+operators requiring the same assurance on macOS must use the open-source CLI
+daemon or enforce an outbound allowlist.
+
 The Center host may also be an application node. In that topology its Agent and
 Tailscale client run on the host, while bundled Headscale stays container-network
 isolated and is reached only through the loopback-bound control port and the

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -50,6 +50,19 @@
   reachable coordination server. Center has no public DNS record or public
   Caddy route. The Headscale hostname forwards only the exact Agent installer
   path to Center; enrollment tokens remain ten-minute, single-use credentials.
+- Bundled Headscale advertises only its authenticated embedded DERP relay. It
+  never downloads Tailscale's public DERP map, performs no Headscale update
+  check, and keeps Headscale Logtail and client auto-update instructions
+  disabled. Vastora-managed Linux clients run `tailscaled` with
+  `TS_NO_LOGS_NO_SUPPORT=true`, so private-network operational logs are not
+  uploaded to Tailscale. Public application traffic and explicitly configured
+  public integrations remain outside this private-network isolation boundary.
+- An external Headscale deployment is operator-controlled and must enforce an
+  equivalent DERP and logging policy before it can satisfy the bundled
+  deployment's private-network security boundary.
+- Tailscale's macOS GUI clients remain outside the strict zero-external-telemetry
+  boundary because they do not support the daemon logging opt-out. Such clients
+  require the open-source CLI daemon or an operator-enforced outbound allowlist.
 - The unauthenticated setup endpoint creates an administrator only while the
   administrator table is empty; all later setup requests are rejected. Until
   setup finishes, the released deployment publishes Center only on server

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,7 @@ fi
 install -d -m 0755 "$(dirname "$install_dir")"
 staging="$(mktemp -d "${install_dir}.new.XXXXXX")"
 tar -xzf "$archive" -C "$staging"
-for required_file in setup.sh upgrade.sh uninstall.sh install-update-service.sh update-center.sh compose.yaml release.env; do
+for required_file in install.sh setup.sh upgrade.sh uninstall.sh install-host-cli.sh install-update-service.sh update-center.sh compose.yaml release.env; do
   if [ ! -f "$staging/$required_file" ]; then
     echo "The Center release is incomplete: missing $required_file" >&2
     exit 1
@@ -149,6 +149,7 @@ done
 chmod 0755 "$staging/setup.sh"
 chmod 0755 "$staging/upgrade.sh"
 chmod 0755 "$staging/uninstall.sh"
+chmod 0755 "$staging/install-host-cli.sh"
 chmod 0755 "$staging/install-update-service.sh"
 chmod 0755 "$staging/update-center.sh"
 

--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -32,6 +32,12 @@ type Client struct {
 	GatewayDriver      GatewayDriver
 	GatewayProvisioner GatewayProvisioner
 	TunnelProvisioner  TunnelProvisioner
+	Decommissioner     HostDecommissioner
+}
+
+type HostDecommissioner interface {
+	Prepare(context.Context, bool) error
+	ScheduleFinalRemoval(context.Context, bool) error
 }
 
 // deferredTaskCompletionError leaves the Center task lease active so the same
@@ -679,6 +685,12 @@ func (c Client) processTask(ctx context.Context, store *Store, task DeploymentTa
 			err = errors.New("agent: tunnel task received without tunnel capability")
 		} else {
 			err = c.TunnelProvisioner.Apply(ctx, *task.TunnelState)
+		}
+	case "agent.decommission":
+		if c.Decommissioner == nil {
+			err = errors.New("agent: host decommission capability is not configured")
+		} else if err = c.Decommissioner.Prepare(ctx, task.DeleteData); err == nil {
+			err = c.Decommissioner.ScheduleFinalRemoval(ctx, task.DeleteData)
 		}
 	default:
 		err = errors.New("agent: unsupported task kind")

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -16,6 +16,26 @@ import (
 	"github.com/petauron/vastora/internal/gateway"
 )
 
+type fakeHostDecommissioner struct {
+	prepared   bool
+	scheduled  bool
+	deleteData bool
+}
+
+func (d *fakeHostDecommissioner) Prepare(_ context.Context, deleteData bool) error {
+	d.prepared = true
+	d.deleteData = deleteData
+	return nil
+}
+
+func (d *fakeHostDecommissioner) ScheduleFinalRemoval(_ context.Context, deleteData bool) error {
+	d.scheduled = true
+	if deleteData != d.deleteData {
+		return errors.New("delete-data changed between cleanup phases")
+	}
+	return nil
+}
+
 func TestEnrollmentReportsNativePlatform(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		var input struct {
@@ -356,5 +376,32 @@ func TestTunnelDesiredStateRequiresFixedImageAndTokenWhileRunning(t *testing.T) 
 	}
 	if err := (TunnelDesiredState{Revision: 3, Status: "stopped"}).Validate(); err != nil {
 		t.Fatalf("stopped Tunnel unexpectedly required a token: %v", err)
+	}
+}
+
+func TestAgentDecommissionSchedulesFinalRemovalBeforeAcknowledgement(t *testing.T) {
+	acknowledged := false
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/agents/agent-1/tasks/agent-decommission-agent-1/result" || request.Header.Get("Authorization") != "Bearer credential" {
+			t.Fatalf("unexpected task acknowledgement: %s %s", request.Method, request.URL.Path)
+		}
+		acknowledged = true
+		response.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "agent-1", Name: "node", CenterURL: server.URL, Credential: "credential"}); err != nil {
+		t.Fatal(err)
+	}
+	decommissioner := &fakeHostDecommissioner{}
+	(Client{HTTPClient: server.Client(), Decommissioner: decommissioner}).processTask(context.Background(), store, DeploymentTask{
+		Kind: "agent.decommission", ID: "agent-decommission-agent-1", Attempt: 1, DeleteData: true,
+	}, func(err error) { t.Errorf("task error: %v", err) })
+	if !decommissioner.prepared || !decommissioner.scheduled || !acknowledged {
+		t.Fatalf("decommission lifecycle incomplete: %#v acknowledged=%v", decommissioner, acknowledged)
 	}
 }

--- a/internal/agent/gateway_provisioner.go
+++ b/internal/agent/gateway_provisioner.go
@@ -108,7 +108,10 @@ func (provisioner DockerGatewayProvisioner) Ensure(ctx context.Context) error {
 	_, _ = io.Copy(io.Discard, pull)
 	_ = pull.Close()
 	for _, name := range []string{settings.DataVolume, settings.ConfigVolume} {
-		if _, err := docker.VolumeCreate(ctx, client.VolumeCreateOptions{Name: name}); err != nil {
+		if _, err := docker.VolumeCreate(ctx, client.VolumeCreateOptions{Name: name, Labels: map[string]string{
+			gatewayruntime.ManagedLabel:   "true",
+			gatewayruntime.ComponentLabel: "gateway-storage",
+		}}); err != nil {
 			return fmt.Errorf("agent: create Caddy volume %s: %w", name, err)
 		}
 	}

--- a/internal/agent/host_install.go
+++ b/internal/agent/host_install.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const HostInstallStateName = "host-install.env"
+
+type HostInstallState struct {
+	TailscaleOwnership string
+	TailscaleEnrolled  bool
+}
+
+func ReadHostInstallState(dataDir string) (HostInstallState, error) {
+	state := HostInstallState{TailscaleOwnership: "external"}
+	file, err := os.Open(filepath.Join(dataDir, HostInstallStateName))
+	if errors.Is(err, os.ErrNotExist) {
+		// Old installations have no trustworthy provenance. Preserve host
+		// packages rather than guessing that Vastora owns them.
+		return state, nil
+	}
+	if err != nil {
+		return HostInstallState{}, fmt.Errorf("agent: read host install state: %w", err)
+	}
+	defer file.Close()
+	values := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), "=")
+		if ok {
+			values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return HostInstallState{}, fmt.Errorf("agent: read host install state: %w", err)
+	}
+	if values["HOST_STATE_VERSION"] != "1" {
+		return HostInstallState{}, errors.New("agent: unsupported host install state")
+	}
+	ownership := values["TAILSCALE_OWNERSHIP"]
+	if ownership != "managed" && ownership != "external" && ownership != "none" {
+		return HostInstallState{}, errors.New("agent: invalid Tailscale ownership state")
+	}
+	state.TailscaleOwnership = ownership
+	state.TailscaleEnrolled = values["TAILSCALE_ENROLLED"] == "1"
+	return state, nil
+}

--- a/internal/agent/host_install_test.go
+++ b/internal/agent/host_install_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadHostInstallStatePreservesUnknownLegacyTailscale(t *testing.T) {
+	directory := t.TempDir()
+	state, err := ReadHostInstallState(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.TailscaleOwnership != "external" || state.TailscaleEnrolled {
+		t.Fatalf("legacy install was treated as Vastora-owned: %#v", state)
+	}
+}
+
+func TestReadHostInstallStateTracksManagedTailscaleWithoutSecrets(t *testing.T) {
+	directory := t.TempDir()
+	content := "HOST_STATE_VERSION=1\nTAILSCALE_OWNERSHIP=managed\nTAILSCALE_ENROLLED=1\n"
+	if err := os.WriteFile(filepath.Join(directory, HostInstallStateName), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := ReadHostInstallState(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.TailscaleOwnership != "managed" || !state.TailscaleEnrolled {
+		t.Fatalf("managed Tailscale provenance was lost: %#v", state)
+	}
+}

--- a/internal/agent/uninstall.go
+++ b/internal/agent/uninstall.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/client"
+	"github.com/petauron/vastora/internal/gatewayruntime"
+)
+
+// PurgeManagedRuntime removes only workloads with fixed Vastora ownership. It
+// is intentionally independent of Center and Agent database availability so a
+// partially damaged node can still be cleaned locally.
+func PurgeManagedRuntime(ctx context.Context, deleteApplicationData bool) error {
+	var result error
+	gatewaySettings, err := (DockerGatewayProvisioner{}).settings()
+	if err != nil {
+		return err
+	}
+	docker, err := client.New(client.WithHost("unix:///var/run/docker.sock"))
+	if err != nil {
+		return fmt.Errorf("agent: connect Docker to inspect gateway data: %w", err)
+	}
+	defer docker.Close()
+	existingGateway, err := inspectManagedCaddy(ctx, docker, gatewaySettings.Container)
+	if err != nil {
+		return err
+	}
+	for _, volume := range []string{gatewaySettings.DataVolume, gatewaySettings.ConfigVolume} {
+		if err := verifyManagedGatewayVolume(ctx, docker, existingGateway, volume); err != nil {
+			return err
+		}
+	}
+	executor := DockerExecutor{}
+	for _, appKey := range []string{keeperKey, komariKey, cpaKey, threeXUIKey} {
+		_, err := executor.Deploy(ctx, DeploymentTask{AppKey: appKey, Operation: "uninstall", DeleteData: deleteApplicationData})
+		result = errors.Join(result, err)
+	}
+	result = errors.Join(result, (DockerTunnelProvisioner{}).Apply(ctx, TunnelDesiredState{Revision: 1, Status: "stopped"}))
+	result = errors.Join(result, (ManagedGatewayProvisioner{Caddy: DockerGatewayProvisioner{}, Layer4: DockerLayer4Provisioner{}}).Remove(ctx))
+	if result != nil {
+		return result
+	}
+	for _, volume := range []string{gatewaySettings.DataVolume, gatewaySettings.ConfigVolume} {
+		if _, err := docker.VolumeRemove(ctx, volume, client.VolumeRemoveOptions{Force: true}); err != nil && !errdefs.IsNotFound(err) {
+			return fmt.Errorf("agent: remove gateway volume %s: %w", volume, err)
+		}
+	}
+	return nil
+}
+
+func verifyManagedGatewayVolume(ctx context.Context, docker *client.Client, gateway *client.ContainerInspectResult, name string) error {
+	volume, err := docker.VolumeInspect(ctx, name, client.VolumeInspectOptions{})
+	if errdefs.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("agent: inspect gateway volume %s: %w", name, err)
+	}
+	if volume.Volume.Labels[gatewayruntime.ManagedLabel] == "true" && volume.Volume.Labels[gatewayruntime.ComponentLabel] == "gateway-storage" {
+		return nil
+	}
+	if gateway != nil {
+		for _, mount := range gateway.Container.Mounts {
+			if mount.Name == name {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("agent: refusing to remove unowned gateway volume %s", name)
+}

--- a/internal/center/agent_decommission_tasks.go
+++ b/internal/center/agent_decommission_tasks.go
@@ -1,0 +1,130 @@
+package center
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func agentDecommissionTaskID(agentID string) string {
+	return "agent-decommission-" + agentID
+}
+
+func (s *Store) queueAgentDecommission(ctx context.Context, agentID string, deleteData bool) error {
+	now := s.now().UTC().Format(time.RFC3339Nano)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO agent_decommissions(agent_id, delete_data, state, created_at, updated_at)
+		VALUES(?, ?, 'pending', ?, ?)
+		ON CONFLICT(agent_id) DO UPDATE SET delete_data = excluded.delete_data, state = CASE WHEN agent_decommissions.state = 'succeeded' THEN agent_decommissions.state ELSE 'pending' END,
+		lease_expires_at = '', last_error = '', updated_at = excluded.updated_at`, agentID, deleteData, now, now)
+	if err != nil {
+		return fmt.Errorf("center: queue Agent host cleanup: %w", err)
+	}
+	return s.recordStandaloneTaskEvent(ctx, agentDecommissionTaskID(agentID), agentID, "agent.decommission", 1, "queued", "host cleanup queued")
+}
+
+func (s *Store) claimAgentDecommission(ctx context.Context, tx *sql.Tx, agentID string) (*AgentTask, error) {
+	var deleteData bool
+	var attempt int64
+	err := tx.QueryRowContext(ctx, `SELECT delete_data, attempt FROM agent_decommissions WHERE agent_id = ? AND state IN ('pending', 'failed')`, agentID).Scan(&deleteData, &attempt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("center: read Agent host cleanup: %w", err)
+	}
+	now := s.now().UTC()
+	result, err := tx.ExecContext(ctx, `UPDATE agent_decommissions SET state = 'running', attempt = attempt + 1, lease_expires_at = ?, last_error = '', updated_at = ?
+		WHERE agent_id = ? AND state IN ('pending', 'failed') AND attempt = ?`, now.Add(taskLeaseDuration).Format(time.RFC3339Nano), now.Format(time.RFC3339Nano), agentID, attempt)
+	if err != nil {
+		return nil, fmt.Errorf("center: claim Agent host cleanup: %w", err)
+	}
+	if changed, _ := result.RowsAffected(); changed != 1 {
+		return nil, errors.New("center: Agent host cleanup changed while claiming")
+	}
+	task := &AgentTask{Kind: "agent.decommission", ID: agentDecommissionTaskID(agentID), Attempt: attempt + 1, DeleteData: deleteData, Revision: 1}
+	if err := s.recordTaskEvent(ctx, tx, task.ID, agentID, task.Kind, 1, "claimed", fmt.Sprintf("attempt %d", task.Attempt)); err != nil {
+		return nil, err
+	}
+	return task, nil
+}
+
+func (s *Store) completeAgentDecommission(ctx context.Context, agentID string, expectedAttempt int64, succeeded bool, taskError string) error {
+	taskError = strings.TrimSpace(taskError)
+	if len(taskError) > 1024 {
+		taskError = taskError[:1024]
+	}
+	state := "succeeded"
+	if !succeeded {
+		state = "failed"
+		if taskError == "" {
+			taskError = "Agent host cleanup failed"
+		}
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	result, err := tx.ExecContext(ctx, `UPDATE agent_decommissions SET state = ?, lease_expires_at = '', last_error = ?, updated_at = ?
+		WHERE agent_id = ? AND state = 'running' AND attempt = ?`, state, taskError, s.now().UTC().Format(time.RFC3339Nano), agentID, expectedAttempt)
+	if err != nil {
+		return fmt.Errorf("center: complete Agent host cleanup: %w", err)
+	}
+	if changed, _ := result.RowsAffected(); changed != 1 {
+		return errors.New("center: Agent host cleanup task is stale")
+	}
+	if err := s.recordTaskEvent(ctx, tx, agentDecommissionTaskID(agentID), agentID, "agent.decommission", 1, state, taskError); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) waitForAgentDecommissions(ctx context.Context, agents []AgentView, progress func(string)) error {
+	pending := make(map[string]string, len(agents))
+	for _, agent := range agents {
+		pending[agent.ID] = agent.Name
+	}
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for len(pending) != 0 {
+		for agentID, name := range pending {
+			var state, taskError string
+			if err := s.db.QueryRowContext(ctx, `SELECT state, last_error FROM agent_decommissions WHERE agent_id = ?`, agentID).Scan(&state, &taskError); err != nil {
+				return fmt.Errorf("center: inspect Agent host cleanup for %s: %w", name, err)
+			}
+			switch state {
+			case "succeeded":
+				delete(pending, agentID)
+				if progress != nil {
+					progress(fmt.Sprintf("Host cleanup acknowledged: %s (%s)", name, agentID))
+				}
+			case "failed":
+				return fmt.Errorf("center: Agent host cleanup failed for %s (%s): %s", name, agentID, taskError)
+			}
+		}
+		if len(pending) == 0 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("center: Agent host cleanup did not finish: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+	if len(agents) != 0 && s.agentDecommissionGrace > 0 {
+		if progress != nil {
+			progress("Waiting for acknowledged Agent host cleanup to finish...")
+		}
+		timer := time.NewTimer(s.agentDecommissionGrace)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("center: final Agent host cleanup did not finish: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+	return nil
+}

--- a/internal/center/agent_install.go
+++ b/internal/center/agent_install.go
@@ -173,7 +173,9 @@ func renderAgentInstallScript(profile AgentEnrollmentInstallProfile, bootstrapUR
 	headscaleBootstrap := ":"
 	if profile.HeadscaleCommand != "" {
 		headscaleBootstrap = `tailscale_version=@@TAILSCALE_VERSION@@
+tailscale_ownership=external
 if ! command -v tailscale >/dev/null 2>&1; then
+	 tailscale_ownership=managed
   if ! command -v apt-get >/dev/null 2>&1; then
     echo "Vastora can install Tailscale automatically only on Ubuntu 24.04." >&2
     exit 1
@@ -194,10 +196,55 @@ if [ "$installed_tailscale_version" != "$tailscale_version" ]; then
   echo "Vastora requires Tailscale $tailscale_version; found $installed_tailscale_version." >&2
   exit 1
 fi
-systemctl enable --now tailscaled
+privacy_override=/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf
+privacy_override_marker="$privacy_override.applied"
+privacy_override_changed=0
+install -d -m 0755 "$(dirname "$privacy_override")"
+privacy_override_temporary="$(mktemp "$(dirname "$privacy_override")/.90-vastora-privacy.XXXXXX")"
+printf '%s\n' '[Service]' 'Environment=TS_NO_LOGS_NO_SUPPORT=true' >"$privacy_override_temporary"
+chmod 0644 "$privacy_override_temporary"
+if ! cmp -s "$privacy_override_temporary" "$privacy_override" || [ ! -f "$privacy_override_marker" ] || [ "$(cat "$privacy_override_marker")" != v1 ]; then
+  mv "$privacy_override_temporary" "$privacy_override"
+  privacy_override_changed=1
+else
+  rm -f "$privacy_override_temporary"
+fi
+tailscaled_was_active=0
+if systemctl is-active --quiet tailscaled.service; then
+  tailscaled_was_active=1
+fi
+if [ "$privacy_override_changed" -eq 1 ]; then
+  systemctl daemon-reload
+fi
+systemctl enable --now tailscaled.service
+if [ "$privacy_override_changed" -eq 1 ] && [ "$tailscaled_was_active" -eq 1 ]; then
+  systemctl restart tailscaled.service
+fi
+if [ "$privacy_override_changed" -eq 1 ]; then
+  privacy_marker_temporary="$(mktemp "$(dirname "$privacy_override_marker")/.90-vastora-privacy-applied.XXXXXX")"
+  printf '%s\n' v1 >"$privacy_marker_temporary"
+  chmod 0644 "$privacy_marker_temporary"
+  mv "$privacy_marker_temporary" "$privacy_override_marker"
+fi
 echo "Joining the private network..."
-` + strings.TrimPrefix(profile.HeadscaleCommand, "sudo ")
+` + strings.TrimPrefix(profile.HeadscaleCommand, "sudo ") + `
+install -d -m 0700 /var/lib/vastora/agent
+if [ ! -f /var/lib/vastora/agent/host-install.env ]; then
+  host_state_temporary="$(mktemp /var/lib/vastora/agent/.host-install.XXXXXX)"
+  printf '%s\n' 'HOST_STATE_VERSION=1' "TAILSCALE_OWNERSHIP=$tailscale_ownership" 'TAILSCALE_ENROLLED=1' >"$host_state_temporary"
+  chmod 0600 "$host_state_temporary"
+  mv "$host_state_temporary" /var/lib/vastora/agent/host-install.env
+fi
+`
 		headscaleBootstrap = strings.ReplaceAll(headscaleBootstrap, "@@TAILSCALE_VERSION@@", shellQuote(agentTailscaleVersion))
+	} else {
+		headscaleBootstrap = `install -d -m 0700 /var/lib/vastora/agent
+if [ ! -f /var/lib/vastora/agent/host-install.env ]; then
+  host_state_temporary="$(mktemp /var/lib/vastora/agent/.host-install.XXXXXX)"
+  printf '%s\n' 'HOST_STATE_VERSION=1' 'TAILSCALE_OWNERSHIP=none' 'TAILSCALE_ENROLLED=0' >"$host_state_temporary"
+  chmod 0600 "$host_state_temporary"
+  mv "$host_state_temporary" /var/lib/vastora/agent/host-install.env
+fi`
 	}
 	return strings.NewReplacer(
 		"@@CENTER_URL@@", shellQuote(profile.CenterURL),

--- a/internal/center/agent_install_test.go
+++ b/internal/center/agent_install_test.go
@@ -192,9 +192,19 @@ func TestAgentInstallScriptInstallsTailscaleBeforeJoiningHeadscale(t *testing.T)
 		"apt-get install -y \"tailscale=$tailscale_version\"",
 		"installed_tailscale_version=",
 		"Vastora requires Tailscale $tailscale_version",
-		"systemctl enable --now tailscaled",
+		"Environment=TS_NO_LOGS_NO_SUPPORT=true",
+		"/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf",
+		"privacy_override_marker=\"$privacy_override.applied\"",
+		"cmp -s \"$privacy_override_temporary\" \"$privacy_override\"",
+		"systemctl is-active --quiet tailscaled.service",
+		"systemctl daemon-reload",
+		"systemctl enable --now tailscaled.service",
+		"systemctl restart tailscaled.service",
+		"printf '%s\\n' v1 >\"$privacy_marker_temporary\"",
 		"Joining the private network...",
 		"tailscale up --login-server 'https://headscale.example.com' --auth-key 'one-time-key' --reset",
+		"TAILSCALE_OWNERSHIP=$tailscale_ownership",
+		"TAILSCALE_ENROLLED=1",
 	} {
 		if !strings.Contains(script, expected) {
 			t.Fatalf("private-network installer is missing %q:\n%s", expected, script)

--- a/internal/center/decommission.go
+++ b/internal/center/decommission.go
@@ -9,10 +9,32 @@ import (
 	"time"
 )
 
-// DecommissionApplications uninstalls every application currently managed by
-// Center. It preserves the control plane until every Agent has acknowledged
-// removal, so an offline node cannot silently become an orphaned workload.
-func (s *Store) DecommissionApplications(ctx context.Context, deleteData bool, progress func(string)) error {
+type OfflineAgentCleanup struct {
+	ID      string
+	Name    string
+	Command string
+}
+
+func (s *Store) OfflineAgentCleanups(ctx context.Context, deferredAgentID string) ([]OfflineAgentCleanup, error) {
+	agents, err := s.ListAgents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("center: list nodes before decommission: %w", err)
+	}
+	cleanups := []OfflineAgentCleanup{}
+	for _, agent := range agents {
+		if agent.ID == deferredAgentID || agent.Connected {
+			continue
+		}
+		cleanups = append(cleanups, OfflineAgentCleanup{ID: agent.ID, Name: agent.Name, Command: "sudo vastora agent uninstall --purge"})
+	}
+	return cleanups, nil
+}
+
+// DecommissionApplications uninstalls every reachable application and then
+// asks each reachable Agent to remove its host-local Vastora state. The
+// deferred Agent is the Center host and is removed locally after Center and
+// bundled infrastructure have stopped.
+func (s *Store) DecommissionApplications(ctx context.Context, deleteData, forceOffline bool, deferredAgentID string, progress func(string)) error {
 	applications, err := s.ListApplications(ctx)
 	if err != nil {
 		return fmt.Errorf("center: list applications before decommission: %w", err)
@@ -24,6 +46,13 @@ func (s *Store) DecommissionApplications(ctx context.Context, deleteData bool, p
 	connectedAgents := make(map[string]bool, len(agents))
 	for _, agent := range agents {
 		connectedAgents[agent.ID] = agent.Connected
+	}
+	offline, err := s.OfflineAgentCleanups(ctx, deferredAgentID)
+	if err != nil {
+		return err
+	}
+	if len(offline) != 0 && !forceOffline {
+		return fmt.Errorf("center: %d Agent(s) are offline; run their displayed manual cleanup commands or explicitly force teardown", len(offline))
 	}
 	groups := make([][]ApplicationView, 3)
 	for _, application := range applications {
@@ -44,7 +73,7 @@ func (s *Store) DecommissionApplications(ctx context.Context, deleteData bool, p
 			}
 		}
 		if !connectedAgents[application.NodeID] {
-			return fmt.Errorf("center: node %s is offline; reconnect it before uninstalling managed applications", application.NodeID)
+			continue
 		}
 		priority := decommissionPriority(application)
 		groups[priority] = append(groups[priority], application)
@@ -95,7 +124,34 @@ func (s *Store) DecommissionApplications(ctx context.Context, deleteData bool, p
 	if progress != nil && total != 0 {
 		progress("Waiting for gateway, tunnel, and DNS cleanup...")
 	}
-	return s.waitForDecommissionInfrastructure(ctx)
+	if err := s.waitForDecommissionInfrastructure(ctx); err != nil {
+		return err
+	}
+	decommissionAgents := []AgentView{}
+	for _, agent := range agents {
+		switch {
+		case agent.ID == deferredAgentID:
+			if progress != nil {
+				progress(fmt.Sprintf("Center host cleanup deferred until local teardown: %s (%s)", agent.Name, agent.ID))
+			}
+		case !agent.Connected:
+			now := s.now().UTC().Format(time.RFC3339Nano)
+			if _, err := s.db.ExecContext(ctx, `INSERT INTO agent_decommissions(agent_id, delete_data, state, last_error, created_at, updated_at)
+				VALUES(?, ?, 'abandoned', 'manual cleanup required because Agent was offline', ?, ?)
+				ON CONFLICT(agent_id) DO UPDATE SET delete_data = excluded.delete_data, state = 'abandoned', lease_expires_at = '', last_error = excluded.last_error, updated_at = excluded.updated_at`, agent.ID, deleteData, now, now); err != nil {
+				return fmt.Errorf("center: record incomplete cleanup for offline Agent %s: %w", agent.ID, err)
+			}
+			if progress != nil {
+				progress(fmt.Sprintf("Manual cleanup still required: %s (%s): sudo vastora agent uninstall --purge", agent.Name, agent.ID))
+			}
+		default:
+			if err := s.queueAgentDecommission(ctx, agent.ID, deleteData); err != nil {
+				return err
+			}
+			decommissionAgents = append(decommissionAgents, agent)
+		}
+	}
+	return s.waitForAgentDecommissions(ctx, decommissionAgents, progress)
 }
 
 // Workers and plugins are removed before their controllers. This preserves the

--- a/internal/center/decommission_test.go
+++ b/internal/center/decommission_test.go
@@ -22,7 +22,7 @@ func TestDecommissionApplicationsUsesNormalAgentLifecycle(t *testing.T) {
 			finished := make(chan error, 1)
 			messages := make(chan string, 10)
 			go func() {
-				finished <- store.DecommissionApplications(ctx, deleteData, func(message string) { messages <- message })
+				finished <- store.DecommissionApplications(ctx, deleteData, false, "", func(message string) { messages <- message })
 			}()
 
 			task := waitForDecommissionTask(t, store, node)
@@ -30,6 +30,13 @@ func TestDecommissionApplicationsUsesNormalAgentLifecycle(t *testing.T) {
 				t.Fatalf("unexpected decommission task: %#v", task)
 			}
 			if err := store.CompleteTask(ctx, node.ID, node.Credential, task.ID, task.Attempt, true, "", nil); err != nil {
+				t.Fatal(err)
+			}
+			hostTask := waitForDecommissionTask(t, store, node)
+			if hostTask.Kind != "agent.decommission" || hostTask.DeleteData != deleteData {
+				t.Fatalf("unexpected Agent host cleanup task: %#v", hostTask)
+			}
+			if err := store.CompleteTask(ctx, node.ID, node.Credential, hostTask.ID, hostTask.Attempt, true, "", nil); err != nil {
 				t.Fatal(err)
 			}
 			if err := <-finished; err != nil {
@@ -77,8 +84,8 @@ func TestDecommissionApplicationsFailsBeforeMutationWhenNodeIsOffline(t *testing
 	if _, err := store.db.ExecContext(context.Background(), `UPDATE agents SET last_seen_at = ? WHERE id = ?`, time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano), node.ID); err != nil {
 		t.Fatal(err)
 	}
-	err := store.DecommissionApplications(context.Background(), false, nil)
-	if err == nil || !strings.Contains(err.Error(), "is offline") {
+	err := store.DecommissionApplications(context.Background(), false, false, "", nil)
+	if err == nil || !strings.Contains(err.Error(), "offline") {
 		t.Fatalf("offline node did not block decommission: %v", err)
 	}
 	var uninstallTasks int
@@ -87,6 +94,34 @@ func TestDecommissionApplicationsFailsBeforeMutationWhenNodeIsOffline(t *testing
 	}
 	if uninstallTasks != 0 {
 		t.Fatalf("offline preflight queued %d uninstall tasks", uninstallTasks)
+	}
+}
+
+func TestForcedDecommissionReportsOfflineAgentWithoutClaimingCleanup(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	node := enrollOrchestrationNode(t, store, "offline-force-node", NodeCapabilities{Docker: true}, []networking.Candidate{{Address: "10.0.0.92", Interface: "eth0", Family: "ipv4", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.92", LANAddress: "10.0.0.92", EnabledKinds: []string{networking.KindLAN}})
+	installCPA(t, store, node, "10.0.0.92")
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE agents SET last_seen_at = ? WHERE id = ?`, time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano), node.ID); err != nil {
+		t.Fatal(err)
+	}
+	cleanups, err := store.OfflineAgentCleanups(context.Background(), "")
+	if err != nil || len(cleanups) != 1 || cleanups[0].Command != "sudo vastora agent uninstall --purge" || strings.Contains(cleanups[0].Command, node.Credential) {
+		t.Fatalf("unsafe offline cleanup report: %#v err=%v", cleanups, err)
+	}
+	var output strings.Builder
+	if err := store.DecommissionApplications(context.Background(), true, true, "", func(message string) {
+		output.WriteString(message)
+		output.WriteByte('\n')
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var state string
+	if err := store.db.QueryRowContext(context.Background(), `SELECT state FROM agent_decommissions WHERE agent_id = ?`, node.ID).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "abandoned" || !strings.Contains(output.String(), "Manual cleanup still required") {
+		t.Fatalf("offline cleanup was not marked incomplete: state=%s output=%q", state, output.String())
 	}
 }
 

--- a/internal/center/deployment_tasks.go
+++ b/internal/center/deployment_tasks.go
@@ -126,7 +126,17 @@ func (s *Store) ClaimNextTask(ctx context.Context, agentID, credential string) (
 				return nil, fmt.Errorf("center: read Tunnel desired state: %w", tunnelErr)
 			}
 			if tunnelTask == nil {
-				return nil, nil
+				decommissionTask, decommissionErr := s.claimAgentDecommission(ctx, tx, agentID)
+				if decommissionErr != nil {
+					return nil, decommissionErr
+				}
+				if decommissionTask == nil {
+					return nil, nil
+				}
+				if err := tx.Commit(); err != nil {
+					return nil, err
+				}
+				return decommissionTask, nil
 			}
 			if err := tx.Commit(); err != nil {
 				return nil, err
@@ -253,6 +263,12 @@ func (s *Store) completeTaskWithDisposition(ctx context.Context, agentID, creden
 	}
 	if strings.HasPrefix(taskID, "application-command-") {
 		return s.completeApplicationCommand(ctx, agentID, taskID, expectedAttempt, succeeded, taskError, rawResult, reconciliationRequired)
+	}
+	if taskID == agentDecommissionTaskID(agentID) {
+		if reconciliationRequired {
+			return errInvalidReconciliationDisposition
+		}
+		return s.completeAgentDecommission(ctx, agentID, expectedAttempt, succeeded, taskError)
 	}
 	if revision, gatewayTask := gatewayTaskRevision(taskID); gatewayTask {
 		if reconciliationRequired {

--- a/internal/center/headscale.go
+++ b/internal/center/headscale.go
@@ -24,7 +24,7 @@ import (
 const (
 	headscaleDNSFile               = "headscale-extra-records.json"
 	builtinHeadscaleRuntimeSetting = "builtin_headscale_runtime"
-	builtinHeadscaleRuntimeVersion = "private-center-dns-v5"
+	builtinHeadscaleRuntimeVersion = "self-hosted-derp-v6"
 )
 
 type HeadscaleInput struct {

--- a/internal/center/migrations/00022_agent_decommissions.sql
+++ b/internal/center/migrations/00022_agent_decommissions.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+CREATE TABLE agent_decommissions (
+    agent_id TEXT PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+    delete_data INTEGER NOT NULL CHECK(delete_data IN (0, 1)),
+    state TEXT NOT NULL CHECK(state IN ('pending', 'running', 'succeeded', 'failed', 'abandoned')),
+    attempt INTEGER NOT NULL DEFAULT 0,
+    lease_expires_at TEXT NOT NULL DEFAULT '',
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+PRAGMA user_version = 22;
+
+-- +goose Down
+SELECT RAISE(ABORT, 'Vastora Center database downgrades are not supported');

--- a/internal/center/migrations_test.go
+++ b/internal/center/migrations_test.go
@@ -706,6 +706,7 @@ func createLegacyVersion3Database(t *testing.T, directory string) {
 		`DROP TABLE three_x_ui_backups`,
 		`DROP TABLE three_x_ui_nodes`,
 		`DROP TABLE system_endpoint_aliases`,
+		`DROP TABLE agent_decommissions`,
 		`DROP INDEX applications_one_three_x_ui_master_idx`,
 		`ALTER TABLE agents DROP COLUMN operating_system`,
 		`ALTER TABLE agents DROP COLUMN architecture`,

--- a/internal/center/orchestration_test.go
+++ b/internal/center/orchestration_test.go
@@ -418,6 +418,7 @@ func openOrchestrationStore(t *testing.T) *Store {
 		store.Close()
 		t.Fatal(err)
 	}
+	store.agentDecommissionGrace = 0
 	return store
 }
 

--- a/internal/center/safety_regression_test.go
+++ b/internal/center/safety_regression_test.go
@@ -65,6 +65,40 @@ func TestCreateDeploymentRequiresConfirmedServiceAddress(t *testing.T) {
 	}
 }
 
+func TestHeartbeatFiltersVirtualInterfacesAndInvalidatesTheirOldProfile(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	node := enrollOrchestrationNode(t, store, "network-filter", NodeCapabilities{Docker: true}, []networking.Candidate{{
+		Address: "10.0.0.93", Interface: "eth0", Family: "ipv4", Kind: networking.KindLAN,
+	}}, networking.Profile{ServiceAddress: "10.0.0.93", LANAddress: "10.0.0.93", EnabledKinds: []string{networking.KindLAN}})
+
+	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, NodeHeartbeat{
+		Version: "test", Roles: []string{"worker"}, Capabilities: NodeCapabilities{Docker: true},
+		NetworkCandidates: []networking.Candidate{
+			{Address: "10.0.0.93", Interface: "docker0", Family: "ipv4", Kind: networking.KindLAN},
+			{Address: "10.77.0.6", Interface: "wg0", Family: "ipv4", Kind: networking.KindLAN},
+			{Address: "100.64.0.93", Interface: "tailscale0", Family: "ipv4", Kind: networking.KindLAN},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := networkCandidates(ctx, store.db, node.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 || candidates[0].Interface != "tailscale0" || candidates[0].Kind != networking.KindHeadscale {
+		t.Fatalf("Center retained virtual interfaces or trusted the reported kind: %#v", candidates)
+	}
+	profile, err := networkProfile(ctx, store.db, node.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile != nil {
+		t.Fatalf("profile that selected a filtered interface remained confirmed: %#v", profile)
+	}
+}
+
 func TestListDeploymentsRetainsOldActiveAndReconciliationTasksBeyondRecentLimit(t *testing.T) {
 	store := openOrchestrationStore(t)
 	defer store.Close()

--- a/internal/center/schema.go
+++ b/internal/center/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const centerSchemaVersion = 21
+const centerSchemaVersion = 22
 
 func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
@@ -149,6 +149,16 @@ func (s *Store) initializeCurrentSchema(ctx context.Context) error {
 			direct_public INTEGER NOT NULL DEFAULT 0,
 			confirmed_at TEXT NOT NULL,
 			candidate_observed_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE agent_decommissions (
+			agent_id TEXT PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+			delete_data INTEGER NOT NULL CHECK(delete_data IN (0, 1)),
+			state TEXT NOT NULL CHECK(state IN ('pending', 'running', 'succeeded', 'failed', 'abandoned')),
+			attempt INTEGER NOT NULL DEFAULT 0,
+			lease_expires_at TEXT NOT NULL DEFAULT '',
+			last_error TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
 		)`,
 		`CREATE TABLE applications (
 			id TEXT PRIMARY KEY,

--- a/internal/center/store.go
+++ b/internal/center/store.go
@@ -41,6 +41,7 @@ type Store struct {
 	publicationVerificationMu      sync.Mutex
 	publicationVerificationJobs    map[string]*publicationVerificationJob
 	publicationVerificationBackoff func(int) time.Duration
+	agentDecommissionGrace         time.Duration
 	verifyPublication              func(context.Context, string, int64) (PublicationView, error)
 	taskChanges                    changeNotifier
 	now                            func() time.Time
@@ -96,6 +97,7 @@ func Open(dataDir string, headscaleAllowedURLs ...string) (*Store, error) {
 		cloudflareOAuthSessions:        make(map[string]*cloudflareOAuthSession),
 		publicationVerificationJobs:    make(map[string]*publicationVerificationJob),
 		publicationVerificationBackoff: defaultPublicationVerificationBackoff,
+		agentDecommissionGrace:         45 * time.Second,
 		now:                            time.Now,
 		discoverNetworkCandidates:      networking.Discover,
 		lookupPublicRegion: countryISLookup(&http.Client{

--- a/internal/center/store_agent.go
+++ b/internal/center/store_agent.go
@@ -293,17 +293,30 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 	if !heartbeat.ApplicationEndpointsObserved && len(heartbeat.ApplicationEndpoints) != 0 {
 		return errors.New("center: Agent reported application endpoints without a complete observation")
 	}
+	reportedNetworkCandidates := len(heartbeat.NetworkCandidates)
 	seenAddresses := map[string]bool{}
+	filteredCandidates := make([]networking.Candidate, 0, len(heartbeat.NetworkCandidates))
 	for _, candidate := range heartbeat.NetworkCandidates {
 		ip := net.ParseIP(candidate.Address)
 		if ip == nil || candidate.Interface == "" || (candidate.Family != "ipv4" && candidate.Family != "ipv6") || (candidate.Kind != networking.KindLAN && candidate.Kind != networking.KindHeadscale && candidate.Kind != networking.KindPublic) {
 			return errors.New("center: Agent reported an invalid network candidate")
 		}
+		if candidate.Family == "ipv4" && ip.To4() == nil || candidate.Family == "ipv6" && ip.To4() != nil {
+			return errors.New("center: Agent reported a network address with the wrong family")
+		}
+		kind := networking.Classify(candidate.Interface, ip)
+		if kind == "" {
+			continue
+		}
+		candidate.Address = ip.String()
+		candidate.Kind = kind
 		if seenAddresses[ip.String()] {
 			return errors.New("center: Agent reported a duplicate network candidate")
 		}
 		seenAddresses[ip.String()] = true
+		filteredCandidates = append(filteredCandidates, candidate)
 	}
+	heartbeat.NetworkCandidates = filteredCandidates
 	rolesJSON, _ := json.Marshal(heartbeat.Roles)
 	capabilitiesJSON, _ := json.Marshal(heartbeat.Capabilities)
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -322,6 +335,11 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 	for _, candidate := range heartbeat.NetworkCandidates {
 		if _, err := tx.ExecContext(ctx, `INSERT INTO agent_network_candidates(agent_id, address, interface_name, family, kind, observed_at) VALUES(?, ?, ?, ?, ?, ?)`, id, net.ParseIP(candidate.Address).String(), candidate.Interface, candidate.Family, candidate.Kind, now.Format(time.RFC3339Nano)); err != nil {
 			return fmt.Errorf("center: record Agent network candidate: %w", err)
+		}
+	}
+	if reportedNetworkCandidates != 0 {
+		if err := invalidateUnusableNetworkProfile(ctx, tx, id); err != nil {
+			return err
 		}
 	}
 	if heartbeat.ApplicationEndpointsObserved {
@@ -353,6 +371,24 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 	}
 	if err := s.cleanupStoppedPublications(ctx, publicationCleanups); err != nil {
 		return fmt.Errorf("center: record publication cleanup state: %w", err)
+	}
+	return nil
+}
+
+func invalidateUnusableNetworkProfile(ctx context.Context, tx *sql.Tx, agentID string) error {
+	profile, err := networkProfile(ctx, tx, agentID)
+	if err != nil || profile == nil {
+		return err
+	}
+	candidates, err := networkCandidates(ctx, tx, agentID)
+	if err != nil {
+		return err
+	}
+	if err := networking.ValidateProfile(candidates, *profile); err == nil {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_network_profiles WHERE agent_id = ?`, agentID); err != nil {
+		return fmt.Errorf("center: invalidate stale Agent network profile: %w", err)
 	}
 	return nil
 }

--- a/internal/center/tasks.go
+++ b/internal/center/tasks.go
@@ -94,6 +94,7 @@ func (s *Store) recoverExpiredTasks(ctx context.Context, agentID string) error {
 		{`SELECT 'gateway-component-' || gateway_node_id || '-g' || generation, generation FROM gateway_components WHERE gateway_node_id = ? AND status = 'applying' AND lease_expires_at <> '' AND lease_expires_at <= ?`, "gateway.component.apply"},
 		{`SELECT 'gateway-route-' || gateway_node_id || '-r' || desired_revision, desired_revision FROM gateway_states WHERE gateway_node_id = ? AND status = 'applying' AND lease_expires_at <> '' AND lease_expires_at <= ?`, "gateway.routes.apply"},
 		{`SELECT 'tunnel-' || agent_id || '-r' || desired_revision, desired_revision FROM cloudflare_tunnels WHERE agent_id = ? AND status = 'applying' AND lease_expires_at <> '' AND lease_expires_at <= ?`, "tunnel.state.apply"},
+		{`SELECT 'agent-decommission-' || agent_id, 1 FROM agent_decommissions WHERE agent_id = ? AND state = 'running' AND lease_expires_at <> '' AND lease_expires_at <= ?`, "agent.decommission"},
 	}
 	for _, candidate := range queries {
 		rows, err := tx.QueryContext(ctx, candidate.query, agentID, now.Format(time.RFC3339Nano))
@@ -134,6 +135,9 @@ func (s *Store) recoverExpiredTasks(ctx context.Context, agentID string) error {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE cloudflare_tunnels SET status = 'failed', lease_expires_at = '', last_error = 'task lease expired; queued for retry', updated_at = ? WHERE agent_id = ? AND status = 'applying' AND lease_expires_at <> '' AND lease_expires_at <= ?`, now.Format(time.RFC3339Nano), agentID, now.Format(time.RFC3339Nano)); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_decommissions SET state = 'pending', lease_expires_at = '', last_error = 'task lease expired; queued for retry', updated_at = ? WHERE agent_id = ? AND state = 'running' AND lease_expires_at <> '' AND lease_expires_at <= ?`, now.Format(time.RFC3339Nano), agentID, now.Format(time.RFC3339Nano)); err != nil {
 		return err
 	}
 	for _, task := range expired {

--- a/internal/deployer/config.go
+++ b/internal/deployer/config.go
@@ -84,18 +84,20 @@ prefixes:
 
 derp:
   server:
-    enabled: false
+    enabled: true
     region_id: 999
     region_code: vastora
     region_name: Vastora Embedded DERP
+    verify_clients: true
     stun_listen_addr: "0.0.0.0:3478"
     private_key_path: /var/lib/headscale/derp_server_private.key
-    automatically_add_embedded_derp_region: false
-  urls:
-    - https://controlplane.tailscale.com/derpmap/default
+    automatically_add_embedded_derp_region: true
+  urls: []
   paths: []
-  auto_update_enabled: true
+  auto_update_enabled: false
   update_frequency: 24h
+
+disable_check_updates: true
 
 database:
   type: sqlite
@@ -126,6 +128,12 @@ unix_socket_permission: "0770"
 log:
   format: text
   level: info
+
+logtail:
+  enabled: false
+
+auto_update:
+  enabled: false
 
 node:
   expiry: 0

--- a/internal/deployer/config_test.go
+++ b/internal/deployer/config_test.go
@@ -47,7 +47,24 @@ func TestPortPreflightReportsAConflict(t *testing.T) {
 
 func TestGeneratedConfigurationUsesStandardHTTPSAndKeepsSecretsOut(t *testing.T) {
 	headscale := string(renderHeadscaleConfig("https://headscale.example.com"))
-	if !strings.Contains(headscale, "listen_addr: 0.0.0.0:8081") || !strings.Contains(headscale, "override_local_dns: true") || !strings.Contains(headscale, "      - 1.1.1.1") || strings.Contains(headscale, "tls_key_path") || strings.Contains(headscale, "extra_records:") {
+	for _, expected := range []string{
+		"listen_addr: 0.0.0.0:8081",
+		"override_local_dns: true",
+		"      - 1.1.1.1",
+		"    enabled: true",
+		"    verify_clients: true",
+		"    automatically_add_embedded_derp_region: true",
+		"  urls: []",
+		"  auto_update_enabled: false",
+		"disable_check_updates: true",
+		"logtail:\n  enabled: false",
+		"auto_update:\n  enabled: false",
+	} {
+		if !strings.Contains(headscale, expected) {
+			t.Fatalf("Headscale configuration is missing %q:\n%s", expected, headscale)
+		}
+	}
+	if strings.Contains(headscale, "controlplane.tailscale.com") || strings.Contains(headscale, "tls_key_path") || strings.Contains(headscale, "extra_records:") {
 		t.Fatalf("unexpected Headscale configuration:\n%s", headscale)
 	}
 	caddy := string(renderCaddyfile("https://center.example.com", "127.0.0.1:8080", "https://headscale.example.com", []string{"100.64.0.1"}, []string{"203.0.113.10"}, []deployapi.CenterEndpointAlias{{URL: "https://old-center.example.com"}}, nil))
@@ -102,5 +119,13 @@ func TestHeadscaleContainerIsolatedFromHostTailscale(t *testing.T) {
 	}
 	if _, exposed := config.ExposedPorts[port]; !exposed {
 		t.Fatalf("Headscale HTTP port is not exposed: %#v", config.ExposedPorts)
+	}
+	stunPort := dockernetwork.MustParsePort("3478/udp")
+	stunBindings := hostConfig.PortBindings[stunPort]
+	if len(stunBindings) != 1 || stunBindings[0].HostIP != netip.MustParseAddr("0.0.0.0") || stunBindings[0].HostPort != "3478" {
+		t.Fatalf("Headscale STUN bindings = %#v", stunBindings)
+	}
+	if _, exposed := config.ExposedPorts[stunPort]; !exposed {
+		t.Fatalf("Headscale STUN port is not exposed: %#v", config.ExposedPorts)
 	}
 }

--- a/internal/deployer/headscale.go
+++ b/internal/deployer/headscale.go
@@ -102,7 +102,10 @@ func (installer DockerHeadscaleInstaller) applyHeadscale(ctx context.Context, in
 		_ = pull.Close()
 	}
 	for _, name := range []string{settings.HeadscaleDataVolume, settings.HeadscaleConfigVolume, settings.CaddyDataVolume, settings.CaddyConfigVolume} {
-		if _, err := docker.VolumeCreate(ctx, client.VolumeCreateOptions{Name: name}); err != nil {
+		if _, err := docker.VolumeCreate(ctx, client.VolumeCreateOptions{Name: name, Labels: map[string]string{
+			gatewayruntime.ManagedLabel:   "true",
+			gatewayruntime.ComponentLabel: "center-headscale-storage",
+		}}); err != nil {
 			return "", "", fmt.Errorf("deployer: create volume %s: %w", name, err)
 		}
 	}
@@ -272,19 +275,21 @@ func (installer DockerHeadscaleInstaller) replaceHeadscale(ctx context.Context, 
 }
 
 func (installer DockerHeadscaleInstaller) headscaleContainerConfig() (*container.Config, *container.HostConfig) {
-	port := dockernetwork.MustParsePort("8081/tcp")
+	httpPort := dockernetwork.MustParsePort("8081/tcp")
+	stunPort := dockernetwork.MustParsePort("3478/udp")
 	return &container.Config{
 			Image:        installer.HeadscaleImage,
 			Cmd:          []string{"serve"},
 			Labels:       map[string]string{"io.vastora.managed": "true", "io.vastora.component": "center-headscale"},
-			ExposedPorts: dockernetwork.PortSet{port: struct{}{}},
+			ExposedPorts: dockernetwork.PortSet{httpPort: struct{}{}, stunPort: struct{}{}},
 		}, &container.HostConfig{
 			NetworkMode:    container.NetworkMode("bridge"),
 			RestartPolicy:  container.RestartPolicy{Name: container.RestartPolicyMode("unless-stopped")},
 			ReadonlyRootfs: true,
 			Tmpfs:          map[string]string{"/var/run/headscale": "rw,noexec,nosuid,size=16m,mode=1777"},
 			PortBindings: dockernetwork.PortMap{
-				port: []dockernetwork.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "8081"}},
+				httpPort: []dockernetwork.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "8081"}},
+				stunPort: []dockernetwork.PortBinding{{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "3478"}},
 			},
 			Mounts: []mount.Mount{
 				{Type: mount.TypeVolume, Source: installer.HeadscaleDataVolume, Target: "/var/lib/headscale"},

--- a/internal/networking/model.go
+++ b/internal/networking/model.go
@@ -115,10 +115,34 @@ func Classify(interfaceName string, ip net.IP) string {
 	if strings.Contains(name, "tailscale") {
 		return KindHeadscale
 	}
+	if IsVirtualInterface(name) {
+		return ""
+	}
 	if ip.IsPrivate() || inCGNAT(ip) {
 		return KindLAN
 	}
 	return KindPublic
+}
+
+// IsVirtualInterface reports interfaces that represent a container, VM, or
+// separate overlay network rather than a LAN that Vastora should offer as a
+// service address. Tailscale is handled before this check because it is a
+// first-class network kind in Vastora.
+func IsVirtualInterface(interfaceName string) bool {
+	name := strings.ToLower(strings.TrimSpace(interfaceName))
+	if name == "" {
+		return true
+	}
+	prefixes := []string{
+		"docker", "br-", "veth", "cni", "flannel", "cali", "kube-ipvs",
+		"podman", "lxcbr", "virbr", "wg", "tun", "tap", "utun", "zt", "nebula",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func ValidateProfile(candidates []Candidate, profile Profile) error {

--- a/internal/networking/model_test.go
+++ b/internal/networking/model_test.go
@@ -15,6 +15,11 @@ func TestClassifyUsesOnlyLocallyAssignedAddressProperties(t *testing.T) {
 		{name: "LAN", interfaceName: "eth0", address: "192.168.1.20", want: KindLAN},
 		{name: "CGNAT is not public", interfaceName: "eth0", address: "100.100.10.20", want: KindLAN},
 		{name: "Tailscale", interfaceName: "tailscale0", address: "100.64.0.20", want: KindHeadscale},
+		{name: "Docker bridge ignored", interfaceName: "docker0", address: "172.17.0.1", want: ""},
+		{name: "Docker network bridge ignored", interfaceName: "br-24fc51862a30", address: "172.18.0.1", want: ""},
+		{name: "container interface ignored", interfaceName: "veth1234", address: "172.19.0.1", want: ""},
+		{name: "WireGuard overlay ignored", interfaceName: "wg0", address: "10.77.0.6", want: ""},
+		{name: "ordinary LAN bridge retained", interfaceName: "br0", address: "10.0.0.1", want: KindLAN},
 		{name: "public IPv4", interfaceName: "eth0", address: "203.0.113.20", want: KindPublic},
 		{name: "loopback ignored", interfaceName: "lo0", address: "127.0.0.1", want: ""},
 	}

--- a/scripts/package-center-install.sh
+++ b/scripts/package-center-install.sh
@@ -66,9 +66,11 @@ temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-center-package.XXXXXX")"
 cleanup() { rm -rf "$temporary_dir"; }
 trap cleanup EXIT HUP INT TERM
 
+install -m 0755 "$project_dir/install.sh" "$temporary_dir/install.sh"
 install -m 0755 "$project_dir/deploy/center/setup.sh" "$temporary_dir/setup.sh"
 install -m 0755 "$project_dir/deploy/center/upgrade.sh" "$temporary_dir/upgrade.sh"
 install -m 0755 "$project_dir/deploy/center/uninstall.sh" "$temporary_dir/uninstall.sh"
+install -m 0755 "$project_dir/deploy/center/install-host-cli.sh" "$temporary_dir/install-host-cli.sh"
 install -m 0755 "$project_dir/deploy/center/install-update-service.sh" "$temporary_dir/install-update-service.sh"
 install -m 0755 "$project_dir/deploy/center/update-center.sh" "$temporary_dir/update-center.sh"
 install -m 0644 "$project_dir/deploy/center/compose.yaml" "$temporary_dir/compose.yaml"

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -4,6 +4,7 @@ set -eu
 script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-center-install-test.XXXXXX")"
+temporary_dir="$(CDPATH='' cd -- "$temporary_dir" && pwd -P)"
 cleanup() { rm -rf "$temporary_dir"; }
 trap cleanup EXIT HUP INT TERM
 
@@ -30,8 +31,10 @@ tar -xzf "$archive" -C "$temporary_dir"
 grep -Fqx 'VASTORA_VERSION=0.1.0-test' "$temporary_dir/release.env"
 grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$temporary_dir/release.env"
 test -x "$temporary_dir/setup.sh"
+test -x "$temporary_dir/install.sh"
 test -x "$temporary_dir/upgrade.sh"
 test -x "$temporary_dir/uninstall.sh"
+test -x "$temporary_dir/install-host-cli.sh"
 test -x "$temporary_dir/install-update-service.sh"
 test -x "$temporary_dir/update-center.sh"
 test -f "$temporary_dir/compose.yaml"
@@ -74,6 +77,10 @@ printf '%s\n' 'VASTORA_VERSION=old' 'VASTORA_CENTER_IMAGE=old-image' > "$existin
 printf '%s\n' 'VASTORA_CENTER_IMAGE=old-image' 'VASTORA_CENTER_BOOTSTRAP_PORT=19090' 'VASTORA_CUSTOM_VALUE=preserved' > "$existing/.env"
 cat > "$fake_bin/docker" <<'EOF'
 #!/bin/sh
+case "${1:-}" in
+  create) printf '%s\n' 'vastora-test-container'; exit 0 ;;
+  cp) cp "$FAKE_VASTORA_BINARY" "$3"; exit 0 ;;
+esac
 exit 0
 EOF
 cat > "$fake_bin/curl" <<'EOF'
@@ -84,15 +91,35 @@ cat > "$fake_bin/systemctl" <<'EOF'
 #!/bin/sh
 exit 0
 EOF
-chmod 0755 "$fake_bin/docker" "$fake_bin/curl" "$fake_bin/systemctl"
-VASTORA_SYSTEMD_UNIT_DIR="$temporary_dir/systemd" PATH="$fake_bin:$PATH" "$temporary_dir/upgrade.sh" --install-dir "$existing" >/dev/null
+cat > "$fake_bin/id" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "-u" ]; then printf '%s\n' 0; else exec /usr/bin/id "$@"; fi
+EOF
+chmod 0755 "$fake_bin/docker" "$fake_bin/curl" "$fake_bin/systemctl" "$fake_bin/id"
+cat > "$temporary_dir/fake-vastora" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  version) printf '%s\n' '0.1.0-test' ;;
+  help) printf '%s\n' 'Vastora control-plane tools' ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod 0755 "$temporary_dir/fake-vastora"
+VASTORA_SYSTEMD_UNIT_DIR="$temporary_dir/systemd" \
+VASTORA_HOST_CLI_PATH="$temporary_dir/host-bin/vastora" \
+FAKE_VASTORA_BINARY="$temporary_dir/fake-vastora" \
+PATH="$fake_bin:$PATH" \
+  "$temporary_dir/upgrade.sh" --install-dir "$existing" >/dev/null
 grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$existing/.env"
 grep -Fqx 'VASTORA_CENTER_BOOTSTRAP_PORT=19090' "$existing/.env"
 grep -Fqx 'VASTORA_CUSTOM_VALUE=preserved' "$existing/.env"
 grep -Fqx 'VASTORA_VERSION=0.1.0-test' "$existing/release.env"
 test -x "$existing/upgrade.sh"
 test -x "$existing/uninstall.sh"
+test -x "$existing/install-host-cli.sh"
 test -x "$existing/update-center.sh"
+test -x "$temporary_dir/host-bin/vastora"
+test -f "$existing/.host-cli-installed"
 test -f "$temporary_dir/systemd/vastora-center-update.service"
 test -f "$temporary_dir/systemd/vastora-center-update.path"
 grep -Fq "PathExists=$existing/.update-request" "$temporary_dir/systemd/vastora-center-update.path"

--- a/scripts/test-center-uninstall.sh
+++ b/scripts/test-center-uninstall.sh
@@ -67,8 +67,22 @@ printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
 case "${1:-}" in
   info) exit 0 ;;
   compose)
-    case "${FAKE_DOCKER_MODE:-}:$*" in
-      cleanup-fail:*exec*) exit 1 ;;
+    case "$*" in
+      *'center capabilities')
+        if [ "${FAKE_DOCKER_CAPABILITIES:-current}" = old ]; then exit 1; fi
+        printf '%s\n' 'decommission-applications' 'agent-host-decommission'
+        exit 0
+        ;;
+      *'center offline-agent-cleanups'*)
+        if [ -n "${FAKE_OFFLINE_AGENT_REPORT:-}" ]; then
+          printf '%s\n' "$FAKE_OFFLINE_AGENT_REPORT"
+        fi
+        exit 0
+        ;;
+      *'center decommission-applications'*)
+        if [ "${FAKE_DOCKER_MODE:-}" = cleanup-fail ]; then exit 1; fi
+        exit 0
+        ;;
     esac
     exit 0
     ;;
@@ -83,6 +97,7 @@ case "${1:-}" in
       rm) exit 0 ;;
     esac
     ;;
+  container) exit 1 ;;
   ps|inspect) exit 0 ;;
   rm) exit 0 ;;
 esac
@@ -218,6 +233,72 @@ PATH="$fake_bin:$PATH" \
   "$project_dir/deploy/center/uninstall.sh" --install-dir "$delete_data_install" >/dev/null
 test ! -e "$delete_data_install"
 grep -Fqx 'compose exec -T center /usr/local/bin/vastora center decommission-applications --data-dir /var/lib/vastora --delete-data' "$docker_log"
+
+offline_install="$temporary_dir/offline-center"
+create_install "$offline_install"
+printf '2\ny\nFORCE\n' > "$temporary_dir/offline.input"
+: > "$docker_log"
+: > "$systemctl_log"
+VASTORA_SYSTEMD_UNIT_DIR="$systemd_dir" \
+VASTORA_UNINSTALL_INPUT="$temporary_dir/offline.input" \
+VASTORA_UNINSTALL_OUTPUT="$temporary_dir/offline.output" \
+FAKE_OFFLINE_AGENT_REPORT='Wuhan node (node-offline)\n  sudo vastora agent uninstall --purge' \
+FAKE_DOCKER_LOG="$docker_log" \
+FAKE_SYSTEMCTL_LOG="$systemctl_log" \
+PATH="$fake_bin:$PATH" \
+  "$project_dir/deploy/center/uninstall.sh" --install-dir "$offline_install" >/dev/null
+test ! -e "$offline_install"
+grep -Fq 'sudo vastora agent uninstall --purge' "$temporary_dir/offline.output"
+grep -Fqx 'compose exec -T center /usr/local/bin/vastora center decommission-applications --data-dir /var/lib/vastora --force-offline' "$docker_log"
+
+legacy_bundle="$temporary_dir/legacy-bundle"
+install -d "$legacy_bundle"
+install -m 0755 "$project_dir/deploy/center/uninstall.sh" "$legacy_bundle/uninstall.sh"
+cat > "$legacy_bundle/upgrade.sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_UPGRADE_LOG"
+EOF
+chmod 0755 "$legacy_bundle/upgrade.sh"
+legacy_install="$temporary_dir/legacy-center"
+create_install "$legacy_install"
+printf '2\ny\n' > "$temporary_dir/legacy.input"
+: > "$docker_log"
+: > "$systemctl_log"
+: > "$temporary_dir/upgrade.log"
+VASTORA_SYSTEMD_UNIT_DIR="$systemd_dir" \
+VASTORA_UNINSTALL_INPUT="$temporary_dir/legacy.input" \
+VASTORA_UNINSTALL_OUTPUT="$temporary_dir/legacy.output" \
+FAKE_DOCKER_CAPABILITIES=old \
+FAKE_UPGRADE_LOG="$temporary_dir/upgrade.log" \
+FAKE_DOCKER_LOG="$docker_log" \
+FAKE_SYSTEMCTL_LOG="$systemctl_log" \
+PATH="$fake_bin:$PATH" \
+  "$legacy_bundle/uninstall.sh" --install-dir "$legacy_install" >/dev/null
+test ! -e "$legacy_install"
+grep -Fqx -- "--install-dir $legacy_install" "$temporary_dir/upgrade.log"
+grep -Fqx 'compose exec -T center /usr/local/bin/vastora center decommission-applications --data-dir /var/lib/vastora' "$docker_log"
+
+cli_install="$temporary_dir/cli-center"
+create_install "$cli_install"
+install -m 0644 /dev/null "$cli_install/.host-cli-installed"
+install -d "$temporary_dir/host-bin"
+cat > "$temporary_dir/host-bin/vastora" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = help ]; then printf '%s\n' 'Vastora control-plane tools'; fi
+EOF
+chmod 0755 "$temporary_dir/host-bin/vastora"
+printf '1\ny\n' > "$temporary_dir/cli.input"
+: > "$docker_log"
+: > "$systemctl_log"
+VASTORA_SYSTEMD_UNIT_DIR="$systemd_dir" \
+VASTORA_HOST_CLI_PATH="$temporary_dir/host-bin/vastora" \
+VASTORA_UNINSTALL_INPUT="$temporary_dir/cli.input" \
+VASTORA_UNINSTALL_OUTPUT="$temporary_dir/cli.output" \
+FAKE_DOCKER_LOG="$docker_log" \
+FAKE_SYSTEMCTL_LOG="$systemctl_log" \
+PATH="$fake_bin:$PATH" \
+  "$project_dir/deploy/center/uninstall.sh" --install-dir "$cli_install" >/dev/null
+test ! -e "$temporary_dir/host-bin/vastora"
 
 unsafe_install="$temporary_dir/unsafe-center"
 install -d "$unsafe_install"


### PR DESCRIPTION
## Summary

- filter Docker, container, WireGuard, and other virtual interfaces from LAN discovery while retaining real LAN bridges
- add guided Center/Agent decommissioning with online orchestration, explicit offline recovery, managed-data choices, and safe Tailscale ownership handling
- enable authenticated bundled DERP, remove the official Tailscale DERP map, and disable Headscale update, Logtail, and client auto-update integrations
- reconcile the Linux `TS_NO_LOGS_NO_SUPPORT=true` systemd override idempotently across install and upgrade, with retry after failed restart and exact uninstall cleanup
- document UDP 3478 and the macOS GUI-client limitation

## Validation

- `go test ./internal/...`
- targeted `go test ./cmd/vastora`
- `go vet ./...`
- Center install and uninstall script tests
- Linux amd64 and arm64 builds

Closes #159
Closes #160