### PR TITLE
fix: recover NAT 1:1 gateways with split DNS

### DIFF
--- a/internal/deployer/config.go
+++ b/internal/deployer/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/petauron/vastora/internal/deployapi"
 	"github.com/petauron/vastora/internal/dockerruntime"
@@ -33,6 +34,10 @@ func centerAliasPrivateKeyPath(index int) string {
 type gatewayResolution struct {
 	hostname  string
 	addresses []netip.Addr
+}
+
+type gatewayDNSResolver interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
 }
 
 func normalizePublicURL(value string) (string, error) {
@@ -186,15 +191,29 @@ func renderHeadscalePolicy() []byte {
 }
 
 func gatewayBindAddresses(ctx context.Context, publicAddress, bindAddress string, endpoints ...string) ([]string, error) {
+	// The host resolver may intentionally return the local bind address for a
+	// split-DNS hostname. Validate the public side of a NAT 1:1 mapping through
+	// an independent resolver instead of rejecting that valid local view.
+	publicResolver := &net.Resolver{PreferGo: true, Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+		transport := "udp4"
+		if strings.HasPrefix(network, "tcp") {
+			transport = "tcp4"
+		}
+		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, transport, "1.1.1.1:53")
+	}}
+	return gatewayBindAddressesWithResolver(ctx, publicResolver, publicAddress, bindAddress, endpoints...)
+}
+
+func gatewayBindAddressesWithResolver(ctx context.Context, resolver gatewayDNSResolver, publicAddress, bindAddress string, endpoints ...string) ([]string, error) {
 	resolutions := make([]gatewayResolution, 0, len(endpoints))
 	for _, endpoint := range endpoints {
 		parsed, err := url.Parse(endpoint)
 		if err != nil || parsed.Hostname() == "" {
 			return nil, errors.New("deployer: gateway endpoint is invalid")
 		}
-		resolved, err := net.DefaultResolver.LookupNetIP(ctx, "ip", parsed.Hostname())
+		resolved, err := resolver.LookupNetIP(ctx, "ip", parsed.Hostname())
 		if err != nil {
-			return nil, fmt.Errorf("deployer: resolve gateway hostname %s: %w", parsed.Hostname(), err)
+			return nil, fmt.Errorf("deployer: resolve public gateway hostname %s: %w", parsed.Hostname(), err)
 		}
 		resolutions = append(resolutions, gatewayResolution{hostname: parsed.Hostname(), addresses: resolved})
 	}

--- a/internal/deployer/config_test.go
+++ b/internal/deployer/config_test.go
@@ -1,6 +1,7 @@
 package deployer
 
 import (
+	"context"
 	"net/netip"
 	"strings"
 	"testing"
@@ -111,6 +112,40 @@ func TestGatewayBindsConfirmedNATAddressOnlyWhenDNSMatches(t *testing.T) {
 	}
 	if _, err := selectMappedGatewayBindAddress([]gatewayResolution{{hostname: "wrong.example.com", addresses: []netip.Addr{netip.MustParseAddr("198.51.100.5")}}}, candidates, "203.0.113.20", "10.0.0.157"); err == nil || !strings.Contains(err.Error(), "does not resolve") {
 		t.Fatalf("non-local DNS address was accepted: %v", err)
+	}
+}
+
+type gatewayDNSResolverFunc func(context.Context, string, string) ([]netip.Addr, error)
+
+func (resolve gatewayDNSResolverFunc) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	return resolve(ctx, network, host)
+}
+
+func TestGatewayNATMappingUsesIndependentPublicDNS(t *testing.T) {
+	var resolvedHosts []string
+	resolver := gatewayDNSResolverFunc(func(_ context.Context, network, host string) ([]netip.Addr, error) {
+		if network != "ip" {
+			t.Fatalf("lookup network = %q, want ip", network)
+		}
+		resolvedHosts = append(resolvedHosts, host)
+		return []netip.Addr{netip.MustParseAddr("203.0.113.20")}, nil
+	})
+	addresses, err := gatewayBindAddressesWithResolver(
+		context.Background(),
+		resolver,
+		"203.0.113.20",
+		"10.0.0.157",
+		"https://headscale.example.com",
+		"https://old-headscale.example.com",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(addresses, ","), "10.0.0.157"; got != want {
+		t.Fatalf("gateway bind addresses = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(resolvedHosts, ","), "headscale.example.com,old-headscale.example.com"; got != want {
+		t.Fatalf("public DNS lookups = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate NAT 1:1 gateway hostnames through an independent public DNS view
- preserve strict matching against the confirmed public address while allowing local split DNS to return the private bind address
- cover the primary Headscale hostname and retained aliases in regression tests

## Validation

- `go test -race ./internal/...`
- `go vet ./internal/deployer ./internal/center`
- `staticcheck ./internal/deployer ./internal/center`
- verified the affected host returns its LAN bind address through system DNS and its confirmed public address through Cloudflare DNS
