### PR TITLE
ci: harden and optimize release delivery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
         update-types:
           - version-update:semver-patch
           - version-update:semver-minor
+    groups:
+      modernc:
+        patterns:
+          - "modernc.org/*"
+        update-types:
+          - patch
+          - minor
   - package-ecosystem: npm
     directory: "/web"
     schedule:
@@ -30,32 +37,9 @@ updates:
     ignore:
       - dependency-name: "@typescript/native"
     groups:
-      react:
+      web-dependencies:
         patterns:
-          - react
-          - react-dom
-          - "@types/react"
-          - "@types/react-dom"
-        update-types:
-          - patch
-          - minor
-      lint-toolchain:
-        patterns:
-          - eslint
-          - "@eslint/*"
-          - typescript
-          - typescript-eslint
-          - "@typescript/*"
-          - globals
-        update-types:
-          - patch
-          - minor
-      vite-toolchain:
-        patterns:
-          - vite
-          - vitest
-          - "@vitejs/*"
-          - "@rolldown/*"
+          - "*"
         update-types:
           - patch
           - minor
@@ -69,6 +53,13 @@ updates:
         update-types:
           - version-update:semver-patch
           - version-update:semver-minor
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - patch
+          - minor
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
   pull_request:
   schedule:
     - cron: "41 3 * * 1"
@@ -40,25 +38,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: scripts/classify-ci-changes.sh --git ci "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
-
-  warm-dependency-caches:
-    name: Warm dependency caches
-    if: github.event_name == 'push'
-    needs: changes
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26.6"
-      - run: go mod download
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24.19.0"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: cd web && npm ci --ignore-scripts
 
   go:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (needs.changes.outputs.go == 'true' || needs.changes.outputs.full == 'true'))

--- a/.github/workflows/dependency-cache.yml
+++ b/.github/workflows/dependency-cache.yml
@@ -1,0 +1,35 @@
+name: Dependency Cache
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - go.mod
+      - go.sum
+      - web/package-lock.json
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-cache-main
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    name: Warm dependency caches
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.6"
+      - run: go mod download
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.19.0"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: cd web && npm ci --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing draft release tag to retry (for example, v0.1.0-alpha.4)
+        description: Existing release tag to retry or stage in R2 (for example, v0.1.0-alpha.55)
         required: false
         type: string
   push:
@@ -37,7 +37,7 @@ jobs:
           target-branch: main
           skip-github-pull-request: true
 
-      - name: Resolve draft release retry
+      - name: Resolve release retry
         id: retry
         if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
         env:
@@ -53,15 +53,10 @@ jobs:
               jq -c --arg tag "$RELEASE_TAG" '[.[][] | select(.tag_name == $tag)] | first'
           )"
           if [ "$release_json" = 'null' ]; then
-            echo "draft release $RELEASE_TAG was not found" >&2
+            echo "release $RELEASE_TAG was not found" >&2
             exit 1
           fi
-          if [ "$(printf '%s' "$release_json" | jq -r '.draft')" != 'true' ]; then
-            echo "release $RELEASE_TAG is not an existing draft" >&2
-            exit 1
-          fi
-          release_target="$(printf '%s' "$release_json" | jq -er '.target_commitish')"
-          release_sha="$(gh api "/repos/$GITHUB_REPOSITORY/commits/$release_target" --jq '.sha')"
+          release_sha="$(gh api "/repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')"
           {
             echo 'release_created=true'
             echo "release_sha=$release_sha"
@@ -81,12 +76,30 @@ jobs:
       id-token: write
       packages: write
     env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      AWS_EC2_METADATA_DISABLED: "true"
+      CENTER_IMAGE: ghcr.io/petauron/vastora-center
       DOCKER_BUILD_RECORD_UPLOAD: "false"
+      R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}
+      R2_ENDPOINT: https://${{ vars.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
     steps:
       - name: Check out release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.release_sha }}
+
+      - name: Validate R2 release destination
+        run: |
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$R2_BUCKET_NAME"
+          test -n "${{ vars.CLOUDFLARE_ACCOUNT_ID }}"
+          aws --cli-connect-timeout 10 --cli-read-timeout 30 s3api head-bucket \
+            --bucket "$R2_BUCKET_NAME" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --no-cli-pager
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
@@ -105,12 +118,9 @@ jobs:
           context: .
           file: Dockerfile.center
           platforms: linux/amd64,linux/arm64
