### PR TITLE
fix: use immutable R2 releases for Center updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,9 @@ jobs:
         with:
           ref: ${{ github.sha }}
           path: .release-tools
-          sparse-checkout: scripts/publish-installer-r2.sh
+          sparse-checkout: |
+            scripts/publish-installer-r2.sh
+            scripts/verify-installer-release.sh
           sparse-checkout-cone-mode: false
 
       - name: Validate R2 release destination
@@ -210,30 +212,15 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: .release-tools/scripts/publish-installer-r2.sh activate --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT"
 
+      - name: Verify immutable installer release
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+        run: .release-tools/scripts/verify-installer-release.sh --base-url "https://vastora.petauron.com/releases/v$RELEASE_VERSION" --expected-version "$RELEASE_VERSION"
+
       - name: Verify public installer endpoint
         env:
           EXPECTED_VERSION: ${{ needs.prepare.outputs.release_version }}
-        run: |
-          temporary_dir="$(mktemp -d)"
-          verify_installer() {
-            rm -f "$temporary_dir/install.sh" "$temporary_dir/vastora-center-install.tar.gz" "$temporary_dir/vastora-center-install.tar.gz.sha256"
-            curl --connect-timeout 10 --max-time 30 -fsSL https://vastora.petauron.com/install.sh -o "$temporary_dir/install.sh" &&
-              curl --connect-timeout 10 --max-time 30 -fsSL https://vastora.petauron.com/vastora-center-install.tar.gz -o "$temporary_dir/vastora-center-install.tar.gz" &&
-              curl --connect-timeout 10 --max-time 30 -fsSL https://vastora.petauron.com/vastora-center-install.tar.gz.sha256 -o "$temporary_dir/vastora-center-install.tar.gz.sha256" &&
-              sh -n "$temporary_dir/install.sh" &&
-              (cd "$temporary_dir" && sha256sum --check vastora-center-install.tar.gz.sha256) &&
-              actual_version="$(tar -xOzf "$temporary_dir/vastora-center-install.tar.gz" ./release.env | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')" &&
-              test "$actual_version" = "$EXPECTED_VERSION"
-          }
-          attempt=1
-          while [ "$attempt" -le 18 ]; do
-            if verify_installer; then exit 0; fi
-            echo "Installer edge cache has not selected $EXPECTED_VERSION yet (attempt $attempt/18)."
-            attempt=$((attempt + 1))
-            sleep 5
-          done
-          echo "Public installer did not converge to $EXPECTED_VERSION." >&2
-          exit 1
+        run: .release-tools/scripts/verify-installer-release.sh --base-url https://vastora.petauron.com --expected-version "$EXPECTED_VERSION" --attempts 18 --retry-delay 5
 
   release-pr:
     name: Prepare next release pull request

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ deployment-check:
 	sh -n deploy/center/uninstall.sh
 	sh -n scripts/package-center-install.sh
 	sh -n scripts/publish-installer-r2.sh
+	sh -n scripts/verify-installer-release.sh
 	sh -n scripts/validate-release-metadata.sh
 	sh -n scripts/assert-image-platforms.sh
 	sh -n scripts/check-runtime-image-platforms.sh
 	sh -n scripts/test-center-install.sh
 	sh -n scripts/test-center-uninstall.sh
+	sh -n scripts/test-center-update.sh
 	sh -n scripts/test-release-metadata.sh
 	sh -n scripts/test-release-workflow.sh
 	sh -n scripts/test-ci-workflows.sh
@@ -47,8 +49,10 @@ deployment-check:
 	deploy/center/uninstall.sh --help >/dev/null
 	scripts/package-center-install.sh --help >/dev/null
 	scripts/publish-installer-r2.sh --help >/dev/null
+	scripts/verify-installer-release.sh --help >/dev/null
 	scripts/test-center-install.sh
 	scripts/test-center-uninstall.sh
+	scripts/test-center-update.sh
 	scripts/test-release-metadata.sh
 	scripts/test-release-workflow.sh
 	scripts/test-ci-workflows.sh

--- a/deploy/center/README.md
+++ b/deploy/center/README.md
@@ -122,14 +122,17 @@ The bundle contains `setup.sh`, `upgrade.sh`, `uninstall.sh`, Compose
 configuration, plus
 `release.env` with the release version and immutable image. `install.sh`
 supports `--release-url` for a trusted mirror and `--install-dir` for a custom
-location. `setup.sh` supports `--bootstrap-port` and `--ssh-host` after the `--`
-separator.
+location. Automatic updates additionally pass `--expected-version`, so a bundle
+for a different release is rejected before any installed file changes.
+`setup.sh` supports `--bootstrap-port` and `--ssh-host` after the `--` separator.
 
-Center checks the same public endpoint for a complete official release. An
+Center checks the fixed public endpoint for a complete official release. An
 administrator can confirm the update in Settings; a narrow deployer operation
-queues a root systemd one-shot service on the host, so Center still never mounts
-the Docker socket. For the first release containing this updater, run the same
-public command once to install the service.
+queues a root systemd one-shot service on the host. That service downloads the
+exact target through `/releases/vVERSION/`, verifies the installer's version and
+SHA-256 metadata, and rejects a mismatched bundle before installation. Center
+still never mounts the Docker socket. For the first release containing this
+updater, run the same public command once to install the service.
 
 Both entry points keep `.env`, replace only managed deployment files, validate
 and pull the new immutable image before changing anything, then start Center and

--- a/deploy/center/update-center.sh
+++ b/deploy/center/update-center.sh
@@ -18,6 +18,12 @@ if [ "$(id -u)" -ne 0 ]; then
   echo "Center updates must run as root." >&2
   exit 1
 fi
