### PR TITLE
fix: isolate Headscale clients from Tailscale services

### DIFF
--- a/cmd/vastora/agent_cmd.go
+++ b/cmd/vastora/agent_cmd.go
@@ -269,6 +269,23 @@ func runAgent(arguments []string) error {
 		defer store.Close()
 		fmt.Printf("Agent state initialized at %s\n", *dataDir)
 		return nil
+	case "prepare-tailscale":
+		flags := flag.NewFlagSet("agent prepare-tailscale", flag.ContinueOnError)
+		flags.SetOutput(os.Stderr)
+		controlURL := flags.String("control-url", "", "Headscale HTTPS control-plane URL")
+		configureOnly := flags.Bool("configure-only", false, "write isolation controls without starting Tailscale")
+		var controlAddresses stringListFlag
+		flags.Var(&controlAddresses, "control-address", "verified Headscale control-plane IP address")
+		if err := flags.Parse(arguments[1:]); err != nil {
+			return err
+		}
+		if err := requireLinuxRoot("agent prepare-tailscale"); err != nil {
+			return err
+		}
+		if *controlURL == "" {
+			return errors.New("--control-url is required")
+		}
+		return reconcileTailscaleIsolation(context.Background(), agent.TailscaleIsolationDesiredState{ControlURL: *controlURL, ControlAddresses: controlAddresses}, *configureOnly, defaultTailscaleIsolationEnvironment())
 	case "serve":
 		flags := flag.NewFlagSet("agent serve", flag.ContinueOnError)
 		flags.SetOutput(os.Stderr)
@@ -306,15 +323,6 @@ func runAgent(arguments []string) error {
 		if capabilities.Tunnel && !containsValue(roles, "worker") {
 			return errors.New("tunnel capability requires the worker role")
 		}
-		if runtime.GOOS == "linux" {
-			if _, lookupErr := exec.LookPath("tailscale"); lookupErr == nil {
-				if err := reconcileTailscalePrivacy("/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf", runHostCommand); err != nil {
-					return err
-				}
-			} else if !errors.Is(lookupErr, exec.ErrNotFound) {
-				return fmt.Errorf("locate Tailscale: %w", lookupErr)
-			}
-		}
 		store, err := agent.Open(*dataDir)
 		if err != nil {
 			return err
@@ -323,7 +331,20 @@ func runAgent(arguments []string) error {
 		if _, err := store.Connection(context.Background()); err != nil {
 			return err
 		}
-		client := agent.Client{Roles: roles, Capabilities: capabilities}
+		hostState, err := agent.ReadHostInstallState(*dataDir)
+		if err != nil {
+			return err
+		}
+		client := agent.Client{Roles: roles, Capabilities: capabilities, TailscaleEnrolled: hostState.TailscaleEnrolled}
+		if runtime.GOOS == "linux" {
+			if _, lookupErr := exec.LookPath("tailscale"); lookupErr == nil {
+				client.TailscaleIsolation = func(ctx context.Context, desired agent.TailscaleIsolationDesiredState) error {
+					return reconcileTailscaleIsolation(ctx, desired, false, defaultTailscaleIsolationEnvironment())
+				}
+			} else if !errors.Is(lookupErr, exec.ErrNotFound) {
+				return fmt.Errorf("locate Tailscale: %w", lookupErr)
+			}
+		}
 		executable, err := os.Executable()
 		if err != nil {
 			return fmt.Errorf("locate vastora executable: %w", err)

--- a/cmd/vastora/agent_uninstall.go
+++ b/cmd/vastora/agent_uninstall.go
@@ -50,6 +50,7 @@ func uninstallAgentHost(ctx context.Context, dataDir string, deleteData, runtime
 		binaryPaths:          []string{"/usr/local/bin/vastora", "/usr/local/bin/vastora.previous"},
 		tailscalePaths:       []string{"/etc/apt/sources.list.d/tailscale.list", "/usr/share/keyrings/tailscale-archive-keyring.gpg", "/var/lib/tailscale"},
 		tailscalePrivacyPath: "/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf",
+		tailscaleHostsPath:   "/etc/hosts",
 		purgeRuntime:         agent.PurgeManagedRuntime,
 		run:                  runHostCommand,
 	})
@@ -80,6 +81,7 @@ type agentUninstallEnvironment struct {
 	binaryPaths          []string
 	tailscalePaths       []string
 	tailscalePrivacyPath string
+	tailscaleHostsPath   string
 	purgeRuntime         func(context.Context, bool) error
 	run                  func(context.Context, string, ...string) ([]byte, error)
 }
@@ -135,6 +137,11 @@ func uninstallAgentHostWithEnvironment(ctx context.Context, deleteData, runtimeC
 			if output, err := environment.run(ctx, "systemctl", "daemon-reload"); err != nil {
 				return fmt.Errorf("reload systemd after removing the Tailscale privacy override: %s: %w", strings.TrimSpace(string(output)), err)
 			}
+		}
+	}
+	if environment.tailscaleHostsPath != "" {
+		if _, err := removeTailscaleControlHosts(environment.tailscaleHostsPath); err != nil {
+			return fmt.Errorf("remove Vastora Headscale resolver pin: %w", err)
 		}
 	}
 	unitOwned, err := stopAndRemoveAgentUnit(ctx, environment)

--- a/cmd/vastora/main_test.go
+++ b/cmd/vastora/main_test.go
@@ -90,6 +90,7 @@ func TestAgentUninstallRemovesOnlyVastoraManagedTailscale(t *testing.T) {
 				}
 			}
 			tailscalePrivacyPath := filepath.Join(root, "tailscaled.service.d", "90-vastora-privacy.conf")
+			tailscaleHostsPath := filepath.Join(root, "hosts")
 			if err := os.MkdirAll(filepath.Dir(tailscalePrivacyPath), 0o755); err != nil {
 				t.Fatal(err)
 			}
@@ -99,9 +100,12 @@ func TestAgentUninstallRemovesOnlyVastoraManagedTailscale(t *testing.T) {
 			if err := os.WriteFile(tailscalePrivacyAppliedPath(tailscalePrivacyPath), []byte(tailscalePrivacyAppliedMarker), 0o644); err != nil {
 				t.Fatal(err)
 			}
+			if err := os.WriteFile(tailscaleHostsPath, []byte("127.0.0.1 localhost\n"+tailscaleHostsBeginMarker+"\n203.0.113.10 headscale.example.com\n"+tailscaleHostsEndMarker+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
 			commands := []string{}
 			environment := agentUninstallEnvironment{
-				dataDir: dataDir, unitPath: unitPath, binaryPaths: []string{binaryPath}, tailscalePaths: tailscalePaths, tailscalePrivacyPath: tailscalePrivacyPath,
+				dataDir: dataDir, unitPath: unitPath, binaryPaths: []string{binaryPath}, tailscalePaths: tailscalePaths, tailscalePrivacyPath: tailscalePrivacyPath, tailscaleHostsPath: tailscaleHostsPath,
 				purgeRuntime: func(context.Context, bool) error { return nil },
 				run: func(_ context.Context, name string, arguments ...string) ([]byte, error) {
 					commands = append(commands, name+" "+strings.Join(arguments, " "))
@@ -134,6 +138,10 @@ func TestAgentUninstallRemovesOnlyVastoraManagedTailscale(t *testing.T) {
 				if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
 					t.Fatalf("Vastora Tailscale privacy state remained at %s: %v", path, err)
 				}
+			}
+			hosts, err := os.ReadFile(tailscaleHostsPath)
+			if err != nil || string(hosts) != "127.0.0.1 localhost\n" {
+				t.Fatalf("Vastora resolver pin was not removed cleanly: %q err=%v", hosts, err)
 			}
 		})
 	}
@@ -183,35 +191,69 @@ func TestSystemdAgentUnitUsesPersistentServiceConfiguration(t *testing.T) {
 	}
 }
 
-func TestTailscalePrivacyOverrideIsIdempotent(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "tailscaled.service.d", "90-vastora-privacy.conf")
+func TestTailscaleIsolationIsIdempotentAndPreservesIdentity(t *testing.T) {
+	root := t.TempDir()
+	overridePath := filepath.Join(root, "tailscaled.service.d", "90-vastora-privacy.conf")
+	hostsPath := filepath.Join(root, "hosts")
+	cachePath := filepath.Join(root, "tailscale", "derpmap.cached.json")
+	statePath := filepath.Join(root, "tailscale", "tailscaled.state")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hostsPath, []byte("127.0.0.1 localhost\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath, []byte(`{"Regions":{"2":{"Nodes":[{"HostName":"derp2.tailscale.com"}]}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, []byte("node-identity"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	commands := []string{}
 	run := func(_ context.Context, name string, arguments ...string) ([]byte, error) {
 		commands = append(commands, name+" "+strings.Join(arguments, " "))
 		return nil, nil
 	}
-	if err := reconcileTailscalePrivacy(path, run); err != nil {
+	desired := agent.TailscaleIsolationDesiredState{ControlURL: "https://headscale.example.com", ControlAddresses: []string{"203.0.113.10"}, ControlAliases: []string{"https://headscale.old.example.com"}}
+	environment := tailscaleIsolationEnvironment{overridePath: overridePath, hostsPath: hostsPath, derpCache: cachePath, run: run}
+	if err := reconcileTailscaleIsolation(context.Background(), desired, false, environment); err != nil {
 		t.Fatal(err)
 	}
-	if err := reconcileTailscalePrivacy(path, run); err != nil {
+	if err := reconcileTailscaleIsolation(context.Background(), desired, false, environment); err != nil {
 		t.Fatal(err)
 	}
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(overridePath)
 	if err != nil || string(raw) != tailscalePrivacyOverride {
 		t.Fatalf("Tailscale privacy override = %q, err=%v", raw, err)
 	}
-	applied, err := os.ReadFile(tailscalePrivacyAppliedPath(path))
+	applied, err := os.ReadFile(tailscalePrivacyAppliedPath(overridePath))
 	if err != nil || string(applied) != tailscalePrivacyAppliedMarker {
 		t.Fatalf("Tailscale privacy marker = %q, err=%v", applied, err)
 	}
+	if _, err := os.Stat(cachePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("official DERP cache was not removed: %v", err)
+	}
+	identity, err := os.ReadFile(statePath)
+	if err != nil || string(identity) != "node-identity" {
+		t.Fatalf("Tailscale identity was changed: %q err=%v", identity, err)
+	}
+	hosts, err := os.ReadFile(hostsPath)
+	if err != nil || !strings.Contains(string(hosts), "203.0.113.10 headscale.example.com headscale.old.example.com") {
+		t.Fatalf("Headscale resolver pin = %q, err=%v", hosts, err)
+	}
 	joined := strings.Join(commands, "\n")
 	if strings.Count(joined, "systemctl daemon-reload") != 1 || strings.Count(joined, "systemctl restart tailscaled.service") != 1 {
-		t.Fatalf("privacy reconciliation was not idempotent:\n%s", joined)
+		t.Fatalf("isolation reconciliation was not idempotent:\n%s", joined)
 	}
 }
 
-func TestTailscalePrivacyReconciliationRetriesAfterRestartFailure(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "tailscaled.service.d", "90-vastora-privacy.conf")
+func TestTailscaleIsolationRetriesAfterRestartFailure(t *testing.T) {
+	root := t.TempDir()
+	overridePath := filepath.Join(root, "tailscaled.service.d", "90-vastora-privacy.conf")
+	hostsPath := filepath.Join(root, "hosts")
+	if err := os.WriteFile(hostsPath, []byte("127.0.0.1 localhost\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	restarts := 0
 	run := func(_ context.Context, name string, arguments ...string) ([]byte, error) {
 		if name == "systemctl" && strings.Join(arguments, " ") == "restart tailscaled.service" {
@@ -222,17 +264,48 @@ func TestTailscalePrivacyReconciliationRetriesAfterRestartFailure(t *testing.T) 
 		}
 		return nil, nil
 	}
-	if err := reconcileTailscalePrivacy(path, run); err == nil {
+	desired := agent.TailscaleIsolationDesiredState{ControlURL: "https://headscale.example.com", ControlAddresses: []string{"203.0.113.10"}}
+	environment := tailscaleIsolationEnvironment{overridePath: overridePath, hostsPath: hostsPath, derpCache: filepath.Join(root, "missing-cache"), run: run}
+	if err := reconcileTailscaleIsolation(context.Background(), desired, false, environment); err == nil {
 		t.Fatal("failed Tailscale restart was accepted")
 	}
-	if _, err := os.Stat(tailscalePrivacyAppliedPath(path)); !errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(tailscalePrivacyAppliedPath(overridePath)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("failed reconciliation was marked applied: %v", err)
 	}
-	if err := reconcileTailscalePrivacy(path, run); err != nil {
+	if err := reconcileTailscaleIsolation(context.Background(), desired, false, environment); err != nil {
 		t.Fatal(err)
 	}
 	if restarts != 2 {
 		t.Fatalf("Tailscale restart attempts = %d, want 2", restarts)
+	}
+}
+
+func TestTailscaleIsolationFailsBeforeChangingHostStateWhenTLSVerificationFails(t *testing.T) {
+	root := t.TempDir()
+	hostsPath := filepath.Join(root, "hosts")
+	cachePath := filepath.Join(root, "derpmap.cached.json")
+	if err := os.WriteFile(hostsPath, []byte("127.0.0.1 localhost\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cache := []byte(`{"Regions":{"2":{"Nodes":[{"HostName":"derp2.tailscale.com"}]}}}`)
+	if err := os.WriteFile(cachePath, cache, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run := func(_ context.Context, name string, _ ...string) ([]byte, error) {
+		if name == "curl" {
+			return []byte("certificate mismatch"), errors.New("verification failed")
+		}
+		return nil, nil
+	}
+	environment := tailscaleIsolationEnvironment{overridePath: filepath.Join(root, "override.conf"), hostsPath: hostsPath, derpCache: cachePath, run: run}
+	err := reconcileTailscaleIsolation(context.Background(), agent.TailscaleIsolationDesiredState{ControlURL: "https://headscale.example.com", ControlAddresses: []string{"203.0.113.10"}}, false, environment)
+	if err == nil {
+		t.Fatal("unverified Headscale endpoint was accepted")
+	}
+	hosts, _ := os.ReadFile(hostsPath)
+	remainingCache, _ := os.ReadFile(cachePath)
+	if string(hosts) != "127.0.0.1 localhost\n" || !bytes.Equal(remainingCache, cache) {
+		t.Fatalf("host state changed before verification: hosts=%q cache=%q", hosts, remainingCache)
 	}
 }
 

--- a/cmd/vastora/tailscale_privacy.go
+++ b/cmd/vastora/tailscale_privacy.go
@@ -2,57 +2,356 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/petauron/vastora/internal/agent"
 )
 
 const (
 	tailscalePrivacyOverride      = "[Service]\nEnvironment=TS_NO_LOGS_NO_SUPPORT=true\n"
-	tailscalePrivacyAppliedMarker = "v1\n"
+	tailscalePrivacyAppliedMarker = "v2\n"
+	tailscaleHostsBeginMarker     = "# BEGIN VASTORA TAILSCALE CONTROL"
+	tailscaleHostsEndMarker       = "# END VASTORA TAILSCALE CONTROL"
 )
+
+type tailscaleIsolationEnvironment struct {
+	overridePath string
+	hostsPath    string
+	derpCache    string
+	run          func(context.Context, string, ...string) ([]byte, error)
+}
+
+func defaultTailscaleIsolationEnvironment() tailscaleIsolationEnvironment {
+	return tailscaleIsolationEnvironment{
+		overridePath: "/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf",
+		hostsPath:    "/etc/hosts",
+		derpCache:    "/var/lib/tailscale/derpmap.cached.json",
+		run:          runHostCommand,
+	}
+}
 
 func tailscalePrivacyAppliedPath(path string) string {
 	return path + ".applied"
 }
 
-func reconcileTailscalePrivacy(path string, run func(context.Context, string, ...string) ([]byte, error)) error {
-	appliedPath := tailscalePrivacyAppliedPath(path)
-	current, fileErr := os.ReadFile(path)
-	applied, markerErr := os.ReadFile(appliedPath)
-	if fileErr == nil && markerErr == nil && string(current) == tailscalePrivacyOverride && string(applied) == tailscalePrivacyAppliedMarker {
+// reconcileTailscaleIsolation applies host privacy controls before tailscaled
+// is started or restarted. It deliberately leaves tailscaled.state untouched
+// because that file contains the node identity and login state.
+func reconcileTailscaleIsolation(ctx context.Context, desired agent.TailscaleIsolationDesiredState, configureOnly bool, environment tailscaleIsolationEnvironment) error {
+	desired, err := validateTailscaleIsolationDesiredState(desired)
+	if err != nil {
+		return err
+	}
+	if environment.run == nil {
+		return errors.New("configure Tailscale isolation: host command runner is required")
+	}
+	current, err := tailscaleIsolationCurrent(environment, desired)
+	if err != nil {
+		return err
+	}
+	if current {
 		return nil
 	}
+	if err := verifyTailscaleControlEndpoint(ctx, desired, environment.run); err != nil {
+		return err
+	}
+	hostsChanged, err := reconcileTailscaleControlHosts(environment.hostsPath, desired)
+	if err != nil {
+		return err
+	}
+	overrideChanged, markerApplied, err := reconcileTailscalePrivacyFiles(environment.overridePath)
+	if err != nil {
+		return err
+	}
+	cacheRemoved, err := removeUntrustedDERPCache(environment.derpCache)
+	if err != nil {
+		return err
+	}
+
+	commandContext, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+	if overrideChanged || !markerApplied {
+		if output, runErr := environment.run(commandContext, "systemctl", "daemon-reload"); runErr != nil {
+			return fmt.Errorf("reload systemd for Tailscale isolation: %s: %w", strings.TrimSpace(string(output)), runErr)
+		}
+	}
+	if configureOnly {
+		return nil
+	}
+	if !overrideChanged && !hostsChanged && !cacheRemoved && markerApplied {
+		return nil
+	}
+
+	active := true
+	if _, activeErr := environment.run(commandContext, "systemctl", "is-active", "--quiet", "tailscaled.service"); activeErr != nil {
+		active = false
+	}
+	var output []byte
+	if active {
+		output, err = environment.run(commandContext, "systemctl", "restart", "tailscaled.service")
+	} else {
+		output, err = environment.run(commandContext, "systemctl", "enable", "--now", "tailscaled.service")
+	}
+	if err != nil {
+		return fmt.Errorf("start Tailscale with Vastora isolation: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	if err := writeAtomicHostFile(tailscalePrivacyAppliedPath(environment.overridePath), tailscalePrivacyAppliedMarker, 0o644); err != nil {
+		return fmt.Errorf("record applied Tailscale isolation state: %w", err)
+	}
+	return nil
+}
+
+func tailscaleIsolationCurrent(environment tailscaleIsolationEnvironment, desired agent.TailscaleIsolationDesiredState) (bool, error) {
+	override, err := os.ReadFile(environment.overridePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("inspect Tailscale privacy override: %w", err)
+	}
+	marker, markerErr := os.ReadFile(tailscalePrivacyAppliedPath(environment.overridePath))
+	if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
+		return false, fmt.Errorf("inspect Tailscale isolation marker: %w", markerErr)
+	}
+	hosts, err := os.ReadFile(environment.hostsPath)
+	if err != nil {
+		return false, fmt.Errorf("read host resolver configuration: %w", err)
+	}
+	expectedHosts, err := replaceTailscaleHostsSection(string(hosts), tailscaleControlHostnames(desired), desired.ControlAddresses)
+	if err != nil {
+		return false, err
+	}
+	untrustedCache, err := untrustedDERPCache(environment.derpCache)
+	if err != nil {
+		return false, err
+	}
+	return string(override) == tailscalePrivacyOverride && markerErr == nil && string(marker) == tailscalePrivacyAppliedMarker && expectedHosts == string(hosts) && !untrustedCache, nil
+}
+
+func validateTailscaleIsolationDesiredState(desired agent.TailscaleIsolationDesiredState) (agent.TailscaleIsolationDesiredState, error) {
+	var err error
+	desired.ControlURL, err = normalizeTailscaleControlURL(desired.ControlURL)
+	if err != nil {
+		return agent.TailscaleIsolationDesiredState{}, err
+	}
+	seenAliases := map[string]struct{}{desired.ControlURL: {}}
+	aliases := make([]string, 0, len(desired.ControlAliases))
+	for _, value := range desired.ControlAliases {
+		alias, aliasErr := normalizeTailscaleControlURL(value)
+		if aliasErr != nil {
+			return agent.TailscaleIsolationDesiredState{}, aliasErr
+		}
+		if _, exists := seenAliases[alias]; exists {
+			continue
+		}
+		seenAliases[alias] = struct{}{}
+		aliases = append(aliases, alias)
+	}
+	desired.ControlAliases = aliases
+	seen := make(map[string]struct{}, len(desired.ControlAddresses))
+	addresses := make([]string, 0, len(desired.ControlAddresses))
+	for _, value := range desired.ControlAddresses {
+		ip := net.ParseIP(strings.TrimSpace(value))
+		if ip == nil {
+			return agent.TailscaleIsolationDesiredState{}, errors.New("configure Tailscale isolation: control address is invalid")
+		}
+		address := ip.String()
+		if _, exists := seen[address]; exists {
+			continue
+		}
+		seen[address] = struct{}{}
+		addresses = append(addresses, address)
+	}
+	desired.ControlAddresses = addresses
+	return desired, nil
+}
+
+func normalizeTailscaleControlURL(value string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != "" && parsed.Path != "/" {
+		return "", errors.New("configure Tailscale isolation: Headscale control URL must be an HTTPS origin")
+	}
+	parsed.Path = ""
+	parsed.RawPath = ""
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}
+
+func tailscaleControlHostnames(desired agent.TailscaleIsolationDesiredState) []string {
+	values := append([]string{desired.ControlURL}, desired.ControlAliases...)
+	hostnames := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		parsed, _ := url.Parse(value)
+		hostname := parsed.Hostname()
+		if _, exists := seen[hostname]; !exists {
+			seen[hostname] = struct{}{}
+			hostnames = append(hostnames, hostname)
+		}
+	}
+	return hostnames
+}
+
+func verifyTailscaleControlEndpoint(ctx context.Context, desired agent.TailscaleIsolationDesiredState, run func(context.Context, string, ...string) ([]byte, error)) error {
+	parsed, _ := url.Parse(desired.ControlURL)
+	hostname := parsed.Hostname()
+	port := parsed.Port()
+	if port == "" {
+		port = "443"
+	}
+	addresses := desired.ControlAddresses
+	if len(addresses) == 0 {
+		addresses = []string{""}
+	}
+	var failures []string
+	for _, address := range addresses {
+		arguments := []string{"--proto", "=https", "--tlsv1.2", "--connect-timeout", "10", "--max-time", "20", "--silent", "--show-error", "--output", "/dev/null"}
+		if address != "" {
+			resolved := address
+			if strings.Contains(address, ":") {
+				resolved = "[" + address + "]"
+			}
+			arguments = append(arguments, "--resolve", hostname+":"+port+":"+resolved)
+		}
+		arguments = append(arguments, desired.ControlURL+"/")
+		verifyContext, cancel := context.WithTimeout(ctx, 25*time.Second)
+		output, err := run(verifyContext, "curl", arguments...)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		failures = append(failures, strings.TrimSpace(string(output)))
+	}
+	return fmt.Errorf("verify Headscale control endpoint before changing Tailscale: %s", strings.Join(failures, "; "))
+}
+
+func reconcileTailscaleControlHosts(path string, desired agent.TailscaleIsolationDesiredState) (bool, error) {
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read host resolver configuration: %w", err)
+	}
+	updated, err := replaceTailscaleHostsSection(string(current), tailscaleControlHostnames(desired), desired.ControlAddresses)
+	if err != nil {
+		return false, err
+	}
+	if updated == string(current) {
+		return false, nil
+	}
+	if err := writeAtomicHostFile(path, updated, 0o644); err != nil {
+		return false, fmt.Errorf("install Headscale control address pin: %w", err)
+	}
+	return true, nil
+}
+
+func replaceTailscaleHostsSection(current string, hostnames, addresses []string) (string, error) {
+	lines := strings.Split(strings.ReplaceAll(current, "\r\n", "\n"), "\n")
+	kept := make([]string, 0, len(lines)+len(addresses)+2)
+	inside := false
+	for _, line := range lines {
+		switch strings.TrimSpace(line) {
+		case tailscaleHostsBeginMarker:
+			if inside {
+				return "", errors.New("host resolver configuration contains nested Vastora markers")
+			}
+			inside = true
+		case tailscaleHostsEndMarker:
+			if !inside {
+				return "", errors.New("host resolver configuration contains an unmatched Vastora marker")
+			}
+			inside = false
+		default:
+			if !inside {
+				kept = append(kept, line)
+			}
+		}
+	}
+	if inside {
+		return "", errors.New("host resolver configuration contains an incomplete Vastora section")
+	}
+	for len(kept) > 0 && strings.TrimSpace(kept[len(kept)-1]) == "" {
+		kept = kept[:len(kept)-1]
+	}
+	if len(addresses) > 0 {
+		kept = append(kept, tailscaleHostsBeginMarker)
+		for _, address := range addresses {
+			kept = append(kept, address+" "+strings.Join(hostnames, " "))
+		}
+		kept = append(kept, tailscaleHostsEndMarker)
+	}
+	return strings.Join(kept, "\n") + "\n", nil
+}
+
+func reconcileTailscalePrivacyFiles(path string) (changed, applied bool, resultErr error) {
+	appliedPath := tailscalePrivacyAppliedPath(path)
+	current, fileErr := os.ReadFile(path)
+	marker, markerErr := os.ReadFile(appliedPath)
 	if fileErr != nil && !errors.Is(fileErr, os.ErrNotExist) {
-		return fmt.Errorf("inspect Tailscale privacy override: %w", fileErr)
+		return false, false, fmt.Errorf("inspect Tailscale privacy override: %w", fileErr)
 	}
 	if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
-		return fmt.Errorf("inspect Tailscale privacy reconciliation marker: %w", markerErr)
+		return false, false, fmt.Errorf("inspect Tailscale isolation marker: %w", markerErr)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create Tailscale systemd override directory: %w", err)
+		return false, false, fmt.Errorf("create Tailscale systemd override directory: %w", err)
 	}
 	if string(current) != tailscalePrivacyOverride {
 		if err := writeAtomicHostFile(path, tailscalePrivacyOverride, 0o644); err != nil {
-			return fmt.Errorf("install Tailscale privacy override: %w", err)
+			return false, false, fmt.Errorf("install Tailscale privacy override: %w", err)
 		}
+		changed = true
 	}
-	_ = os.Remove(appliedPath)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if output, err := run(ctx, "systemctl", "daemon-reload"); err != nil {
-		return fmt.Errorf("reload systemd for Tailscale privacy: %s: %w", strings.TrimSpace(string(output)), err)
+	return changed, markerErr == nil && string(marker) == tailscalePrivacyAppliedMarker, nil
+}
+
+func removeUntrustedDERPCache(path string) (bool, error) {
+	untrusted, err := untrustedDERPCache(path)
+	if err != nil || !untrusted {
+		return false, err
 	}
-	if output, err := run(ctx, "systemctl", "restart", "tailscaled.service"); err != nil {
-		return fmt.Errorf("restart Tailscale with log uploads disabled: %s: %w", strings.TrimSpace(string(output)), err)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("remove untrusted Tailscale DERP cache: %w", err)
 	}
-	if err := writeAtomicHostFile(appliedPath, tailscalePrivacyAppliedMarker, 0o644); err != nil {
-		return fmt.Errorf("record applied Tailscale privacy state: %w", err)
+	return true, nil
+}
+
+func untrustedDERPCache(path string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
 	}
-	return nil
+	if err != nil {
+		return false, fmt.Errorf("inspect cached Tailscale DERP map: %w", err)
+	}
+	lower := strings.ToLower(string(raw))
+	if json.Valid(raw) && !strings.Contains(lower, ".tailscale.com") {
+		return false, nil
+	}
+	return true, nil
+}
+
+func removeTailscaleControlHosts(path string) (bool, error) {
+	current, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	updated, err := replaceTailscaleHostsSection(string(current), nil, nil)
+	if err != nil {
+		return false, err
+	}
+	if updated == string(current) {
+		return false, nil
+	}
+	if err := writeAtomicHostFile(path, updated, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func writeAtomicHostFile(path, content string, mode os.FileMode) error {

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -55,8 +55,12 @@
   check, and keeps Headscale Logtail and client auto-update instructions
   disabled. Vastora-managed Linux clients run `tailscaled` with
   `TS_NO_LOGS_NO_SUPPORT=true`, so private-network operational logs are not
-  uploaded to Tailscale. Public application traffic and explicitly configured
-  public integrations remain outside this private-network isolation boundary.
+  uploaded to Tailscale. Before starting or restarting the daemon, Agent pins
+  the verified bundled Headscale address (including active domain aliases) in
+  a Vastora-owned resolver section and removes malformed or Tailscale-hosted
+  DERP cache data without touching `tailscaled.state` or node keys. Public
+  application traffic and explicitly configured public integrations remain
+  outside this private-network isolation boundary.
 - An external Headscale deployment is operator-controlled and must enforce an
   equivalent DERP and logging policy before it can satisfy the bundled
   deployment's private-network security boundary.

--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -33,6 +33,14 @@ type Client struct {
 	GatewayProvisioner GatewayProvisioner
 	TunnelProvisioner  TunnelProvisioner
 	Decommissioner     HostDecommissioner
+	TailscaleIsolation func(context.Context, TailscaleIsolationDesiredState) error
+	TailscaleEnrolled  bool
+}
+
+type TailscaleIsolationDesiredState struct {
+	ControlURL       string   `json:"controlUrl"`
+	ControlAddresses []string `json:"controlAddresses"`
+	ControlAliases   []string `json:"controlAliases,omitempty"`
 }
 
 type HostDecommissioner interface {
@@ -397,17 +405,24 @@ func (c Client) heartbeat(ctx context.Context, store *Store) (error, error) {
 		observeErr = fmt.Errorf("agent: observe 3x-ui: %w", observeErr)
 	}
 	var response struct {
-		CenterURL string `json:"centerUrl"`
+		CenterURL          string                          `json:"centerUrl"`
+		TailscaleIsolation *TailscaleIsolationDesiredState `json:"tailscaleIsolation,omitempty"`
 	}
 	err = c.post(ctx, connection.CenterURL+"/api/v1/agents/"+url.PathEscape(connection.AgentID)+"/heartbeat", map[string]any{
 		"version": Version, "appliedInstallations": len(states), "roles": c.Roles,
 		"capabilities": c.Capabilities, "networkCandidates": candidates, "applicationEndpoints": endpoints, "applicationEndpointsObserved": endpointsObserved, "gatewayHealthy": gatewayHealthy,
+		"tailscaleEnrolled": c.TailscaleEnrolled,
 	}, connection.Credential, &response)
 	if err != nil {
 		return observeErr, err
 	}
 	if err := c.applyDesiredCenterURL(ctx, store, connection, response.CenterURL); err != nil {
 		return observeErr, err
+	}
+	if response.TailscaleIsolation != nil && c.TailscaleIsolation != nil {
+		if err := c.TailscaleIsolation(ctx, *response.TailscaleIsolation); err != nil {
+			return observeErr, fmt.Errorf("agent: apply Tailscale isolation: %w", err)
+		}
 	}
 	return observeErr, nil
 }

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -365,6 +365,36 @@ func TestHeartbeatKeepsCurrentCenterWhenDesiredURLIsNotReady(t *testing.T) {
 	}
 }
 
+func TestHeartbeatAppliesCenterTailscaleIsolationState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/agents/agent-1/heartbeat" {
+			t.Fatalf("unexpected request path: %s", request.URL.Path)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"tailscaleIsolation":{"controlUrl":"https://headscale.example.com","controlAddresses":["203.0.113.10"]}}`))
+	}))
+	defer server.Close()
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.SaveConnection(context.Background(), Connection{AgentID: "agent-1", Name: "test", CenterURL: server.URL, Credential: "credential"}); err != nil {
+		t.Fatal(err)
+	}
+	var applied TailscaleIsolationDesiredState
+	client := Client{TailscaleIsolation: func(_ context.Context, state TailscaleIsolationDesiredState) error {
+		applied = state
+		return nil
+	}}
+	if _, err := client.heartbeat(context.Background(), store); err != nil {
+		t.Fatal(err)
+	}
+	if applied.ControlURL != "https://headscale.example.com" || len(applied.ControlAddresses) != 1 || applied.ControlAddresses[0] != "203.0.113.10" {
+		t.Fatalf("Tailscale isolation state was not applied: %#v", applied)
+	}
+}
+
 func TestTunnelDesiredStateRequiresFixedImageAndTokenWhileRunning(t *testing.T) {
 	valid := TunnelDesiredState{Revision: 2, Status: "running", Image: "docker.io/cloudflare/cloudflared:2026.7.2", Token: "token"}
 	if err := valid.Validate(); err != nil {

--- a/internal/center/agent_install.go
+++ b/internal/center/agent_install.go
@@ -172,10 +172,15 @@ func renderAgentInstallLoader(centerURL string) string {
 func renderAgentInstallScript(profile AgentEnrollmentInstallProfile, bootstrapURL string) string {
 	headscaleBootstrap := ":"
 	if profile.HeadscaleCommand != "" {
+		prepareArguments := "--control-url " + shellQuote(profile.HeadscaleURL)
+		for _, address := range profile.HeadscaleAddresses {
+			prepareArguments += " --control-address " + shellQuote(address)
+		}
 		headscaleBootstrap = `tailscale_version=@@TAILSCALE_VERSION@@
 tailscale_ownership=external
 if ! command -v tailscale >/dev/null 2>&1; then
-	 tailscale_ownership=managed
+  tailscale_ownership=managed
+  "$temporary" agent prepare-tailscale @@TAILSCALE_PREPARE_ARGUMENTS@@ --configure-only
   if ! command -v apt-get >/dev/null 2>&1; then
     echo "Vastora can install Tailscale automatically only on Ubuntu 24.04." >&2
     exit 1
@@ -196,47 +201,24 @@ if [ "$installed_tailscale_version" != "$tailscale_version" ]; then
   echo "Vastora requires Tailscale $tailscale_version; found $installed_tailscale_version." >&2
   exit 1
 fi
-privacy_override=/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf
-privacy_override_marker="$privacy_override.applied"
-privacy_override_changed=0
-install -d -m 0755 "$(dirname "$privacy_override")"
-privacy_override_temporary="$(mktemp "$(dirname "$privacy_override")/.90-vastora-privacy.XXXXXX")"
-printf '%s\n' '[Service]' 'Environment=TS_NO_LOGS_NO_SUPPORT=true' >"$privacy_override_temporary"
-chmod 0644 "$privacy_override_temporary"
-if ! cmp -s "$privacy_override_temporary" "$privacy_override" || [ ! -f "$privacy_override_marker" ] || [ "$(cat "$privacy_override_marker")" != v1 ]; then
-  mv "$privacy_override_temporary" "$privacy_override"
-  privacy_override_changed=1
-else
-  rm -f "$privacy_override_temporary"
-fi
-tailscaled_was_active=0
-if systemctl is-active --quiet tailscaled.service; then
-  tailscaled_was_active=1
-fi
-if [ "$privacy_override_changed" -eq 1 ]; then
-  systemctl daemon-reload
-fi
-systemctl enable --now tailscaled.service
-if [ "$privacy_override_changed" -eq 1 ] && [ "$tailscaled_was_active" -eq 1 ]; then
-  systemctl restart tailscaled.service
-fi
-if [ "$privacy_override_changed" -eq 1 ]; then
-  privacy_marker_temporary="$(mktemp "$(dirname "$privacy_override_marker")/.90-vastora-privacy-applied.XXXXXX")"
-  printf '%s\n' v1 >"$privacy_marker_temporary"
-  chmod 0644 "$privacy_marker_temporary"
-  mv "$privacy_marker_temporary" "$privacy_override_marker"
-fi
+"$temporary" agent prepare-tailscale @@TAILSCALE_PREPARE_ARGUMENTS@@
 echo "Joining the private network..."
 ` + strings.TrimPrefix(profile.HeadscaleCommand, "sudo ") + `
 install -d -m 0700 /var/lib/vastora/agent
-if [ ! -f /var/lib/vastora/agent/host-install.env ]; then
-  host_state_temporary="$(mktemp /var/lib/vastora/agent/.host-install.XXXXXX)"
-  printf '%s\n' 'HOST_STATE_VERSION=1' "TAILSCALE_OWNERSHIP=$tailscale_ownership" 'TAILSCALE_ENROLLED=1' >"$host_state_temporary"
-  chmod 0600 "$host_state_temporary"
-  mv "$host_state_temporary" /var/lib/vastora/agent/host-install.env
+if [ -f /var/lib/vastora/agent/host-install.env ]; then
+  while IFS='=' read -r host_state_key host_state_value; do
+    case "$host_state_key=$host_state_value" in
+      TAILSCALE_OWNERSHIP=managed) tailscale_ownership=managed ;;
+    esac
+  done </var/lib/vastora/agent/host-install.env
 fi
+host_state_temporary="$(mktemp /var/lib/vastora/agent/.host-install.XXXXXX)"
+printf '%s\n' 'HOST_STATE_VERSION=1' "TAILSCALE_OWNERSHIP=$tailscale_ownership" 'TAILSCALE_ENROLLED=1' >"$host_state_temporary"
+chmod 0600 "$host_state_temporary"
+mv "$host_state_temporary" /var/lib/vastora/agent/host-install.env
 `
 		headscaleBootstrap = strings.ReplaceAll(headscaleBootstrap, "@@TAILSCALE_VERSION@@", shellQuote(agentTailscaleVersion))
+		headscaleBootstrap = strings.ReplaceAll(headscaleBootstrap, "@@TAILSCALE_PREPARE_ARGUMENTS@@", prepareArguments)
 	} else {
 		headscaleBootstrap = `install -d -m 0700 /var/lib/vastora/agent
 if [ ! -f /var/lib/vastora/agent/host-install.env ]; then

--- a/internal/center/agent_install_test.go
+++ b/internal/center/agent_install_test.go
@@ -181,8 +181,10 @@ func TestAgentInstallScriptUsesTLSAuthenticatedBinaryDownload(t *testing.T) {
 
 func TestAgentInstallScriptInstallsTailscaleBeforeJoiningHeadscale(t *testing.T) {
 	script := renderAgentInstallScript(AgentEnrollmentInstallProfile{
-		CenterURL:        "https://center.example.com",
-		HeadscaleCommand: "sudo tailscale up --login-server 'https://headscale.example.com' --auth-key 'one-time-key' --reset",
+		CenterURL:          "https://center.example.com",
+		HeadscaleCommand:   "sudo tailscale up --login-server 'https://headscale.example.com' --auth-key 'one-time-key' --reset",
+		HeadscaleURL:       "https://headscale.example.com",
+		HeadscaleAddresses: []string{"203.0.113.10"},
 	}, "https://headscale.example.com")
 	for _, expected := range []string{
 		"tailscale_version='1.102.3'",
@@ -192,15 +194,8 @@ func TestAgentInstallScriptInstallsTailscaleBeforeJoiningHeadscale(t *testing.T)
 		"apt-get install -y \"tailscale=$tailscale_version\"",
 		"installed_tailscale_version=",
 		"Vastora requires Tailscale $tailscale_version",
-		"Environment=TS_NO_LOGS_NO_SUPPORT=true",
-		"/etc/systemd/system/tailscaled.service.d/90-vastora-privacy.conf",
-		"privacy_override_marker=\"$privacy_override.applied\"",
-		"cmp -s \"$privacy_override_temporary\" \"$privacy_override\"",
-		"systemctl is-active --quiet tailscaled.service",
-		"systemctl daemon-reload",
-		"systemctl enable --now tailscaled.service",
-		"systemctl restart tailscaled.service",
-		"printf '%s\\n' v1 >\"$privacy_marker_temporary\"",
+		"agent prepare-tailscale --control-url 'https://headscale.example.com' --control-address '203.0.113.10' --configure-only",
+		"agent prepare-tailscale --control-url 'https://headscale.example.com' --control-address '203.0.113.10'",
 		"Joining the private network...",
 		"tailscale up --login-server 'https://headscale.example.com' --auth-key 'one-time-key' --reset",
 		"TAILSCALE_OWNERSHIP=$tailscale_ownership",

--- a/internal/center/headscale.go
+++ b/internal/center/headscale.go
@@ -39,6 +39,12 @@ type HeadscaleJoin struct {
 	ExpiresAt time.Time `json:"expiresAt"`
 }
 
+type TailscaleIsolationDesiredState struct {
+	ControlURL       string   `json:"controlUrl"`
+	ControlAddresses []string `json:"controlAddresses"`
+	ControlAliases   []string `json:"controlAliases,omitempty"`
+}
+
 type headscaleClient struct {
 	baseURL string
 	apiKey  string
@@ -219,6 +225,51 @@ func (s *Store) headscale(ctx context.Context) (headscaleClient, error) {
 		}
 	}
 	return headscaleClient{baseURL: allowedEndpoint, apiKey: string(key), http: httpClient}, nil
+}
+
+func (s *Store) tailscaleIsolationDesiredState(ctx context.Context, agentID string) (*TailscaleIsolationDesiredState, error) {
+	var mode, endpoint string
+	if err := s.db.QueryRowContext(ctx, `SELECT mode, endpoint FROM network_integrations WHERE kind = 'headscale' AND status = 'configured'`).Scan(&mode, &endpoint); errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("center: read Tailscale isolation state: %w", err)
+	}
+	normalized, err := normalizeHeadscaleEndpoint(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("center: stored Headscale endpoint is invalid: %w", err)
+	}
+	state := &TailscaleIsolationDesiredState{ControlURL: normalized}
+	if mode != "builtin" {
+		return state, nil
+	}
+	aliases, err := readSystemEndpointAliases(ctx, s.db, "headscale")
+	if err != nil {
+		return nil, fmt.Errorf("center: read Headscale endpoint aliases: %w", err)
+	}
+	for _, alias := range aliases {
+		if alias.Endpoint != normalized {
+			state.ControlAliases = append(state.ControlAliases, alias.Endpoint)
+		}
+	}
+	binding, configured, err := s.setupGatewayBinding(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("center: read Headscale public binding: %w", err)
+	}
+	if !configured || net.ParseIP(binding.PublicAddress) == nil {
+		return nil, errors.New("center: built-in Headscale has no verified public address")
+	}
+	controlAddress := net.ParseIP(binding.PublicAddress).String()
+	if strings.TrimSpace(agentID) != "" && binding.BindAddress != binding.PublicAddress {
+		var local int
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_network_candidates WHERE agent_id = ? AND address = ?`, agentID, binding.BindAddress).Scan(&local); err != nil {
+			return nil, fmt.Errorf("center: inspect co-located Headscale Agent: %w", err)
+		}
+		if local > 0 {
+			controlAddress = net.ParseIP(binding.BindAddress).String()
+		}
+	}
+	state.ControlAddresses = []string{controlAddress}
+	return state, nil
 }
 
 func builtinHeadscaleHTTPClient(endpoint string, base *http.Client) (*http.Client, error) {

--- a/internal/center/network_integrations_test.go
+++ b/internal/center/network_integrations_test.go
@@ -163,8 +163,8 @@ func TestHeadscaleBootstrapDoesNotRequireAnEnrolledAgent(t *testing.T) {
 		t.Fatal("Headscale bootstrap key was stored in plaintext")
 	}
 	profile, err := store.AgentEnrollmentInstallProfile(context.Background(), enrollment.Token)
-	if err != nil || !strings.Contains(profile.HeadscaleCommand, "bootstrap-one-time-key") {
-		t.Fatalf("installer profile bootstrap = %q, err = %v", profile.HeadscaleCommand, err)
+	if err != nil || !strings.Contains(profile.HeadscaleCommand, "bootstrap-one-time-key") || profile.HeadscaleURL != server.URL || len(profile.HeadscaleAddresses) != 0 {
+		t.Fatalf("installer profile bootstrap = %#v, err = %v", profile, err)
 	}
 	if _, err := store.EnrollAgent(context.Background(), enrollment.Token, "test", "linux", "amd64"); err != nil {
 		t.Fatal(err)
@@ -172,6 +172,28 @@ func TestHeadscaleBootstrapDoesNotRequireAnEnrolledAgent(t *testing.T) {
 	var remaining int
 	if err := store.db.QueryRow(`SELECT COUNT(*) FROM secrets WHERE id = ?`, bootstrapSecretID).Scan(&remaining); err != nil || remaining != 0 {
 		t.Fatalf("consumed bootstrap secret count = %d, err = %v", remaining, err)
+	}
+}
+
+func TestBuiltinHeadscaleIsolationUsesVerifiedPublicBinding(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := store.db.Exec(`INSERT INTO network_integrations(kind, mode, endpoint, status, created_at, updated_at) VALUES('headscale', 'builtin', 'https://headscale.example.com', 'configured', ?, ?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO settings(key, value) VALUES(?, ?)`, setupGatewayBindingSetting, `{"publicAddress":"203.0.113.10","bindAddress":"10.0.0.10"}`); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.tailscaleIsolationDesiredState(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.ControlURL != "https://headscale.example.com" || len(state.ControlAddresses) != 1 || state.ControlAddresses[0] != "203.0.113.10" {
+		t.Fatalf("built-in Tailscale isolation state = %#v", state)
 	}
 }
 

--- a/internal/center/server_agent.go
+++ b/internal/center/server_agent.go
@@ -149,6 +149,7 @@ func (s *Server) handleAgentHeartbeat(writer http.ResponseWriter, request *http.
 		ApplicationEndpoints         []ApplicationEndpointObservation `json:"applicationEndpoints"`
 		ApplicationEndpointsObserved bool                             `json:"applicationEndpointsObserved"`
 		GatewayHealthy               bool                             `json:"gatewayHealthy"`
+		TailscaleEnrolled            bool                             `json:"tailscaleEnrolled"`
 	}
 	if err := decodeJSON(request, &input); err != nil {
 		writeError(writer, http.StatusBadRequest, err)
@@ -168,7 +169,15 @@ func (s *Server) handleAgentHeartbeat(writer http.ResponseWriter, request *http.
 		writeError(writer, http.StatusInternalServerError, err)
 		return
 	}
-	writeJSON(writer, http.StatusOK, map[string]any{"connected": true, "centerUrl": network.AgentConnectURL})
+	var isolation *TailscaleIsolationDesiredState
+	if input.TailscaleEnrolled {
+		isolation, err = s.store.tailscaleIsolationDesiredState(request.Context(), request.PathValue("id"))
+		if err != nil {
+			writeError(writer, http.StatusInternalServerError, err)
+			return
+		}
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"connected": true, "centerUrl": network.AgentConnectURL, "tailscaleIsolation": isolation})
 }
 
 func (s *Server) handleClaimTask(writer http.ResponseWriter, request *http.Request) {

--- a/internal/center/store_agent.go
+++ b/internal/center/store_agent.go
@@ -32,11 +32,13 @@ type AgentEnrollmentSpec struct {
 }
 
 type AgentEnrollmentInstallProfile struct {
-	Name             string
-	CenterURL        string
-	Roles            []string
-	Capabilities     NodeCapabilities
-	HeadscaleCommand string
+	Name               string
+	CenterURL          string
+	Roles              []string
+	Capabilities       NodeCapabilities
+	HeadscaleCommand   string
+	HeadscaleURL       string
+	HeadscaleAddresses []string
 }
 
 type AgentCredential struct {
@@ -173,6 +175,15 @@ func (s *Store) AgentEnrollmentInstallProfile(ctx context.Context, token string)
 			return AgentEnrollmentInstallProfile{}, err
 		}
 		profile.HeadscaleCommand = string(command)
+		isolation, err := s.tailscaleIsolationDesiredState(ctx, "")
+		if err != nil {
+			return AgentEnrollmentInstallProfile{}, err
+		}
+		if isolation == nil {
+			return AgentEnrollmentInstallProfile{}, errors.New("center: Headscale isolation state is unavailable")
+		}
+		profile.HeadscaleURL = isolation.ControlURL
+		profile.HeadscaleAddresses = append([]string(nil), isolation.ControlAddresses...)
 	}
 	return profile, nil
 }


### PR DESCRIPTION
## Summary

- apply host-level Tailscale isolation only to nodes enrolled by Vastora
- pin the verified bundled Headscale address and active aliases before tailscaled starts
- remove untrusted DERP cache without touching node identity or login state
- preserve managed Tailscale ownership across agent migrations and clean up only Vastora-owned resolver entries on uninstall

## Validation

- `go test ./cmd/vastora -run 'Test(TailscaleIsolation|AgentUninstall)'`\n- `go test ./internal/agent ./internal/center`\n- `go vet ./cmd/vastora ./internal/agent ./internal/center`\n- `git diff --check`\n\nNo deployed machine is updated by this PR.