-          push: true
+          outputs: type=image,name=${{ env.CENTER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             VASTORA_VERSION=${{ needs.prepare.outputs.release_version }}
-          tags: |
-            ghcr.io/petauron/vastora-center:${{ needs.prepare.outputs.release_tag }}
-            ghcr.io/petauron/vastora-center:latest
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ needs.prepare.outputs.release_sha }}
@@ -119,6 +129,41 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
+
+      - name: Scan released Center image for x64 vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/amd64
+        with:
+          scan-type: image
+          image-ref: ${{ env.CENTER_IMAGE }}@${{ steps.image.outputs.digest }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Scan released Center image for ARM64 vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          scan-type: image
+          image-ref: ${{ env.CENTER_IMAGE }}@${{ steps.image.outputs.digest }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          skip-setup-trivy: true
+
+      - name: Publish verified Center image tags
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$CENTER_IMAGE:$RELEASE_TAG" \
+            --tag "$CENTER_IMAGE:latest" \
+            "$CENTER_IMAGE@$IMAGE_DIGEST"
 
       - name: Attest Center image
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -141,37 +186,46 @@ jobs:
           anonymous_config="$(mktemp -d)"
           DOCKER_CONFIG="$anonymous_config" scripts/assert-image-platforms.sh "$VASTORA_CENTER_IMAGE"
 
-      - name: Upload assets and publish release
+      - name: Stage immutable installer assets in R2
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+        run: scripts/publish-installer-r2.sh stage --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT"
+
+      - name: Publish GitHub release metadata
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
-        run: |
-          gh release upload "$RELEASE_TAG" \
-            install.sh \
-            dist/vastora-center-install.tar.gz \
-            dist/vastora-center-install.tar.gz.sha256 \
-            --clobber
-          gh release edit "$RELEASE_TAG" --draft=false
+        run: gh release edit "$RELEASE_TAG" --draft=false
+
+      - name: Atomically activate installer release in R2
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+        run: scripts/publish-installer-r2.sh activate --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT"
 
       - name: Verify public installer endpoint
         env:
           EXPECTED_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: |
           temporary_dir="$(mktemp -d)"
-          curl --connect-timeout 10 --max-time 30 --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 -fsSL \
-            https://vastora.petauron.com/install.sh \
-            -o "$temporary_dir/install.sh"
-          curl --connect-timeout 10 --max-time 30 --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 -fsSL \
-            https://vastora.petauron.com/vastora-center-install.tar.gz \
-            -o "$temporary_dir/vastora-center-install.tar.gz"
-          curl --connect-timeout 10 --max-time 30 --retry 5 --retry-all-errors --retry-delay 5 --retry-max-time 120 -fsSL \
-            https://vastora.petauron.com/vastora-center-install.tar.gz.sha256 \
-            -o "$temporary_dir/vastora-center-install.tar.gz.sha256"
-          sh -n "$temporary_dir/install.sh"
-          cd "$temporary_dir"
-          sha256sum --check vastora-center-install.tar.gz.sha256
-          actual_version="$(tar -xOzf vastora-center-install.tar.gz ./release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')"
-          test "$actual_version" = "$EXPECTED_VERSION"
+          verify_installer() {
+            rm -f "$temporary_dir/install.sh" "$temporary_dir/vastora-center-install.tar.gz" "$temporary_dir/vastora-center-install.tar.gz.sha256"
+            curl --connect-timeout 10 --max-time 30 -fsSL https://vastora.petauron.com/install.sh -o "$temporary_dir/install.sh" &&
+              curl --connect-timeout 10 --max-time 30 -fsSL https://vastora.petauron.com/vastora-center-install.tar.gz -o "$temporary_dir/vastora-center-install.tar.gz" &&
+              curl --connect-timeout 10 --max-time 30 -fsSL https://vastora.petauron.com/vastora-center-install.tar.gz.sha256 -o "$temporary_dir/vastora-center-install.tar.gz.sha256" &&
+              sh -n "$temporary_dir/install.sh" &&
+              (cd "$temporary_dir" && sha256sum --check vastora-center-install.tar.gz.sha256) &&
+              actual_version="$(tar -xOzf "$temporary_dir/vastora-center-install.tar.gz" ./release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')" &&
+              test "$actual_version" = "$EXPECTED_VERSION"
+          }
+          attempt=1
+          while [ "$attempt" -le 18 ]; do
+            if verify_installer; then exit 0; fi
+            echo "Installer edge cache has not selected $EXPECTED_VERSION yet (attempt $attempt/18)."
+            attempt=$((attempt + 1))
+            sleep 5
+          done
+          echo "Public installer did not converge to $EXPECTED_VERSION." >&2
+          exit 1
 
   release-pr:
     name: Prepare next release pull request

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ deployment-check:
 	sh -n deploy/center/upgrade.sh
 	sh -n deploy/center/uninstall.sh
 	sh -n scripts/package-center-install.sh
+	sh -n scripts/publish-installer-r2.sh
 	sh -n scripts/validate-release-metadata.sh
 	sh -n scripts/assert-image-platforms.sh
 	sh -n scripts/check-runtime-image-platforms.sh
@@ -38,17 +39,20 @@ deployment-check:
 	sh -n scripts/test-release-metadata.sh
 	sh -n scripts/test-release-workflow.sh
 	sh -n scripts/test-ci-workflows.sh
+	sh -n scripts/test-publish-installer-r2.sh
 	node scripts/test-installer-worker.mjs
 	./install.sh --help >/dev/null
 	deploy/center/setup.sh --help >/dev/null
 	deploy/center/upgrade.sh --help >/dev/null
 	deploy/center/uninstall.sh --help >/dev/null
 	scripts/package-center-install.sh --help >/dev/null
+	scripts/publish-installer-r2.sh --help >/dev/null
 	scripts/test-center-install.sh
 	scripts/test-center-uninstall.sh
 	scripts/test-release-metadata.sh
 	scripts/test-release-workflow.sh
 	scripts/test-ci-workflows.sh
+	scripts/test-publish-installer-r2.sh
 
 security-check:
 	gitleaks detect --no-git --redact --source .

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -97,11 +97,17 @@ disconnected from Vastora but its package and repository are preserved.
 ## Release packaging
 
 The public command becomes usable when a release publishes the immutable Center
-image and these three fixed-name assets:
+image and stages these three assets under a versioned prefix in the private
+installer R2 bucket:
 
 - `install.sh`
 - `vastora-center-install.tar.gz`
 - `vastora-center-install.tar.gz.sha256`
+
+After their digests are verified, the release workflow replaces the small
+`vastora/current.json` manifest in one operation. The Installer Worker reads
+that pointer and serves the selected version through `vastora.petauron.com`;
+GitHub Release attachments are not part of the installation path.
 
 Create them locally without uploading anything:
 

--- a/deploy/installer-worker/README.md
+++ b/deploy/installer-worker/README.md
@@ -1,13 +1,12 @@
-# Installer redirect Worker
+# Installer Worker
 
 `worker.js` is the source deployed as the `vastora-installer` Cloudflare Worker
-behind `vastora.petauron.com`. It selects the newest non-draft GitHub release
-named by the repository's `version.txt`, verifies that the installer, bundle,
-and checksum are all public, and then caches the selection for one minute. A
-seven-day last-known-good selection keeps installations working while a new
-release is being assembled or GitHub is temporarily unavailable. This avoids
-GitHub's anonymous API rate limit without coupling prereleases to the
-stable-only `releases/latest` endpoint.
+behind `vastora.petauron.com`. Bind the private `petauron-downloads` R2 bucket as
+`INSTALLER_ASSETS`. The release workflow uploads immutable, versioned installer
+objects, publishes the GitHub release metadata, and then atomically replaces
+`vastora/current.json`. The Worker validates that manifest, serves only its
+three fixed installer assets, and caches the selected version for one minute.
+The bucket remains private and GitHub Release is not a runtime download source.
 
 The Worker also relays the short-lived Cloudflare OAuth authorization code from
 the fixed public callback to the private Center that started the login. It never
@@ -31,5 +30,6 @@ only that public Web traffic can reach both required ports; it is not a claim
 that the host has unrestricted one-to-one NAT for every port or protocol.
 
 The Worker contains no credentials. Keep the deployed source identical to this
-file and verify all three public installer paths plus the OAuth callback after
-every release.
+file, preserve the `OAUTH_SESSIONS` Durable Object binding, and verify the
+`INSTALLER_ASSETS` R2 binding, all three public installer paths, and the OAuth
+callback after every deployment.

--- a/deploy/installer-worker/worker.js
+++ b/deploy/installer-worker/worker.js
@@ -1,14 +1,13 @@
 import { connect } from "cloudflare:sockets";
 
 const repository = "petauron/vastora";
-const releaseAssets = new Set([
-  "install.sh",
-  "vastora-center-install.tar.gz",
-  "vastora-center-install.tar.gz.sha256",
+const releaseAssets = new Map([
+  ["install.sh", "text/x-shellscript; charset=utf-8"],
+  ["vastora-center-install.tar.gz", "application/gzip"],
+  ["vastora-center-install.tar.gz.sha256", "text/plain; charset=utf-8"],
 ]);
 const currentCacheKey = new Request("https://vastora-installer.internal/current-release");
-const lastKnownCacheKey = new Request("https://vastora-installer.internal/last-known-release");
-const versionURL = `https://raw.githubusercontent.com/${repository}/main/version.txt`;
+const currentManifestKey = "vastora/current.json";
 const oauthCallbackPath = "/oauth/cloudflare/callback";
 const oauthSessionPrefix = "/oauth/cloudflare/sessions/";
 const publicAddressPath = "/network/public-address";
@@ -16,70 +15,54 @@ const verifyPublicEntryPath = "/network/verify-public-entry";
 const oauthSessionLifetimeMs = 10 * 60 * 1000;
 const oauthStatePattern = /^v1\.([A-Za-z0-9_-]{24,64})\.([A-Za-z0-9_-]{43})$/;
 
-function releaseAssetURL(tag, asset) {
-  return `https://github.com/${repository}/releases/download/${encodeURIComponent(tag)}/${asset}`;
+function validManifest(manifest) {
+  if (!manifest || manifest.schema !== 1 || !/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(manifest.version || "")) {
+    return false;
+  }
+  if (!manifest.assets || Object.keys(manifest.assets).length !== releaseAssets.size) return false;
+  const prefix = `vastora/releases/v${manifest.version}/`;
+  for (const asset of releaseAssets.keys()) {
+    const descriptor = manifest.assets[asset];
+    if (!descriptor || descriptor.key !== `${prefix}${asset}` || !/^[0-9a-f]{64}$/.test(descriptor.sha256 || "")) {
+      return false;
+    }
+  }
+  return true;
 }
 
-function cachedSelection(result, maxAge) {
-  return Response.json(result, {
-    headers: { "Cache-Control": `public, max-age=${maxAge}` },
-  });
-}
-
-async function requestedRelease() {
-  const versionResponse = await fetch(versionURL, {
-    headers: { "User-Agent": "vastora-installer-worker" },
-  });
-  if (!versionResponse.ok) {
-    throw new Error(`Version pointer returned ${versionResponse.status}`);
-  }
-
-  const version = (await versionResponse.text()).trim();
-  if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
-    throw new Error("Version pointer is invalid");
-  }
-
-  const tag = `v${version}`;
-  const assetResponses = await Promise.all(
-    [...releaseAssets].map((asset) =>
-      fetch(releaseAssetURL(tag, asset), {
-        method: "HEAD",
-        redirect: "manual",
-        headers: { "User-Agent": "vastora-installer-worker" },
-      }),
-    ),
-  );
-  if (!assetResponses.every((response) => response.ok || response.status === 302)) {
-    throw new Error("Requested release assets are incomplete");
-  }
-
-  return { tag };
-}
-
-async function selectedRelease(ctx) {
+async function selectedRelease(env, ctx) {
+  if (!env.INSTALLER_ASSETS) throw new Error("Installer R2 binding is unavailable");
   const cache = caches.default;
   const cached = await cache.match(currentCacheKey);
   if (cached) return cached.json();
+  const object = await env.INSTALLER_ASSETS.get(currentManifestKey);
+  if (!object) throw new Error("Installer release manifest is unavailable");
+  const manifest = await object.json();
+  if (!validManifest(manifest)) throw new Error("Installer release manifest is invalid");
+  ctx.waitUntil(cache.put(currentCacheKey, Response.json(manifest, {
+    headers: { "Cache-Control": "public, max-age=60" },
+  })));
+  return manifest;
+}
 
-  try {
-    const result = await requestedRelease();
-    ctx.waitUntil(
-      Promise.all([
-        cache.put(currentCacheKey, cachedSelection(result, 60)),
-        cache.put(lastKnownCacheKey, cachedSelection(result, 604800)),
-      ]),
-    );
-    return result;
-  } catch (error) {
-    const lastKnown = await cache.match(lastKnownCacheKey);
-    if (lastKnown) {
-      console.warn("Using the last known installer release", {
-        message: error instanceof Error ? error.message : String(error),
-      });
-      return lastKnown.json();
-    }
-    throw error;
+async function installerAssetResponse(request, env, ctx, asset) {
+  const manifest = await selectedRelease(env, ctx);
+  const descriptor = manifest.assets[asset];
+  const object = request.method === "HEAD"
+    ? await env.INSTALLER_ASSETS.head(descriptor.key)
+    : await env.INSTALLER_ASSETS.get(descriptor.key);
+  if (!object || object.customMetadata?.sha256 !== descriptor.sha256) {
+    throw new Error(`Installer release object is unavailable or mismatched: ${asset}`);
   }
+  const headers = new Headers(responseHeaders());
+  object.writeHttpMetadata(headers);
+  headers.set("Cache-Control", "public, max-age=60");
+  headers.set("Content-Length", String(object.size));
+  headers.set("Content-Type", releaseAssets.get(asset));
+  headers.set("ETag", object.httpEtag);
+  headers.set("X-Vastora-SHA256", descriptor.sha256);
+  headers.set("X-Vastora-Version", manifest.version);
+  return new Response(request.method === "HEAD" ? null : object.body, { headers });
 }
 
 function responseHeaders() {
@@ -281,14 +264,9 @@ export default {
     }
 
     try {
-      const release = await selectedRelease(ctx);
-      const location = releaseAssetURL(release.tag, asset);
-      return new Response(null, {
-        status: 302,
-        headers: { ...responseHeaders(), Location: location },
-      });
+      return await installerAssetResponse(request, env, ctx, asset);
     } catch (error) {
-      console.error("Unable to select installer release", error);
+      console.error("Unable to serve installer release", error);
       return new Response("No complete Vastora release is currently available.\n", {
         status: 503,
         headers: {

--- a/scripts/publish-installer-r2.sh
+++ b/scripts/publish-installer-r2.sh
@@ -1,0 +1,198 @@
+#!/bin/sh
+set -eu
+
+command_name="${1:-}"
+if [ "$#" -gt 0 ]; then shift; fi
+version=""
+bucket=""
+endpoint=""
+source_dir="dist"
+
+usage() {
+  cat <<'EOF'
+Usage: publish-installer-r2.sh stage --version VERSION --bucket BUCKET --endpoint HTTPS_URL [--source-dir DIR]
+       publish-installer-r2.sh activate --version VERSION --bucket BUCKET --endpoint HTTPS_URL
+
+Stages immutable Center installer assets in R2, or atomically activates an
+already staged version by replacing the current release manifest.
+EOF
+}
+
+if [ "$command_name" = "-h" ] || [ "$command_name" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version) version="${2:-}"; shift 2 ;;
+    --bucket) bucket="${2:-}"; shift 2 ;;
+    --endpoint) endpoint="${2:-}"; shift 2 ;;
+    --source-dir) source_dir="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$command_name" in
+  stage|activate) ;;
+  *) usage >&2; exit 2 ;;
+esac
+if [ -z "$version" ] || [ -z "$bucket" ] || [ -z "$endpoint" ]; then
+  echo "Version, bucket, and endpoint are required." >&2
+  usage >&2
+  exit 2
+fi
+if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "Version must be valid Vastora SemVer." >&2
+  exit 2
+fi
+case "$bucket" in
+  *[!a-z0-9.-]*|'') echo "R2 bucket name is invalid." >&2; exit 2 ;;
+esac
+case "$endpoint" in
+  https://*.r2.cloudflarestorage.com) ;;
+  *) echo "R2 endpoint must use the Cloudflare HTTPS endpoint." >&2; exit 2 ;;
+esac
+
+for required in awk aws cmp grep jq mktemp sha256sum; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    echo "Required command is not installed: $required" >&2
+    exit 1
+  fi
+done
+
+tag="v$version"
+prefix="vastora/releases/$tag"
+manifest_key="$prefix/manifest.json"
+current_key="vastora/current.json"
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-r2-release.XXXXXX")"
+cleanup() { rm -rf "$temporary_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+aws_r2() {
+  aws --cli-connect-timeout 10 --cli-read-timeout 60 s3api "$@" --endpoint-url "$endpoint" --no-cli-pager
+}
+
+retry() {
+  attempt=1
+  while ! "$@"; do
+    if [ "$attempt" -ge 3 ]; then
+      return 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+}
+
+remote_digest() {
+  key="$1"
+  aws_r2 head-object --bucket "$bucket" --key "$key" --query 'Metadata.sha256' --output text 2>/dev/null || true
+}
+
+upload_immutable() {
+  source="$1"
+  key="$2"
+  content_type="$3"
+  digest="$(sha256sum "$source" | awk 'NR == 1 {print tolower($1)}')"
+  head="$temporary_dir/head.json"
+  if aws_r2 head-object --bucket "$bucket" --key "$key" >"$head" 2>/dev/null; then
+    existing="$(jq -r '.Metadata.sha256 // empty' "$head")"
+    if [ "$existing" != "$digest" ]; then
+      echo "R2 release object already exists with different content: $key" >&2
+      return 1
+    fi
+  else
+    retry aws_r2 put-object \
+      --bucket "$bucket" \
+      --key "$key" \
+      --body "$source" \
+      --content-type "$content_type" \
+      --cache-control 'public, max-age=31536000, immutable' \
+      --metadata "sha256=$digest" >/dev/null
+  fi
+  if [ "$(remote_digest "$key")" != "$digest" ]; then
+    echo "R2 release object failed metadata verification: $key" >&2
+    return 1
+  fi
+  printf '%s' "$digest"
+}
+
+verify_manifest() {
+  manifest="$1"
+  jq -e \
+    --arg version "$version" \
+    --arg prefix "$prefix/" \
+    '(.schema == 1) and (.version == $version) and
+     ((.assets | keys | sort) == ["install.sh", "vastora-center-install.tar.gz", "vastora-center-install.tar.gz.sha256"]) and
+     (all(.assets[]; (.key | startswith($prefix)) and (.sha256 | test("^[0-9a-f]{64}$"))))' \
+    "$manifest" >/dev/null
+}
+
+verify_remote_assets() {
+  manifest="$1"
+  jq -r '.assets[] | [.key, .sha256] | @tsv' "$manifest" |
+    while IFS="$(printf '\t')" read -r key digest; do
+      if [ "$(remote_digest "$key")" != "$digest" ]; then
+        echo "R2 manifest references an unavailable or mismatched object: $key" >&2
+        exit 1
+      fi
+    done
+}
+
+if [ "$command_name" = "stage" ]; then
+  script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+  project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
+  installer="$project_dir/install.sh"
+  bundle="$source_dir/vastora-center-install.tar.gz"
+  checksum="$source_dir/vastora-center-install.tar.gz.sha256"
+  for required_file in "$installer" "$bundle" "$checksum"; do
+    if [ ! -f "$required_file" ]; then
+      echo "Release asset is missing: $required_file" >&2
+      exit 1
+    fi
+  done
+
+  installer_digest="$(upload_immutable "$installer" "$prefix/install.sh" 'text/x-shellscript; charset=utf-8')"
+  bundle_digest="$(upload_immutable "$bundle" "$prefix/vastora-center-install.tar.gz" 'application/gzip')"
+  checksum_digest="$(upload_immutable "$checksum" "$prefix/vastora-center-install.tar.gz.sha256" 'text/plain; charset=utf-8')"
+  manifest="$temporary_dir/manifest.json"
+  jq -n -S \
+    --arg version "$version" \
+    --arg installer_key "$prefix/install.sh" \
+    --arg installer_digest "$installer_digest" \
+    --arg bundle_key "$prefix/vastora-center-install.tar.gz" \
+    --arg bundle_digest "$bundle_digest" \
+    --arg checksum_key "$prefix/vastora-center-install.tar.gz.sha256" \
+    --arg checksum_digest "$checksum_digest" \
+    '{schema: 1, version: $version, assets: {
+      "install.sh": {key: $installer_key, sha256: $installer_digest},
+      "vastora-center-install.tar.gz": {key: $bundle_key, sha256: $bundle_digest},
+      "vastora-center-install.tar.gz.sha256": {key: $checksum_key, sha256: $checksum_digest}
+    }}' > "$manifest"
+  verify_manifest "$manifest"
+  upload_immutable "$manifest" "$manifest_key" 'application/json; charset=utf-8' >/dev/null
+  verify_remote_assets "$manifest"
+  echo "Staged Vastora $version installer assets in R2."
+  exit 0
+fi
+
+manifest="$temporary_dir/manifest.json"
+retry aws_r2 get-object --bucket "$bucket" --key "$manifest_key" "$manifest" >/dev/null
+verify_manifest "$manifest"
+verify_remote_assets "$manifest"
+manifest_digest="$(sha256sum "$manifest" | awk 'NR == 1 {print tolower($1)}')"
+retry aws_r2 put-object \
+  --bucket "$bucket" \
+  --key "$current_key" \
+  --body "$manifest" \
+  --content-type 'application/json; charset=utf-8' \
+  --cache-control 'no-cache' \
+  --metadata "sha256=$manifest_digest,version=$version" >/dev/null
+activated="$temporary_dir/current.json"
+retry aws_r2 get-object --bucket "$bucket" --key "$current_key" "$activated" >/dev/null
+if ! cmp -s "$manifest" "$activated"; then
+  echo "R2 current release pointer verification failed." >&2
+  exit 1
+fi
+echo "Activated Vastora $version installer release in R2."

--- a/scripts/test-ci-workflows.sh
+++ b/scripts/test-ci-workflows.sh
@@ -5,6 +5,7 @@ script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 ci_workflow="$project_dir/.github/workflows/ci.yml"
 codeql_workflow="$project_dir/.github/workflows/codeql.yml"
+cache_workflow="$project_dir/.github/workflows/dependency-cache.yml"
 classifier="$project_dir/scripts/classify-ci-changes.sh"
 
 require_line() {
@@ -21,7 +22,10 @@ require_line "$ci_workflow" '    name: Release metadata'
 require_line "$ci_workflow" '        run: scripts/validate-release-metadata.sh "$BASE_SHA"'
 require_line "$ci_workflow" '        run: scripts/classify-ci-changes.sh --git ci "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"'
 require_line "$codeql_workflow" '        run: scripts/classify-ci-changes.sh --git codeql "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"'
-require_line "$ci_workflow" '    name: Warm dependency caches'
+require_line "$cache_workflow" '    name: Warm dependency caches'
+require_line "$cache_workflow" '      - go.mod'
+require_line "$cache_workflow" '      - go.sum'
+require_line "$cache_workflow" '      - web/package-lock.json'
 require_line "$ci_workflow" '      DOCKER_BUILD_RECORD_UPLOAD: "false"'
 require_line "$ci_workflow" '        run: scripts/check-runtime-image-platforms.sh'
 require_line "$ci_workflow" '        run: go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --redact --verbose .'
@@ -56,7 +60,11 @@ if grep -Fq 'runtime-image-platforms:' "$ci_workflow"; then
   echo 'Runtime image validation should share the deployment runner.' >&2
   exit 1
 fi
-for workflow in "$ci_workflow" "$codeql_workflow"; do
+if grep -Eq '^  push:' "$ci_workflow"; then
+  echo 'Main-branch dependency cache warming must use the path-filtered cache workflow.' >&2
+  exit 1
+fi
+for workflow in "$ci_workflow" "$codeql_workflow" "$cache_workflow"; do
   if ! grep -Fq 'timeout-minutes:' "$workflow"; then
     echo "$workflow has no job timeouts." >&2
     exit 1

--- a/scripts/test-installer-worker.mjs
+++ b/scripts/test-installer-worker.mjs
@@ -84,46 +84,92 @@ function oauthEnvironment() {
   };
 }
 
-{
-  const storage = cacheStorage();
-  globalThis.caches = { default: storage.cache };
-  const fetched = [];
-  globalThis.fetch = async (url) => {
-    fetched.push(String(url));
-    if (new URL(url).hostname === "raw.githubusercontent.com") {
-      return new Response("0.1.0-alpha.4\n");
-    }
-    return new Response(null, { status: 302 });
+const installerManifest = {
+  schema: 1,
+  version: "0.1.0-alpha.4",
+  assets: {
+    "install.sh": {
+      key: "vastora/releases/v0.1.0-alpha.4/install.sh",
+      sha256: "a".repeat(64),
+    },
+    "vastora-center-install.tar.gz": {
+      key: "vastora/releases/v0.1.0-alpha.4/vastora-center-install.tar.gz",
+      sha256: "b".repeat(64),
+    },
+    "vastora-center-install.tar.gz.sha256": {
+      key: "vastora/releases/v0.1.0-alpha.4/vastora-center-install.tar.gz.sha256",
+      sha256: "c".repeat(64),
+    },
+  },
+};
+
+function installerEnvironment({ mismatchAsset = "", manifest = installerManifest } = {}) {
+  const objects = new Map([
+    ["vastora/current.json", { body: JSON.stringify(manifest), sha256: "d".repeat(64), contentType: "application/json" }],
+    [installerManifest.assets["install.sh"].key, { body: "#!/bin/sh\n", sha256: installerManifest.assets["install.sh"].sha256, contentType: "text/x-shellscript" }],
+    [installerManifest.assets["vastora-center-install.tar.gz"].key, { body: "archive", sha256: installerManifest.assets["vastora-center-install.tar.gz"].sha256, contentType: "application/gzip" }],
+    [installerManifest.assets["vastora-center-install.tar.gz.sha256"].key, { body: "checksum", sha256: installerManifest.assets["vastora-center-install.tar.gz.sha256"].sha256, contentType: "text/plain" }],
+  ]);
+  const reads = [];
+  function object(key, includeBody) {
+    const stored = objects.get(key);
+    if (!stored) return null;
+    const bytes = new TextEncoder().encode(stored.body);
+    const sha256 = key.endsWith(`/${mismatchAsset}`) ? "f".repeat(64) : stored.sha256;
+    return {
+      ...(includeBody ? { body: bytes } : {}),
+      customMetadata: { sha256 },
+      httpEtag: `"${sha256.slice(0, 16)}"`,
+      size: bytes.byteLength,
+      async json() { return JSON.parse(stored.body); },
+      writeHttpMetadata(headers) { headers.set("Content-Type", stored.contentType); },
+    };
+  }
+  return {
+    INSTALLER_ASSETS: {
+      async get(key) { reads.push(["get", key]); return object(key, true); },
+      async head(key) { reads.push(["head", key]); return object(key, false); },
+    },
+    reads,
   };
-
-  const execution = executionContext();
-  const response = await worker.fetch(request(), {}, execution.context);
-  await execution.flush();
-  assert.equal(response.status, 302);
-  assert.equal(
-    response.headers.get("location"),
-    "https://github.com/petauron/vastora/releases/download/v0.1.0-alpha.4/install.sh",
-  );
-  assert.equal(fetched.length, 4);
-
-  const cachedResponse = await worker.fetch(request("/vastora-center-install.tar.gz"), {}, executionContext().context);
-  assert.equal(cachedResponse.status, 302);
-  assert.equal(fetched.length, 4);
-
-  storage.entries.delete("https://vastora-installer.internal/current-release");
-  globalThis.fetch = async () => new Response(null, { status: 503 });
-  const fallback = await worker.fetch(request(), {}, executionContext().context);
-  assert.equal(fallback.status, 302);
 }
 
 {
   const storage = cacheStorage();
   globalThis.caches = { default: storage.cache };
-  globalThis.fetch = async () => new Response(null, { status: 503 });
+  const env = installerEnvironment();
+  const execution = executionContext();
+  const response = await worker.fetch(request(), env, execution.context);
+  await execution.flush();
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "#!/bin/sh\n");
+  assert.equal(response.headers.get("x-vastora-version"), "0.1.0-alpha.4");
+  assert.equal(response.headers.get("x-vastora-sha256"), "a".repeat(64));
+
+  const cachedResponse = await worker.fetch(request("/vastora-center-install.tar.gz"), env, executionContext().context);
+  assert.equal(cachedResponse.status, 200);
+  assert.equal(env.reads.filter(([, key]) => key === "vastora/current.json").length, 1);
+
+  const head = await worker.fetch(request("/install.sh", "HEAD"), env, executionContext().context);
+  assert.equal(head.status, 200);
+  assert.equal(await head.text(), "");
+  assert.ok(env.reads.some(([method, key]) => method === "head" && key.endsWith("/install.sh")));
+}
+
+{
+  const storage = cacheStorage();
+  globalThis.caches = { default: storage.cache };
   const response = await worker.fetch(request(), {}, executionContext().context);
   assert.equal(response.status, 503);
   assert.equal(response.headers.get("cache-control"), "no-store");
   assert.equal(response.headers.get("cloudflare-cdn-cache-control"), "no-store");
+}
+
+{
+  const storage = cacheStorage();
+  globalThis.caches = { default: storage.cache };
+  const response = await worker.fetch(request(), installerEnvironment({ mismatchAsset: "install.sh" }), executionContext().context);
+  assert.equal(response.status, 503);
 }
 
 {
@@ -265,7 +311,7 @@ function oauthEnvironment() {
   assert.equal(response.headers.get("cache-control"), "no-store");
 }
 
-assert.deepEqual(workerLogs.map(([level]) => level), ["warn", "error"]);
+assert.deepEqual(workerLogs.map(([level]) => level), ["error", "error"]);
 console.warn = originalWarn;
 console.error = originalError;
 console.log("installer worker tests: OK");

--- a/scripts/test-publish-installer-r2.sh
+++ b/scripts/test-publish-installer-r2.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-r2-test.XXXXXX")"
+cleanup() { rm -rf "$temporary_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+fake_bin="$temporary_dir/bin"
+fake_r2="$temporary_dir/r2"
+source_dir="$temporary_dir/dist"
+mkdir -p "$fake_bin" "$fake_r2/objects" "$source_dir"
+printf 'bundle\n' > "$source_dir/vastora-center-install.tar.gz"
+(cd "$source_dir" && sha256sum vastora-center-install.tar.gz > vastora-center-install.tar.gz.sha256)
+
+cat > "$fake_bin/aws" <<'EOF'
+#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ] && [ "$1" != "s3api" ]; do shift; done
+[ "${1:-}" = "s3api" ] || exit 2
+shift
+operation="${1:-}"
+shift
+key=""
+body=""
+metadata=""
+query=""
+destination=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --key) key="$2"; shift 2 ;;
+    --body) body="$2"; shift 2 ;;
+    --metadata) metadata="$2"; shift 2 ;;
+    --query) query="$2"; shift 2 ;;
+    --bucket|--content-type|--cache-control|--endpoint-url|--output) shift 2 ;;
+    --no-cli-pager) shift ;;
+    *) destination="$1"; shift ;;
+  esac
+done
+object="$FAKE_R2_DIR/objects/$key"
+meta="$FAKE_R2_DIR/metadata/$key"
+case "$operation" in
+  head-object)
+    [ -f "$object" ] || exit 254
+    digest="$(cat "$meta")"
+    if [ -n "$query" ]; then
+      printf '%s\n' "$digest"
+    else
+      printf '{"Metadata":{"sha256":"%s"}}\n' "$digest"
+    fi
+    ;;
+  put-object)
+    mkdir -p "$(dirname "$object")" "$(dirname "$meta")"
+    cp "$body" "$object"
+    digest="$(printf '%s' "$metadata" | sed -n 's/^sha256=\([^,]*\).*$/\1/p')"
+    printf '%s' "$digest" > "$meta"
+    printf '{}\n'
+    ;;
+  get-object)
+    [ -f "$object" ] || exit 254
+    cp "$object" "$destination"
+    printf '{}\n'
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod 0755 "$fake_bin/aws"
+
+export FAKE_R2_DIR="$fake_r2"
+export PATH="$fake_bin:$PATH"
+endpoint="https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com"
+bucket="petauron-downloads"
+version="0.1.0-test"
+
+"$script_dir/publish-installer-r2.sh" stage --version "$version" --bucket "$bucket" --endpoint "$endpoint" --source-dir "$source_dir" >/dev/null
+manifest="$fake_r2/objects/vastora/releases/v$version/manifest.json"
+test -f "$manifest"
+jq -e --arg version "$version" '.schema == 1 and .version == $version and (.assets | length) == 3' "$manifest" >/dev/null
+
+"$script_dir/publish-installer-r2.sh" activate --version "$version" --bucket "$bucket" --endpoint "$endpoint" >/dev/null
+cmp -s "$manifest" "$fake_r2/objects/vastora/current.json"
+
+printf 'changed bundle\n' > "$source_dir/vastora-center-install.tar.gz"
+if "$script_dir/publish-installer-r2.sh" stage --version "$version" --bucket "$bucket" --endpoint "$endpoint" --source-dir "$source_dir" >/dev/null 2>&1; then
+  echo "Immutable R2 release assets accepted changed content." >&2
+  exit 1
+fi
+
+echo "R2 installer publication tests: OK"

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -19,9 +19,22 @@ require_in() {
 
 require_in "$prepare_job" '          skip-github-pull-request: true'
 require_in "$prepare_job" '      pull-requests: write'
+require_in "$prepare_job" '          release_sha="$(gh api "/repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG"'
 require_in "$publish_job" '      artifact-metadata: write'
+require_in "$publish_job" '      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}'
+require_in "$publish_job" '      R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}'
+require_in "$publish_job" '      - name: Validate R2 release destination'
 require_in "$publish_job" '          platforms: linux/amd64,linux/arm64'
+require_in "$publish_job" '          outputs: type=image,name=${{ env.CENTER_IMAGE }},push-by-digest=true,name-canonical=true,push=true'
 require_in "$publish_job" '          DOCKER_CONFIG="$anonymous_config" scripts/assert-image-platforms.sh "$VASTORA_CENTER_IMAGE"'
+require_in "$publish_job" '          TRIVY_PLATFORM: linux/amd64'
+require_in "$publish_job" '          TRIVY_PLATFORM: linux/arm64'
+require_in "$publish_job" '      - name: Publish verified Center image tags'
+require_in "$publish_job" '            --tag "$CENTER_IMAGE:$RELEASE_TAG"'
+require_in "$publish_job" '            --tag "$CENTER_IMAGE:latest"'
+require_in "$publish_job" '        run: scripts/publish-installer-r2.sh stage --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT"'
+require_in "$publish_job" '        run: gh release edit "$RELEASE_TAG" --draft=false'
+require_in "$publish_job" '        run: scripts/publish-installer-r2.sh activate --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT"'
 require_in "$release_pr_job" '    needs: [prepare, publish]'
 require_in "$release_pr_job" "    if: always() && needs.prepare.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped')"
 require_in "$release_pr_job" '          skip-github-release: true'
@@ -35,6 +48,25 @@ if printf '%s\n' "$prepare_job" | grep -Fq 'skip-github-release: true'; then
 fi
 if printf '%s\n' "$release_pr_job" | grep -Fq 'skip-github-pull-request: true'; then
   echo 'Release pull request preparation must not publish a release.' >&2
+  exit 1
+fi
+if printf '%s\n' "$publish_job" | grep -Fq 'gh release upload'; then
+  echo 'Installer assets must be published to R2, not uploaded to GitHub Release.' >&2
+  exit 1
+fi
+if printf '%s\n' "$publish_job" | grep -Fq '          tags:'; then
+  echo 'Official image tags must be promoted only after both architecture scans pass.' >&2
+  exit 1
+fi
+
+scan_line="$(printf '%s\n' "$publish_job" | grep -nF 'Scan released Center image for ARM64 vulnerabilities' | cut -d: -f1)"
+promote_line="$(printf '%s\n' "$publish_job" | grep -nF 'Publish verified Center image tags' | cut -d: -f1)"
+stage_line="$(printf '%s\n' "$publish_job" | grep -nF 'publish-installer-r2.sh stage' | cut -d: -f1)"
+publish_line="$(printf '%s\n' "$publish_job" | grep -nF 'gh release edit "$RELEASE_TAG" --draft=false' | cut -d: -f1)"
+activate_line="$(printf '%s\n' "$publish_job" | grep -nF 'publish-installer-r2.sh activate' | cut -d: -f1)"
+verify_line="$(printf '%s\n' "$publish_job" | grep -nF 'Verify public installer endpoint' | cut -d: -f1)"
+if [ "$scan_line" -ge "$promote_line" ] || [ "$promote_line" -ge "$stage_line" ] || [ "$stage_line" -ge "$publish_line" ] || [ "$publish_line" -ge "$activate_line" ] || [ "$activate_line" -ge "$verify_line" ]; then
+  echo 'Release workflow must stage, publish metadata, activate R2, then verify the public endpoint.' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- enforce required CI and CodeQL gates while moving trusted dependency-cache warming to lockfile-only main pushes
- group routine Dependabot updates to reduce duplicate PR runs
- scan untagged x64 and ARM64 image digests before promoting release tags
- publish immutable installer assets to private R2 and atomically select the active release through a verified manifest
- serve installer assets from the existing Cloudflare Worker R2 binding without GitHub Release attachments

## Validation

- `actionlint .github/workflows/*.yml`
- installer Worker tests
- R2 staging, immutability, and activation tests
- CI policy tests
- release sequencing tests
- `git diff --check`

This PR does not update any deployed Center.