### PR TITLE
fix(center): restore private gateway listeners

### DIFF
--- a/internal/center/co_located_agent_test.go
+++ b/internal/center/co_located_agent_test.go
@@ -2,9 +2,11 @@ package center
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/petauron/vastora/internal/gateway"
 	"github.com/petauron/vastora/internal/networking"
 )
 
@@ -78,11 +80,18 @@ func TestRestoredTailnetAddressQueuesPrivateGatewayListener(t *testing.T) {
 	defer store.Close()
 	ctx := context.Background()
 	node := enrollOrchestrationNode(t, store, "center-gateway", NodeCapabilities{Docker: true, Gateway: true}, []networking.Candidate{{Address: "10.0.0.10", Interface: "ens3", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.10", LANAddress: "10.0.0.10", EnabledKinds: []string{networking.KindLAN}})
+	configureBuiltinHeadscaleForTest(t, store)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO settings(key, value) VALUES(?, ?), (?, ?), (?, ?)`,
+		agentConnectionModeSetting, "headscale",
+		agentConnectURLSetting, "https://center.example.test",
+		setupGatewayBindingSetting, `{"publicAddress":"192.9.143.79","bindAddress":"10.0.0.10"}`); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.db.ExecContext(ctx, `UPDATE gateway_components SET status = 'ready', applied_generation = generation WHERE gateway_node_id = ?`, node.ID); err != nil {
 		t.Fatal(err)
 	}
-	var before int64
-	if err := store.db.QueryRowContext(ctx, `SELECT generation FROM gateway_components WHERE gateway_node_id = ?`, node.ID).Scan(&before); err != nil {
+	var beforeRevision int64
+	if err := store.db.QueryRowContext(ctx, `SELECT desired_revision FROM gateway_states WHERE gateway_node_id = ?`, node.ID).Scan(&beforeRevision); err != nil {
 		t.Fatal(err)
 	}
 	heartbeat := NodeHeartbeat{
@@ -95,12 +104,35 @@ func TestRestoredTailnetAddressQueuesPrivateGatewayListener(t *testing.T) {
 	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, heartbeat); err != nil {
 		t.Fatal(err)
 	}
-	var generation int64
-	var status, lastError string
-	if err := store.db.QueryRowContext(ctx, `SELECT generation, status, last_error FROM gateway_components WHERE gateway_node_id = ?`, node.ID).Scan(&generation, &status, &lastError); err != nil {
+	var revision int64
+	var encoded []byte
+	if err := store.db.QueryRowContext(ctx, `SELECT desired_revision, desired_json FROM gateway_states WHERE gateway_node_id = ?`, node.ID).Scan(&revision, &encoded); err != nil {
 		t.Fatal(err)
 	}
-	if generation != before+1 || status != "failed" || lastError != "tailnet address became available; queued private listener reconcile" {
-		t.Fatalf("restored tailnet reconcile = generation %d status %q error %q", generation, status, lastError)
+	if revision != beforeRevision+1 {
+		t.Fatalf("restored tailnet desired revision = %d, want %d", revision, beforeRevision+1)
+	}
+	var desired gateway.DesiredState
+	if err := json.Unmarshal(encoded, &desired); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, listener := range desired.Listeners {
+		if listener.Kind == "headscale" && listener.Address == "100.64.0.1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("restored tailnet desired state is missing its private listener: %#v", desired)
+	}
+	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, heartbeat); err != nil {
+		t.Fatal(err)
+	}
+	var unchanged int64
+	if err := store.db.QueryRowContext(ctx, `SELECT desired_revision FROM gateway_states WHERE gateway_node_id = ?`, node.ID).Scan(&unchanged); err != nil {
+		t.Fatal(err)
+	}
+	if unchanged != revision {
+		t.Fatalf("matching private listener was queued again: revision %d to %d", revision, unchanged)
 	}
 }

--- a/internal/center/store_agent.go
+++ b/internal/center/store_agent.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/petauron/vastora/internal/gateway"
 	"github.com/petauron/vastora/internal/networking"
 	"github.com/petauron/vastora/internal/platform"
 )
@@ -349,10 +350,6 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 	if err := tx.QueryRowContext(ctx, `SELECT runtime_generation FROM agents WHERE id = ?`, id).Scan(&previousRuntimeGeneration); err != nil {
 		return fmt.Errorf("center: read Agent runtime generation: %w", err)
 	}
-	var previousHeadscaleAddresses int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_network_candidates WHERE agent_id = ? AND kind = ?`, id, networking.KindHeadscale).Scan(&previousHeadscaleAddresses); err != nil {
-		return fmt.Errorf("center: inspect previous Agent tailnet address: %w", err)
-	}
 	if _, err := tx.ExecContext(ctx, `UPDATE agents SET version = ?, applied_installations = ?, roles_json = ?, capabilities_json = ?, gateway_healthy = ?, runtime_generation = CASE WHEN runtime_generation < ? THEN ? ELSE runtime_generation END, tailscale_ownership = ?, last_seen_at = ? WHERE id = ?`, strings.TrimSpace(heartbeat.Version), heartbeat.AppliedInstallations, rolesJSON, capabilitiesJSON, heartbeat.GatewayHealthy, heartbeat.ApplicationRuntimeGeneration, heartbeat.ApplicationRuntimeGeneration, heartbeat.TailscaleOwnership, now.Format(time.RFC3339Nano), id); err != nil {
 		return fmt.Errorf("center: record agent heartbeat: %w", err)
 	}
@@ -395,18 +392,13 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 			}
 		}
 	}