+for required in awk curl grep mktemp sha256sum; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    echo "Required command is not installed: $required" >&2
+    exit 1
+  fi
+done
 
 request="$install_dir/.update-request"
 status_file="$install_dir/.update-status.json"
@@ -46,27 +52,67 @@ write_status() {
 
 temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-center-update.XXXXXX")"
 installer="$temporary_dir/install.sh"
+installer_headers="$temporary_dir/install.headers"
 completed=no
+failure_message="Update failed. Review the host service log, then retry."
 cleanup() {
   result=$?
   rm -rf "$temporary_dir"
   if [ "$result" -ne 0 ] && [ "$completed" = no ]; then
-    write_status failed "$target_version" "Update failed. Review the host service log, then retry."
+    write_status failed "$target_version" "$failure_message"
   fi
   exit "$result"
 }
 trap cleanup EXIT HUP INT TERM
 
 write_status applying "$target_version" "Downloading and applying the verified release."
-release_base="https://github.com/petauron/vastora/releases/download/v$target_version"
-curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
-  "$release_base/install.sh" -o "$installer"
+release_base="https://vastora.petauron.com/releases/v$target_version"
+failure_message="The immutable Center installer could not be downloaded."
+if ! curl --proto '=https' --tlsv1.2 -fsS \
+  --dump-header "$installer_headers" \
+  "$release_base/install.sh" -o "$installer"; then
+  exit 1
+fi
+installer_version="$(awk '
+  index($0, ":") > 0 && tolower(substr($0, 1, index($0, ":") - 1)) == "x-vastora-version" {
+    value = substr($0, index($0, ":") + 1)
+    sub(/^[[:space:]]+/, "", value)
+    sub(/\r$/, "", value)
+    result = value
+  }
+  END { print result }
+' "$installer_headers")"
+if [ "$installer_version" != "$target_version" ]; then
+  failure_message="The immutable Center installer version did not match the requested update."
+  exit 1
+fi
+expected_installer_digest="$(awk '
+  index($0, ":") > 0 && tolower(substr($0, 1, index($0, ":") - 1)) == "x-vastora-sha256" {
+    value = substr($0, index($0, ":") + 1)
+    sub(/^[[:space:]]+/, "", value)
+    sub(/\r$/, "", value)
+    result = tolower(value)
+  }
+  END { print result }
+' "$installer_headers")"
+if ! printf '%s\n' "$expected_installer_digest" | grep -Eq '^[0-9a-f]{64}$' || \
+   [ "$(sha256sum "$installer" | awk 'NR == 1 {print tolower($1)}')" != "$expected_installer_digest" ]; then
+  failure_message="The immutable Center installer failed its SHA-256 integrity check."
+  exit 1
+fi
 chmod 0700 "$installer"
-/bin/sh "$installer" center \
+failure_message="The verified Center installer did not complete successfully."
+if ! /bin/sh "$installer" center \
   --release-url "$release_base/vastora-center-install.tar.gz" \
-  --install-dir "$install_dir"
+  --install-dir "$install_dir" \
+  --expected-version "$target_version"; then
+  exit 1
+fi
 
 installed_version="$(awk -F= '$1 == "VASTORA_VERSION" {sub(/^[^=]*=/, ""); print; exit}' "$install_dir/release.env")"
-if [ -z "$installed_version" ]; then installed_version="$target_version"; fi
+if [ "$installed_version" != "$target_version" ]; then
+  failure_message="The Center update completed with an unexpected installed version."
+  exit 1
+fi
 write_status succeeded "$installed_version" "Center was updated successfully."
 completed=yes

--- a/deploy/installer-worker/README.md
+++ b/deploy/installer-worker/README.md
@@ -4,9 +4,13 @@
 behind `vastora.petauron.com`. Bind the private `petauron-downloads` R2 bucket as
 `INSTALLER_ASSETS`. The release workflow uploads immutable, versioned installer
 objects, publishes the GitHub release metadata, and then atomically replaces
-`vastora/current.json`. The Worker validates that manifest, serves only its
-three fixed installer assets, and caches the selected version for one minute.
-The bucket remains private and GitHub Release is not a runtime download source.
+`vastora/current.json`. The Worker validates that manifest, serves its three
+fixed current-release paths with a one-minute cache, and exposes the same R2
+objects through immutable `/releases/vVERSION/ASSET` paths for automatic Center
+updates. A versioned path becomes visible only after the release workflow writes
+its immutable activation manifest; merely staged objects cannot be downloaded.
+GitHub Release is metadata only and is never a runtime download source.
+The bucket remains private.
 
 The Worker also relays the short-lived Cloudflare OAuth authorization code from
 the fixed public callback to the private Center that started the login. It never

--- a/deploy/installer-worker/worker.js
+++ b/deploy/installer-worker/worker.js
@@ -6,7 +6,9 @@ const releaseAssets = new Map([
   ["vastora-center-install.tar.gz", "application/gzip"],
   ["vastora-center-install.tar.gz.sha256", "text/plain; charset=utf-8"],
 ]);
-const currentCacheKey = new Request("https://vastora-installer.internal/current-release");
+const releaseVersionPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+const immutableCacheControl = "public, max-age=31536000, immutable";
+const currentCacheControl = "public, max-age=60";
 const currentManifestKey = "vastora/current.json";
 const oauthCallbackPath = "/oauth/cloudflare/callback";
 const oauthSessionPrefix = "/oauth/cloudflare/sessions/";
@@ -16,7 +18,7 @@ const oauthSessionLifetimeMs = 10 * 60 * 1000;
 const oauthStatePattern = /^v1\.([A-Za-z0-9_-]{24,64})\.([A-Za-z0-9_-]{43})$/;
 
 function validManifest(manifest) {
-  if (!manifest || manifest.schema !== 1 || !/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(manifest.version || "")) {
+  if (!manifest || manifest.schema !== 1 || !releaseVersionPattern.test(manifest.version || "")) {
     return false;
   }
   if (!manifest.assets || Object.keys(manifest.assets).length !== releaseAssets.size) return false;
@@ -30,23 +32,50 @@ function validManifest(manifest) {
   return true;
 }
 
-async function selectedRelease(env, ctx) {
+function manifestCacheKey(key) {
+  return new Request(`https://vastora-installer.internal/${key}`);
+}
+
+async function releaseManifest(env, ctx, key, cacheControl) {
   if (!env.INSTALLER_ASSETS) throw new Error("Installer R2 binding is unavailable");
   const cache = caches.default;
-  const cached = await cache.match(currentCacheKey);
+  const cacheKey = manifestCacheKey(key);
+  const cached = await cache.match(cacheKey);
   if (cached) return cached.json();
-  const object = await env.INSTALLER_ASSETS.get(currentManifestKey);
-  if (!object) throw new Error("Installer release manifest is unavailable");
+  const object = await env.INSTALLER_ASSETS.get(key);
+  if (!object) return null;
   const manifest = await object.json();
   if (!validManifest(manifest)) throw new Error("Installer release manifest is invalid");
-  ctx.waitUntil(cache.put(currentCacheKey, Response.json(manifest, {
-    headers: { "Cache-Control": "public, max-age=60" },
+  ctx.waitUntil(cache.put(cacheKey, Response.json(manifest, {
+    headers: { "Cache-Control": cacheControl },
   })));
   return manifest;
 }
 
-async function installerAssetResponse(request, env, ctx, asset) {
-  const manifest = await selectedRelease(env, ctx);
+async function selectedRelease(env, ctx) {
+  const manifest = await releaseManifest(env, ctx, currentManifestKey, currentCacheControl);
+  if (!manifest) throw new Error("Installer release manifest is unavailable");
+  return manifest;
+}
+
+async function versionedRelease(env, ctx, version) {
+  const manifest = await releaseManifest(
+    env,
+    ctx,
+    `vastora/releases/v${version}/activated.json`,
+    immutableCacheControl,
+  );
+  if (manifest && manifest.version !== version) throw new Error("Installer release manifest version is mismatched");
+  return manifest;
+}
+
+function versionedAsset(pathname) {
+  const match = /^\/releases\/v([^/]+)\/([^/]+)$/.exec(pathname);
+  if (!match || !releaseVersionPattern.test(match[1]) || !releaseAssets.has(match[2])) return null;
+  return { version: match[1], asset: match[2] };
+}
+
+async function installerAssetResponse(request, env, manifest, asset, cacheControl) {
   const descriptor = manifest.assets[asset];
   const object = request.method === "HEAD"
     ? await env.INSTALLER_ASSETS.head(descriptor.key)
@@ -56,7 +85,7 @@ async function installerAssetResponse(request, env, ctx, asset) {
   }
   const headers = new Headers(responseHeaders());
   object.writeHttpMetadata(headers);
-  headers.set("Cache-Control", "public, max-age=60");
+  headers.set("Cache-Control", cacheControl);
   headers.set("Content-Length", String(object.size));
   headers.set("Content-Type", releaseAssets.get(asset));
   headers.set("ETag", object.httpEtag);
@@ -258,13 +287,20 @@ export default {
     if (url.pathname === "/") {
       return Response.redirect(`https://github.com/${repository}`, 302);
     }
-    const asset = url.pathname.slice(1);
-    if (!releaseAssets.has(asset)) {
+    const immutableAsset = versionedAsset(url.pathname);
+    const currentAsset = url.pathname.slice(1);
+    if (!immutableAsset && !releaseAssets.has(currentAsset)) {
       return new Response("Not found\n", { status: 404, headers: responseHeaders() });
     }
 
     try {
-      return await installerAssetResponse(request, env, ctx, asset);
+      if (immutableAsset) {
+        const manifest = await versionedRelease(env, ctx, immutableAsset.version);
+        if (!manifest) return new Response("Not found\n", { status: 404, headers: responseHeaders() });
+        return await installerAssetResponse(request, env, manifest, immutableAsset.asset, immutableCacheControl);
+      }
+      const manifest = await selectedRelease(env, ctx);
+      return await installerAssetResponse(request, env, manifest, currentAsset, currentCacheControl);
     } catch (error) {
       console.error("Unable to serve installer release", error);
       return new Response("No complete Vastora release is currently available.\n", {

--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,11 @@ set -eu
 default_release_url="https://vastora.petauron.com/vastora-center-install.tar.gz"
 release_url="$default_release_url"
 install_dir="/opt/vastora/center"
+expected_version=""
 
 usage() {
   cat <<'EOF'
-Usage: install.sh center [--release-url HTTPS_URL] [--install-dir DIR] [-- SETUP_OPTIONS]
+Usage: install.sh center [--release-url HTTPS_URL] [--install-dir DIR] [--expected-version VERSION] [-- SETUP_OPTIONS]
        install.sh center uninstall [--release-url HTTPS_URL] [--install-dir DIR]
 
 Installs the verified Vastora Center release bundle on loopback, then prints an
@@ -49,6 +50,11 @@ while [ "$#" -gt 0 ]; do
       install_dir="$2"
       shift 2
       ;;
+    --expected-version)
+      [ "$#" -ge 2 ] || { echo "--expected-version requires a value." >&2; exit 2; }
+      expected_version="$2"
+      shift 2
+      ;;
     --) shift; break ;;
     *) break ;;
   esac
@@ -80,12 +86,16 @@ case "$install_dir" in
   /*) ;;
   *) echo "The installation directory must be an absolute path." >&2; exit 2 ;;
 esac
-for required in curl tar mktemp install awk dirname mv; do
+for required in curl tar mktemp install awk dirname grep mv; do
   if ! command -v "$required" >/dev/null 2>&1; then
     echo "Required command is not installed: $required" >&2
     exit 1
   fi
 done
+if [ -n "$expected_version" ] && ! printf '%s\n' "$expected_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "The expected Center version is invalid." >&2
+  exit 2
+fi
 if command -v sha256sum >/dev/null 2>&1; then
   digest_command="sha256sum"
 elif command -v shasum >/dev/null 2>&1; then
@@ -146,6 +156,15 @@ for required_file in install.sh setup.sh upgrade.sh uninstall.sh install-host-cl
     exit 1
   fi
 done
+bundle_version="$(awk -F= '$1 == "VASTORA_VERSION" {sub(/^[^=]*=/, ""); print; exit}' "$staging/release.env")"
+if ! printf '%s\n' "$bundle_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "The Center release contains an invalid version; nothing was installed." >&2
+  exit 1
+fi
+if [ -n "$expected_version" ] && [ "$bundle_version" != "$expected_version" ]; then
+  echo "The Center release version does not match the requested update; nothing was installed." >&2
+  exit 1
+fi
 chmod 0755 "$staging/setup.sh"
 chmod 0755 "$staging/upgrade.sh"
 chmod 0755 "$staging/uninstall.sh"

--- a/internal/deployer/center_update.go
+++ b/internal/deployer/center_update.go
@@ -77,17 +77,31 @@ func (updater FileCenterUpdater) StartCenterUpdate(ctx context.Context, version 
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	queued := deployapi.CenterUpdateExecution{Available: true, State: "queued", TargetVersion: version, Message: "Waiting for the host update service.", UpdatedAt: now}
-	statusPayload, err := json.Marshal(queued)
-	if err != nil {
-		return deployapi.CenterUpdateExecution{}, err
-	}
-	if err := writeCenterUpdateFile(filepath.Join(updater.InstallDir, ".update-status.json"), append(statusPayload, '\n'), 0o600); err != nil {
+	statusPath := filepath.Join(updater.InstallDir, ".update-status.json")
+	if err := writeCenterUpdateStatus(statusPath, queued); err != nil {
 		return deployapi.CenterUpdateExecution{}, fmt.Errorf("deployer: queue Center update status: %w", err)
 	}
 	if err := writeCenterUpdateFile(filepath.Join(updater.InstallDir, ".update-request"), []byte(version+"\n"), 0o600); err != nil {
+		failed := queued
+		failed.State = "failed"
+		failed.Message = "The update request could not be queued."
+		if statusErr := writeCenterUpdateStatus(statusPath, failed); statusErr != nil {
+			return deployapi.CenterUpdateExecution{}, errors.Join(
+				fmt.Errorf("deployer: queue Center update request: %w", err),
+				fmt.Errorf("deployer: record Center update queue failure: %w", statusErr),
+			)
+		}
 		return deployapi.CenterUpdateExecution{}, fmt.Errorf("deployer: queue Center update request: %w", err)
 	}
 	return queued, nil
+}
+
+func writeCenterUpdateStatus(path string, status deployapi.CenterUpdateExecution) error {
+	payload, err := json.Marshal(status)
+	if err != nil {
+		return err
+	}
+	return writeCenterUpdateFile(path, append(payload, '\n'), 0o600)
 }
 
 func installedCenterVersion(path string) (string, error) {

--- a/internal/deployer/center_update_test.go
+++ b/internal/deployer/center_update_test.go
@@ -52,3 +52,30 @@ func TestFileCenterUpdaterRequiresInstalledHostService(t *testing.T) {
 		t.Fatal("update was queued without the host service")
 	}
 }
+
+func TestFileCenterUpdaterDoesNotLeaveAStuckQueueWhenRequestWriteFails(t *testing.T) {
+	installDir := t.TempDir()
+	for _, name := range []string{".update-service-enabled", "update-center.sh"} {
+		if err := os.WriteFile(filepath.Join(installDir, name), []byte("ready\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "release.env"), []byte("VASTORA_VERSION=0.1.0-alpha.47\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(installDir, ".update-request"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	updater := FileCenterUpdater{InstallDir: installDir}
+	if _, err := updater.StartCenterUpdate(context.Background(), "0.1.0-alpha.48"); err == nil {
+		t.Fatal("request write failure was accepted")
+	}
+	status, err := updater.CenterUpdateStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.State != "failed" || status.TargetVersion != "0.1.0-alpha.48" {
+		t.Fatalf("queue failure left an invalid status: %#v", status)
+	}
+}

--- a/scripts/publish-installer-r2.sh
+++ b/scripts/publish-installer-r2.sh
@@ -67,6 +67,7 @@ done
 tag="v$version"
 prefix="vastora/releases/$tag"
 manifest_key="$prefix/manifest.json"
+activated_key="$prefix/activated.json"
 current_key="vastora/current.json"
 temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-r2-release.XXXXXX")"
 cleanup() { rm -rf "$temporary_dir"; }
@@ -143,6 +144,12 @@ verify_remote_assets() {
 }
 
 if [ "$command_name" = "stage" ]; then
+  for required in sh tar; do
+    if ! command -v "$required" >/dev/null 2>&1; then
+      echo "Required command is not installed: $required" >&2
+      exit 1
+    fi
+  done
   script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
   project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
   if [ -z "$installer" ]; then installer="$project_dir/install.sh"; fi
@@ -154,6 +161,21 @@ if [ "$command_name" = "stage" ]; then
       exit 1
     fi
   done
+  if ! sh -n "$installer"; then
+    echo "The Center installer script is invalid." >&2
+    exit 1
+  fi
+  bundle_version="$(tar -xOzf "$bundle" ./release.env 2>/dev/null | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')"
+  if [ "$bundle_version" != "$version" ]; then
+    echo "The Center bundle version does not match the R2 release version." >&2
+    exit 1
+  fi
+  expected_bundle_digest="$(awk 'NR == 1 {print tolower($1)}' "$checksum")"
+  actual_bundle_digest="$(sha256sum "$bundle" | awk 'NR == 1 {print tolower($1)}')"
+  if ! printf '%s\n' "$expected_bundle_digest" | grep -Eq '^[0-9a-f]{64}$' || [ "$actual_bundle_digest" != "$expected_bundle_digest" ]; then
+    echo "The Center bundle checksum is invalid." >&2
+    exit 1
+  fi
 
   installer_digest="$(upload_immutable "$installer" "$prefix/install.sh" 'text/x-shellscript; charset=utf-8')"
   bundle_digest="$(upload_immutable "$bundle" "$prefix/vastora-center-install.tar.gz" 'application/gzip')"
@@ -183,6 +205,7 @@ manifest="$temporary_dir/manifest.json"
 retry aws_r2 get-object --bucket "$bucket" --key "$manifest_key" "$manifest" >/dev/null
 verify_manifest "$manifest"
 verify_remote_assets "$manifest"
+upload_immutable "$manifest" "$activated_key" 'application/json; charset=utf-8' >/dev/null
 manifest_digest="$(sha256sum "$manifest" | awk 'NR == 1 {print tolower($1)}')"
 retry aws_r2 put-object \
   --bucket "$bucket" \

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -27,6 +27,52 @@ else
   actual_digest="$(shasum -a 256 "$archive" | awk 'NR == 1 {print $1}')"
 fi
 test "$expected_digest" = "$actual_digest"
+
+validation_bin="$temporary_dir/validation-bin"
+mkdir -p "$validation_bin"
+cat > "$validation_bin/id" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "-u" ]; then printf '%s\n' 0; else exec /usr/bin/id "$@"; fi
+EOF
+cat > "$validation_bin/uname" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  -s) printf '%s\n' Linux ;;
+  -m) printf '%s\n' x86_64 ;;
+  *) printf '%s\n' Linux ;;
+esac
+EOF
+cat > "$validation_bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --proto|--proto-redir) shift 2 ;;
+    --tlsv1.2|-fsSL) shift ;;
+    -o) output="$2"; shift 2 ;;
+    *) url="$1"; shift ;;
+  esac
+done
+case "$url" in
+  *.sha256) cp "$FAKE_RELEASE_CHECKSUM" "$output" ;;
+  *) cp "$FAKE_RELEASE_ARCHIVE" "$output" ;;
+esac
+EOF
+chmod 0755 "$validation_bin/id" "$validation_bin/uname" "$validation_bin/curl"
+if FAKE_RELEASE_ARCHIVE="$archive" \
+   FAKE_RELEASE_CHECKSUM="$archive.sha256" \
+   PATH="$validation_bin:$PATH" \
+   "$project_dir/install.sh" center \
+     --release-url https://vastora.petauron.com/releases/v0.1.0-test/vastora-center-install.tar.gz \
+     --install-dir "$temporary_dir/version-mismatch" \
+     --expected-version 0.1.0-other >/dev/null 2>&1; then
+  echo "Center installer accepted a bundle for a different requested version." >&2
+  exit 1
+fi
+test ! -e "$temporary_dir/version-mismatch"
+
 tar -xzf "$archive" -C "$temporary_dir"
 grep -Fqx 'VASTORA_VERSION=0.1.0-test' "$temporary_dir/release.env"
 grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$temporary_dir/release.env"

--- a/scripts/test-center-update.sh
+++ b/scripts/test-center-update.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-center-update-test.XXXXXX")"
+cleanup() { rm -rf "$temporary_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+fake_bin="$temporary_dir/bin"
+install_dir="$temporary_dir/center"
+mkdir -p "$fake_bin" "$install_dir"
+
+cat > "$fake_bin/id" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "-u" ]; then printf '%s\n' 0; else exec /usr/bin/id "$@"; fi
+EOF
+cat > "$temporary_dir/installer.sh" <<'EOF'
+#!/bin/sh
+set -eu
+[ "${1:-}" = "center" ]
+shift
+release_url=""
+install_dir=""
+expected_version=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --release-url) release_url="$2"; shift 2 ;;
+    --install-dir) install_dir="$2"; shift 2 ;;
+    --expected-version) expected_version="$2"; shift 2 ;;
+    *) exit 2 ;;
+  esac
+done
+[ "$release_url" = "https://vastora.petauron.com/releases/v$expected_version/vastora-center-install.tar.gz" ]
+printf '%s\n' "$release_url" > "$FAKE_INSTALLER_LOG"
+printf 'VASTORA_VERSION=%s\n' "$expected_version" > "$install_dir/release.env"
+EOF
+cat > "$fake_bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+headers=""
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --proto) shift 2 ;;
+    --tlsv1.2) shift ;;
+    --dump-header) headers="$2"; shift 2 ;;
+    -o) output="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+[ "$url" = "https://vastora.petauron.com/releases/v$FAKE_TARGET_VERSION/install.sh" ]
+cp "$FAKE_INSTALLER_SOURCE" "$output"
+digest="$(sha256sum "$output" | awk 'NR == 1 {print $1}')"
+{
+  printf 'HTTP/2 200\r\n'
+  printf 'X-Vastora-Version: %s\r\n' "${FAKE_RESPONSE_VERSION:-$FAKE_TARGET_VERSION}"
+  printf 'X-Vastora-SHA256: %s\r\n\r\n' "$digest"
+} > "$headers"
+EOF
+chmod 0755 "$fake_bin/id" "$fake_bin/curl" "$temporary_dir/installer.sh"
+
+run_update() {
+  target_version="$1"
+  response_version="$2"
+  printf '%s\n' "$target_version" > "$install_dir/.update-request"
+  FAKE_INSTALLER_LOG="$temporary_dir/installer.log" \
+  FAKE_INSTALLER_SOURCE="$temporary_dir/installer.sh" \
+  FAKE_RESPONSE_VERSION="$response_version" \
+  FAKE_TARGET_VERSION="$target_version" \
+  PATH="$fake_bin:$PATH" \
+    "$project_dir/deploy/center/update-center.sh" --install-dir "$install_dir"
+}
+
+run_update 0.1.0-alpha.58 0.1.0-alpha.58
+grep -Fq '"state":"succeeded"' "$install_dir/.update-status.json"
+grep -Fq '"targetVersion":"0.1.0-alpha.58"' "$install_dir/.update-status.json"
+grep -Fqx 'VASTORA_VERSION=0.1.0-alpha.58' "$install_dir/release.env"
+grep -Fqx 'https://vastora.petauron.com/releases/v0.1.0-alpha.58/vastora-center-install.tar.gz' "$temporary_dir/installer.log"
+
+if run_update 0.1.0-alpha.59 0.1.0-alpha.58 >/dev/null 2>&1; then
+  echo "Center updater accepted an installer for the wrong version." >&2
+  exit 1
+fi
+grep -Fq '"state":"failed"' "$install_dir/.update-status.json"
+grep -Fq 'installer version did not match' "$install_dir/.update-status.json"
+
+echo "Center automatic update tests: OK"

--- a/scripts/test-installer-worker.mjs
+++ b/scripts/test-installer-worker.mjs
@@ -106,6 +106,7 @@ const installerManifest = {
 function installerEnvironment({ mismatchAsset = "", manifest = installerManifest } = {}) {
   const objects = new Map([
     ["vastora/current.json", { body: JSON.stringify(manifest), sha256: "d".repeat(64), contentType: "application/json" }],
+    [`vastora/releases/v${installerManifest.version}/activated.json`, { body: JSON.stringify(manifest), sha256: "e".repeat(64), contentType: "application/json" }],
     [installerManifest.assets["install.sh"].key, { body: "#!/bin/sh\n", sha256: installerManifest.assets["install.sh"].sha256, contentType: "text/x-shellscript" }],
     [installerManifest.assets["vastora-center-install.tar.gz"].key, { body: "archive", sha256: installerManifest.assets["vastora-center-install.tar.gz"].sha256, contentType: "application/gzip" }],
     [installerManifest.assets["vastora-center-install.tar.gz.sha256"].key, { body: "checksum", sha256: installerManifest.assets["vastora-center-install.tar.gz.sha256"].sha256, contentType: "text/plain" }],
@@ -145,6 +146,7 @@ function installerEnvironment({ mismatchAsset = "", manifest = installerManifest
   assert.equal(await response.text(), "#!/bin/sh\n");
   assert.equal(response.headers.get("x-vastora-version"), "0.1.0-alpha.4");
   assert.equal(response.headers.get("x-vastora-sha256"), "a".repeat(64));
+  assert.equal(response.headers.get("cache-control"), "public, max-age=60");
 
   const cachedResponse = await worker.fetch(request("/vastora-center-install.tar.gz"), env, executionContext().context);
   assert.equal(cachedResponse.status, 200);
@@ -154,6 +156,31 @@ function installerEnvironment({ mismatchAsset = "", manifest = installerManifest
   assert.equal(head.status, 200);
   assert.equal(await head.text(), "");
   assert.ok(env.reads.some(([method, key]) => method === "head" && key.endsWith("/install.sh")));
+}
+
+{
+  const storage = cacheStorage();
+  globalThis.caches = { default: storage.cache };
+  const env = installerEnvironment();
+  const execution = executionContext();
+  const prefix = "/releases/v0.1.0-alpha.4";
+  const response = await worker.fetch(request(`${prefix}/install.sh`), env, execution.context);
+  await execution.flush();
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "#!/bin/sh\n");
+  assert.equal(response.headers.get("x-vastora-version"), "0.1.0-alpha.4");
+  assert.equal(response.headers.get("cache-control"), "public, max-age=31536000, immutable");
+  assert.ok(env.reads.some(([, key]) => key === "vastora/releases/v0.1.0-alpha.4/activated.json"));
+  assert.equal(env.reads.some(([, key]) => key === "vastora/current.json"), false);
+
+  const archive = await worker.fetch(request(`${prefix}/vastora-center-install.tar.gz`), env, executionContext().context);
+  assert.equal(archive.status, 200);
+  assert.equal(env.reads.filter(([, key]) => key === "vastora/releases/v0.1.0-alpha.4/activated.json").length, 1);
+
+  const missing = await worker.fetch(request("/releases/v0.1.0-alpha.5/install.sh"), env, executionContext().context);
+  assert.equal(missing.status, 404);
+  const invalid = await worker.fetch(request("/releases/vlatest/install.sh"), env, executionContext().context);
+  assert.equal(invalid.status, 404);
 }
 
 {

--- a/scripts/test-publish-installer-r2.sh
+++ b/scripts/test-publish-installer-r2.sh
@@ -10,8 +10,10 @@ trap cleanup EXIT HUP INT TERM
 fake_bin="$temporary_dir/bin"
 fake_r2="$temporary_dir/r2"
 source_dir="$temporary_dir/dist"
-mkdir -p "$fake_bin" "$fake_r2/objects" "$source_dir"
-printf 'bundle\n' > "$source_dir/vastora-center-install.tar.gz"
+bundle_dir="$temporary_dir/bundle"
+mkdir -p "$fake_bin" "$fake_r2/objects" "$source_dir" "$bundle_dir"
+printf 'VASTORA_VERSION=0.1.0-test\n' > "$bundle_dir/release.env"
+tar -czf "$source_dir/vastora-center-install.tar.gz" -C "$bundle_dir" .
 (cd "$source_dir" && sha256sum vastora-center-install.tar.gz > vastora-center-install.tar.gz.sha256)
 
 cat > "$fake_bin/aws" <<'EOF'
@@ -76,14 +78,23 @@ version="0.1.0-test"
 "$script_dir/publish-installer-r2.sh" stage --version "$version" --bucket "$bucket" --endpoint "$endpoint" --source-dir "$source_dir" --installer "$project_dir/install.sh" >/dev/null
 manifest="$fake_r2/objects/vastora/releases/v$version/manifest.json"
 test -f "$manifest"
+test ! -e "$fake_r2/objects/vastora/releases/v$version/activated.json"
 jq -e --arg version "$version" '.schema == 1 and .version == $version and (.assets | length) == 3' "$manifest" >/dev/null
 
 "$script_dir/publish-installer-r2.sh" activate --version "$version" --bucket "$bucket" --endpoint "$endpoint" >/dev/null
+cmp -s "$manifest" "$fake_r2/objects/vastora/releases/v$version/activated.json"
 cmp -s "$manifest" "$fake_r2/objects/vastora/current.json"
 
-printf 'changed bundle\n' > "$source_dir/vastora-center-install.tar.gz"
+printf 'changed\n' > "$bundle_dir/content.txt"
+tar -czf "$source_dir/vastora-center-install.tar.gz" -C "$bundle_dir" .
+(cd "$source_dir" && sha256sum vastora-center-install.tar.gz > vastora-center-install.tar.gz.sha256)
 if "$script_dir/publish-installer-r2.sh" stage --version "$version" --bucket "$bucket" --endpoint "$endpoint" --source-dir "$source_dir" --installer "$project_dir/install.sh" >/dev/null 2>&1; then
   echo "Immutable R2 release assets accepted changed content." >&2
+  exit 1
+fi
+
+if "$script_dir/publish-installer-r2.sh" stage --version "0.1.0-other" --bucket "$bucket" --endpoint "$endpoint" --source-dir "$source_dir" --installer "$project_dir/install.sh" >/dev/null 2>&1; then
+  echo "R2 publication accepted a bundle for a different version." >&2
   exit 1
 fi
 

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -26,6 +26,7 @@ require_in "$publish_job" '      R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}'
 require_in "$publish_job" '      - name: Validate R2 release destination'
 require_in "$publish_job" '      - name: Check out current release tooling'
 require_in "$publish_job" '          path: .release-tools'
+require_in "$publish_job" '            scripts/verify-installer-release.sh'
 require_in "$publish_job" '          platforms: linux/amd64,linux/arm64'
 require_in "$publish_job" '          outputs: type=image,name=${{ env.CENTER_IMAGE }},push-by-digest=true,name-canonical=true,push=true'
 require_in "$publish_job" '          DOCKER_CONFIG="$anonymous_config" scripts/assert-image-platforms.sh "$VASTORA_CENTER_IMAGE"'
@@ -35,8 +36,11 @@ require_in "$publish_job" '      - name: Publish verified Center image tags'
 require_in "$publish_job" '            --tag "$CENTER_IMAGE:$RELEASE_TAG"'
 require_in "$publish_job" '            --tag "$CENTER_IMAGE:latest"'
 require_in "$publish_job" '        run: .release-tools/scripts/publish-installer-r2.sh stage --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT" --installer install.sh'
+require_in "$publish_job" '      - name: Verify immutable installer release'
+require_in "$publish_job" '        run: .release-tools/scripts/verify-installer-release.sh --base-url "https://vastora.petauron.com/releases/v$RELEASE_VERSION" --expected-version "$RELEASE_VERSION"'
 require_in "$publish_job" '        run: gh release edit "$RELEASE_TAG" --draft=false'
 require_in "$publish_job" '        run: .release-tools/scripts/publish-installer-r2.sh activate --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT"'
+require_in "$publish_job" '        run: .release-tools/scripts/verify-installer-release.sh --base-url https://vastora.petauron.com --expected-version "$EXPECTED_VERSION" --attempts 18 --retry-delay 5'
 require_in "$release_pr_job" '    needs: [prepare, publish]'
 require_in "$release_pr_job" "    if: always() && needs.prepare.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped')"
 require_in "$release_pr_job" '          skip-github-release: true'
@@ -64,10 +68,11 @@ fi
 scan_line="$(printf '%s\n' "$publish_job" | grep -nF 'Scan released Center image for ARM64 vulnerabilities' | cut -d: -f1)"
 promote_line="$(printf '%s\n' "$publish_job" | grep -nF 'Publish verified Center image tags' | cut -d: -f1)"
 stage_line="$(printf '%s\n' "$publish_job" | grep -nF 'publish-installer-r2.sh stage' | cut -d: -f1)"
+immutable_verify_line="$(printf '%s\n' "$publish_job" | grep -nF 'Verify immutable installer release' | cut -d: -f1)"
 publish_line="$(printf '%s\n' "$publish_job" | grep -nF 'gh release edit "$RELEASE_TAG" --draft=false' | cut -d: -f1)"
 activate_line="$(printf '%s\n' "$publish_job" | grep -nF 'publish-installer-r2.sh activate' | cut -d: -f1)"
 verify_line="$(printf '%s\n' "$publish_job" | grep -nF 'Verify public installer endpoint' | cut -d: -f1)"
-if [ "$scan_line" -ge "$promote_line" ] || [ "$promote_line" -ge "$stage_line" ] || [ "$stage_line" -ge "$publish_line" ] || [ "$publish_line" -ge "$activate_line" ] || [ "$activate_line" -ge "$verify_line" ]; then
+if [ "$scan_line" -ge "$promote_line" ] || [ "$promote_line" -ge "$stage_line" ] || [ "$stage_line" -ge "$publish_line" ] || [ "$publish_line" -ge "$activate_line" ] || [ "$activate_line" -ge "$immutable_verify_line" ] || [ "$immutable_verify_line" -ge "$verify_line" ]; then
   echo 'Release workflow must stage, publish metadata, activate R2, then verify the public endpoint.' >&2
   exit 1
 fi

--- a/scripts/verify-installer-release.sh
+++ b/scripts/verify-installer-release.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+set -eu
+
+base_url=""
+expected_version=""
+attempts=1
+retry_delay=5
+
+usage() {
+  cat <<'EOF'
+Usage: verify-installer-release.sh --base-url HTTPS_URL --expected-version VERSION [--attempts COUNT] [--retry-delay SECONDS]
+
+Downloads and verifies one complete R2-backed Vastora installer release.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base-url) base_url="${2:-}"; shift 2 ;;
+    --expected-version) expected_version="${2:-}"; shift 2 ;;
+    --attempts) attempts="${2:-}"; shift 2 ;;
+    --retry-delay) retry_delay="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+for required in awk curl grep mktemp sha256sum sh tar tr; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    echo "Required command is not installed: $required" >&2
+    exit 1
+  fi
+done
+base_url="${base_url%/}"
+if ! printf '%s\n' "$expected_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "The expected installer version is invalid." >&2
+  exit 2
+fi
+case "$base_url" in
+  https://vastora.petauron.com|"https://vastora.petauron.com/releases/v$expected_version") ;;
+  *) echo "The installer base URL must be an official Vastora release endpoint." >&2; exit 2 ;;
+esac
+case "$attempts:$retry_delay" in
+  *[!0-9:]*|0:*|*:) echo "Attempts and retry delay must be non-negative integers, with at least one attempt." >&2; exit 2 ;;
+esac
+
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-installer-verify.XXXXXX")"
+# shellcheck disable=SC2329 # Invoked by the trap below.
+cleanup() { rm -rf "$temporary_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+header_value() {
+  header_name="$1"
+  header_file="$2"
+  awk -v expected="$header_name" '
+    index($0, ":") > 0 && tolower(substr($0, 1, index($0, ":") - 1)) == expected {
+      value = substr($0, index($0, ":") + 1)
+      sub(/^[[:space:]]+/, "", value)
+      sub(/\r$/, "", value)
+      result = value
+    }
+    END { print result }
+  ' "$header_file"
+}
+
+download_asset() {
+  asset="$1"
+  output="$temporary_dir/$asset"
+  headers="$temporary_dir/$asset.headers"
+  curl --connect-timeout 10 --max-time 30 --proto '=https' --tlsv1.2 -fsS \
+    --dump-header "$headers" "$base_url/$asset" -o "$output" || return 1
+  [ "$(header_value x-vastora-version "$headers")" = "$expected_version" ] || return 1
+  expected_digest="$(header_value x-vastora-sha256 "$headers" | tr '[:upper:]' '[:lower:]')"
+  printf '%s\n' "$expected_digest" | grep -Eq '^[0-9a-f]{64}$' || return 1
+  [ "$(sha256sum "$output" | awk 'NR == 1 {print tolower($1)}')" = "$expected_digest" ] || return 1
+}
+
+verify_once() {
+  rm -f "$temporary_dir"/install.sh "$temporary_dir"/vastora-center-install.tar.gz "$temporary_dir"/vastora-center-install.tar.gz.sha256
+  download_asset install.sh || return 1
+  download_asset vastora-center-install.tar.gz || return 1
+  download_asset vastora-center-install.tar.gz.sha256 || return 1
+  sh -n "$temporary_dir/install.sh" || return 1
+  (cd "$temporary_dir" && sha256sum --check vastora-center-install.tar.gz.sha256) || return 1
+  actual_version="$(tar -xOzf "$temporary_dir/vastora-center-install.tar.gz" ./release.env 2>/dev/null | awk -F= '$1 == "VASTORA_VERSION" {print $2; exit}')"
+  [ "$actual_version" = "$expected_version" ]
+}
+
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
+  if verify_once; then
+    echo "Verified Vastora $expected_version installer at $base_url."
+    exit 0
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "Installer endpoint has not selected $expected_version yet (attempt $attempt/$attempts)." >&2
+    sleep "$retry_delay"
+  fi
+  attempt=$((attempt + 1))
+done
+
+echo "Installer endpoint did not provide a complete verified $expected_version release: $base_url" >&2
+exit 1


### PR DESCRIPTION
## Summary
- route Center updates through activated immutable R2 releases
- verify release versions and SHA-256 digests before installation
- harden R2 stage/activate ordering and prevent stuck queued update state

## Validation
- `make deployment-check`
- `GOCACHE=/tmp/vastora-go-build-cache GOTOOLCHAIN=go1.26.6 go test ./internal/deployer ./internal/center`
- `shellcheck -S warning` on changed shell scripts
- `gitleaks detect --no-git --redact --source .`
- live read-only verification of the published 0.1.0-alpha.58 installer assets