### PR TITLE
fix: read release version from R2 installer

### DIFF
--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -154,10 +154,12 @@ commit. Merging that pull request creates a draft release, builds and pushes one
 `linux/amd64` + `linux/arm64` Center image index to GHCR, verifies both
 platforms, packages the installer against the immutable index digest, uploads
 all three assets, and publishes the release only after every step succeeds.
-Failed builds leave the release as a draft. The Cloudflare
-Worker behind `vastora.petauron.com` selects the newest
-non-draft release containing all three assets, including prereleases, so it does
-not depend on GitHub's stable-only `releases/latest` endpoint.
+Failed builds leave the release as a draft. After GitHub publishes the release
+metadata, the workflow atomically activates the already-staged R2 manifest. The
+Cloudflare Worker behind `vastora.petauron.com` serves only the three objects
+named by that manifest and returns `X-Vastora-Version` on every installer
+response. Center update checks use that trusted header, including for
+prereleases, rather than GitHub's stable-only `releases/latest` endpoint.
 
 The GHCR package must allow unauthenticated pulls. The release job checks that
 before publishing and then downloads the public short URLs and verifies the
@@ -167,7 +169,8 @@ Repository owners must enable **Settings → Actions → General → Allow GitHu
 Actions to create and approve pull requests** once. The first image publication
 may also require changing the new `vastora-center` package visibility to
 **Public** and rerunning only the failed `publish` job. Until that succeeds, the
-draft release is not exposed by the installer Worker.
+R2 current-release manifest is not changed and the installer Worker continues
+serving the previously verified release.
 
 Built-in Headscale configuration is generated and validated by the restricted
 deployment helper. It is not edited as a file in the installation directory.

--- a/internal/center/center_update.go
+++ b/internal/center/center_update.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -71,10 +70,10 @@ func (checker *OfficialReleaseChecker) LatestVersion(ctx context.Context) (strin
 		return "", time.Time{}, fmt.Errorf("center: check official release: %w", err)
 	}
 	defer response.Body.Close()
-	if response.StatusCode < 300 || response.StatusCode > 399 {
+	if response.StatusCode < 200 || response.StatusCode > 299 {
 		return "", time.Time{}, fmt.Errorf("center: official installer returned HTTP %d", response.StatusCode)
 	}
-	version, err := releaseVersionFromLocation(response.Header.Get("Location"))
+	version, err := releaseVersionFromHeader(response.Header.Get("X-Vastora-Version"))
 	if err != nil {
 		return "", time.Time{}, err
 	}
@@ -84,18 +83,10 @@ func (checker *OfficialReleaseChecker) LatestVersion(ctx context.Context) (strin
 	return version, now, nil
 }
 
-func releaseVersionFromLocation(location string) (string, error) {
-	target, err := url.Parse(location)
-	if err != nil || target.Scheme != "https" || !strings.EqualFold(target.Hostname(), "github.com") {
-		return "", errors.New("center: official installer selected an invalid release URL")
-	}
-	const prefix = "/petauron/vastora/releases/download/v"
-	if !strings.HasPrefix(target.Path, prefix) || !strings.HasSuffix(target.Path, "/install.sh") {
-		return "", errors.New("center: official installer selected an unexpected release asset")
-	}
-	version := strings.TrimSuffix(strings.TrimPrefix(target.Path, prefix), "/install.sh")
-	if strings.Contains(version, "/") || !semver.IsValid("v"+version) {
-		return "", errors.New("center: official installer selected an invalid release version")
+func releaseVersionFromHeader(value string) (string, error) {
+	version := strings.TrimSpace(value)
+	if version == "" || strings.HasPrefix(version, "v") || !semver.IsValid("v"+version) {
+		return "", errors.New("center: official installer returned an invalid release version")
 	}
 	return version, nil
 }

--- a/internal/center/center_update_test.go
+++ b/internal/center/center_update_test.go
@@ -33,13 +33,13 @@ func (updater *fakeCenterUpdater) StartCenterUpdate(_ context.Context, version s
 	return deployapi.CenterUpdateExecution{Available: true, State: "queued", TargetVersion: version}, nil
 }
 
-func TestOfficialReleaseCheckerReadsTheInstallerSelectedRelease(t *testing.T) {
+func TestOfficialReleaseCheckerReadsTheR2ReleaseVersion(t *testing.T) {
 	installer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodHead {
 			t.Fatalf("method = %s", request.Method)
 		}
-		writer.Header().Set("Location", "https://github.com/petauron/vastora/releases/download/v0.1.0-alpha.48/install.sh")
-		writer.WriteHeader(http.StatusFound)
+		writer.Header().Set("X-Vastora-Version", "0.1.0-alpha.48")
+		writer.WriteHeader(http.StatusOK)
 	}))
 	defer installer.Close()
 	checker := NewOfficialReleaseChecker(installer.URL)
@@ -47,8 +47,30 @@ func TestOfficialReleaseCheckerReadsTheInstallerSelectedRelease(t *testing.T) {
 	if err != nil || version != "0.1.0-alpha.48" || checkedAt.IsZero() {
 		t.Fatalf("unexpected release: version=%q checked=%s err=%v", version, checkedAt, err)
 	}
-	if _, err := releaseVersionFromLocation("https://example.com/v0.1.0/install.sh"); err == nil {
-		t.Fatal("untrusted release location was accepted")
+	for _, value := range []string{"", "v0.1.0", "latest", "0.1.0/other"} {
+		if _, err := releaseVersionFromHeader(value); err == nil {
+			t.Fatalf("invalid release version %q was accepted", value)
+		}
+	}
+}
+
+func TestOfficialReleaseCheckerRejectsRedirectsAndMissingVersionHeaders(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+	}{
+		{name: "redirect", status: http.StatusFound},
+		{name: "missing version", status: http.StatusOK},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			installer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(test.status)
+			}))
+			defer installer.Close()
+			if _, _, err := NewOfficialReleaseChecker(installer.URL).LatestVersion(context.Background()); err == nil {
+				t.Fatal("invalid installer response was accepted")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- read the official release version from the R2-backed installer response header
- fail closed on redirects, missing headers, and malformed versions
- document the atomic R2 release pointer used by Center update checks

## Validation
- `go test ./internal/center`
- `git diff --check`
- live `HEAD https://vastora.petauron.com/install.sh` returns `200` and `X-Vastora-Version: 0.1.0-alpha.55`

## Rollout
Existing Centers running the redirect-only checker require one manual installer update after the fixed release is published. No deployed machine is changed by this PR.