-	if heartbeat.Capabilities.Gateway && previousHeadscaleAddresses == 0 && reportedHeadscaleAddress {
-		result, err := tx.ExecContext(ctx, `UPDATE gateway_components SET generation = generation + 1, status = 'failed', lease_expires_at = '', last_error = 'tailnet address became available; queued private listener reconcile', updated_at = ? WHERE gateway_node_id = ? AND desired_status = 'running' AND status = 'ready'`, now.Format(time.RFC3339Nano), id)
+	if heartbeat.Capabilities.Gateway && reportedHeadscaleAddress {
+		needsPrivateListener, err := gatewayStateNeedsReportedHeadscaleListener(ctx, tx, id, heartbeat.NetworkCandidates)
 		if err != nil {
-			return fmt.Errorf("center: queue restored private gateway listener: %w", err)
+			return err
 		}
-		changed, _ := result.RowsAffected()
-		if changed != 0 {
-			var generation int64
-			if err := tx.QueryRowContext(ctx, `SELECT generation FROM gateway_components WHERE gateway_node_id = ?`, id).Scan(&generation); err != nil {
-				return err
-			}
-			if err := s.recordTaskEvent(ctx, tx, gatewayComponentTaskID(id, generation), id, "gateway.component.apply", generation, "queued", "tailnet address became available; queued private listener reconcile"); err != nil {
+		if needsPrivateListener {
+			if err := s.queueGatewayState(ctx, tx, id, now); err != nil {
 				return err
 			}
 		}
@@ -421,6 +413,38 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 		return fmt.Errorf("center: record publication cleanup state: %w", err)
 	}
 	return nil
+}
+
+func gatewayStateNeedsReportedHeadscaleListener(ctx context.Context, tx *sql.Tx, agentID string, candidates []networking.Candidate) (bool, error) {
+	reported := make(map[string]struct{})
+	for _, candidate := range candidates {
+		if candidate.Kind == networking.KindHeadscale {
+			reported[candidate.Address] = struct{}{}
+		}
+	}
+	if len(reported) == 0 {
+		return false, nil
+	}
+	var encoded []byte
+	err := tx.QueryRowContext(ctx, `SELECT desired_json FROM gateway_states WHERE gateway_node_id = ?`, agentID).Scan(&encoded)
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("center: inspect private gateway listener: %w", err)
+	}
+	var desired gateway.DesiredState
+	if err := json.Unmarshal(encoded, &desired); err != nil {
+		return false, errors.New("center: stored gateway desired state is invalid")
+	}
+	for _, listener := range desired.Listeners {
+		if listener.Kind == "headscale" {
+			if _, current := reported[listener.Address]; current {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
 }
 
 func invalidateUnusableNetworkProfile(ctx context.Context, tx *sql.Tx, agentID string) error {


### PR DESCRIPTION
## Summary
- detect when a gateway Agent reports a Headscale address that is absent from the current desired gateway listeners
- queue a full gateway desired-state reconcile so immutable Caddy port bindings are recreated with the private listener
- keep heartbeat reconciliation idempotent once the listener matches

## Validation
- `go test -race ./internal/center -run 'TestRestoredTailnetAddressQueuesPrivateGatewayListener|TestReconcileBuiltinHeadscaleAppliesAnOlderRuntimeOnce'`
- `go test -race ./internal/...`
- `go vet ./internal/center ./internal/agent`

Follow-up runtime fix after alpha.62 restored NAT/split-DNS update reconciliation but exposed a stale desired-state edge case.