### PR TITLE
fix: make release retries immutable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       release_sha: ${{ steps.retry.outputs.release_sha || steps.release.outputs.sha }}
       release_tag: ${{ steps.retry.outputs.release_tag || steps.release.outputs.tag_name }}
       release_version: ${{ steps.retry.outputs.release_version || steps.release.outputs.version }}
+      release_retry: ${{ steps.retry.outputs.release_retry || 'false' }}
     steps:
       - name: Create a release without updating the next release pull request
         id: release
@@ -62,6 +63,7 @@ jobs:
             echo "release_sha=$release_sha"
             echo "release_tag=$RELEASE_TAG"
             echo "release_version=${RELEASE_TAG#v}"
+            echo 'release_retry=true'
           } >> "$GITHUB_OUTPUT"
 
   publish:
@@ -86,6 +88,7 @@ jobs:
       R2_ENDPOINT: https://${{ vars.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
     steps:
       - name: Check out release commit
+        if: needs.prepare.outputs.release_retry != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.release_sha }}
@@ -112,9 +115,11 @@ jobs:
             --no-cli-pager
 
       - name: Set up Docker Buildx
+        if: needs.prepare.outputs.release_retry != 'true'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
 
       - name: Log in to GitHub Container Registry
+        if: needs.prepare.outputs.release_retry != 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.0.0
         with:
           registry: ghcr.io
@@ -122,6 +127,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build and push Center image
+        if: needs.prepare.outputs.release_retry != 'true'
         id: image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
@@ -141,6 +147,7 @@ jobs:
           sbom: true
 
       - name: Scan released Center image for x64 vulnerabilities
+        if: needs.prepare.outputs.release_retry != 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: linux/amd64
@@ -153,6 +160,7 @@ jobs:
           exit-code: "1"
 
       - name: Scan released Center image for ARM64 vulnerabilities
+        if: needs.prepare.outputs.release_retry != 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: linux/arm64
@@ -166,6 +174,7 @@ jobs:
           skip-setup-trivy: true
 
       - name: Publish verified Center image tags
+        if: needs.prepare.outputs.release_retry != 'true'
         env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
@@ -176,6 +185,7 @@ jobs:
             "$CENTER_IMAGE@$IMAGE_DIGEST"
 
       - name: Attest Center image
+        if: needs.prepare.outputs.release_retry != 'true'
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ghcr.io/petauron/vastora-center
@@ -183,12 +193,14 @@ jobs:
           push-to-registry: true
 
       - name: Package release installer
+        if: needs.prepare.outputs.release_retry != 'true'
         env:
           VASTORA_CENTER_IMAGE: ghcr.io/petauron/vastora-center@${{ steps.image.outputs.digest }}
           VASTORA_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: make center-install-bundle
 
       - name: Verify release assets and public image access
+        if: needs.prepare.outputs.release_retry != 'true'
         env:
           VASTORA_CENTER_IMAGE: ghcr.io/petauron/vastora-center@${{ steps.image.outputs.digest }}
         run: |
@@ -197,6 +209,7 @@ jobs:
           DOCKER_CONFIG="$anonymous_config" scripts/assert-image-platforms.sh "$VASTORA_CENTER_IMAGE"
 
       - name: Stage immutable installer assets in R2
+        if: needs.prepare.outputs.release_retry != 'true'
         env:
           RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: .release-tools/scripts/publish-installer-r2.sh stage --version "$RELEASE_VERSION" --bucket "$R2_BUCKET_NAME" --endpoint "$R2_ENDPOINT" --installer install.sh

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -20,6 +20,8 @@ require_in() {
 require_in "$prepare_job" '          skip-github-pull-request: true'
 require_in "$prepare_job" '      pull-requests: write'
 require_in "$prepare_job" '          release_sha="$(gh api "/repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG"'
+require_in "$prepare_job" "      release_retry: \${{ steps.retry.outputs.release_retry || 'false' }}"
+require_in "$prepare_job" "            echo 'release_retry=true'"
 require_in "$publish_job" '      artifact-metadata: write'
 require_in "$publish_job" '      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}'
 require_in "$publish_job" '      R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}'
@@ -47,6 +49,24 @@ require_in "$release_pr_job" '          skip-github-release: true'
 require_in "$release_pr_job" "            echo \"ci_id=\$(start_check 'CI / gate')\""
 require_in "$release_pr_job" "            echo \"codeql_id=\$(start_check 'CodeQL / gate')\""
 require_in "$release_pr_job" '        run: scripts/validate-release-metadata.sh "$BASE_SHA"'
+
+require_fresh_release_step() {
+  step_name="$1"
+  step_block="$(printf '%s\n' "$publish_job" | sed -n "/^      - name: $step_name$/,/^      - name:/p")"
+  require_in "$step_block" "        if: needs.prepare.outputs.release_retry != 'true'"
+}
+
+require_fresh_release_step 'Check out release commit'
+require_fresh_release_step 'Set up Docker Buildx'
+require_fresh_release_step 'Log in to GitHub Container Registry'
+require_fresh_release_step 'Build and push Center image'
+require_fresh_release_step 'Scan released Center image for x64 vulnerabilities'
+require_fresh_release_step 'Scan released Center image for ARM64 vulnerabilities'
+require_fresh_release_step 'Publish verified Center image tags'
+require_fresh_release_step 'Attest Center image'
+require_fresh_release_step 'Package release installer'
+require_fresh_release_step 'Verify release assets and public image access'
+require_fresh_release_step 'Stage immutable installer assets in R2'
 
 if printf '%s\n' "$prepare_job" | grep -Fq 'skip-github-release: true'; then
   echo 'Release creation must not update the next release pull request.' >&2


### PR DESCRIPTION
## Summary

- mark explicit existing-tag runs as release retries
- skip image rebuild, scanning, packaging, and R2 staging during retries
- reuse the already staged immutable manifest, then publish, activate, and verify it
- add workflow policy coverage for every fresh-release-only step

## Validation

- `make deployment-check`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

This prevents an existing version retry from rebuilding different bytes and colliding with the immutable R2 objects.