### PR TITLE
fix(gateway): recover full runtime state

### DIFF
--- a/internal/agent/gateway_provisioner.go
+++ b/internal/agent/gateway_provisioner.go
@@ -120,15 +120,15 @@ func (provisioner DockerGatewayProvisioner) reconcile(ctx context.Context, desir
 		}
 	}
 	matchesRuntime := existing != nil && existing.Container.HostConfig != nil && existing.Container.HostConfig.NetworkMode == container.NetworkMode(dockerruntime.NetworkName)
-	matchesPorts := desired == nil || existing != nil && reflect.DeepEqual(existing.Container.Config.ExposedPorts, exposedPorts) && reflect.DeepEqual(existing.Container.HostConfig.PortBindings, portBindings)
+	matchesPorts := desired == nil || existing != nil && caddyPortsMatch(existing.Container.Config, existing.Container.HostConfig, exposedPorts, portBindings)
 	if existing != nil && matchesRuntime && matchesPorts && caddySharesAdminPath(existing.Container.HostConfig, settings.AdminSocketPath) && (protectedSystemGateway || existing.Container.Config.Image == settings.Image) {
 		if existing.Container.State != nil && existing.Container.State.Running {
-			return nil
+			return waitForCaddyAdminSocket(ctx, settings.AdminSocketPath)
 		}
 		if _, err := docker.ContainerStart(ctx, existing.Container.ID, client.ContainerStartOptions{}); err != nil {
 			return fmt.Errorf("agent: start existing Caddy container: %w", err)
 		}
-		return nil
+		return waitForCaddyAdminSocket(ctx, settings.AdminSocketPath)
 	}
 	pull, err := docker.ImagePull(ctx, settings.Image, client.ImagePullOptions{})
 	if err != nil {
@@ -201,7 +201,46 @@ func (provisioner DockerGatewayProvisioner) reconcile(ctx context.Context, desir
 	if _, err := docker.ContainerStart(ctx, created.ID, client.ContainerStartOptions{}); err != nil {
 		return fmt.Errorf("agent: start Caddy container: %w", err)
 	}
-	return nil
+	return waitForCaddyAdminSocket(ctx, settings.AdminSocketPath)
+}
+
+func caddyPortsMatch(config *container.Config, host *container.HostConfig, expectedExposed dockernetwork.PortSet, expectedBindings dockernetwork.PortMap) bool {
+	if config == nil || host == nil || !reflect.DeepEqual(host.PortBindings, expectedBindings) {
+		return false
+	}
+	for port := range expectedExposed {
+		if _, exists := config.ExposedPorts[port]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func waitForCaddyAdminSocket(ctx context.Context, socketPath string) error {
+	if socketPath == "" {
+		return nil
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		info, err := os.Lstat(socketPath)
+		if err == nil {
+			if info.Mode()&os.ModeSocket == 0 {
+				return errors.New("agent: Caddy Admin socket path is occupied by a non-socket file")
+			}
+			return nil
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("agent: inspect Caddy Admin socket: %w", err)
+		}
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("agent: wait for Caddy Admin socket: %w", waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func gatewayMounts(settings DockerGatewayProvisioner) []mount.Mount {

--- a/internal/agent/gateway_test.go
+++ b/internal/agent/gateway_test.go
@@ -12,13 +12,19 @@ import (
 	"errors"
 	"io"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
+	dockernetwork "github.com/moby/moby/api/types/network"
 	"github.com/petauron/vastora/internal/gateway"
 )
 
@@ -437,6 +443,39 @@ func TestGatewayProvisionerSharesUnixAdminSocketWithHost(t *testing.T) {
 	}
 	if _, err := (DockerGatewayProvisioner{AdminSocketPath: "relative.sock"}).settings(); err == nil {
 		t.Fatal("relative Admin socket path was accepted")
+	}
+}
+
+func TestCaddyPortsMatchAllowsImageExposedPorts(t *testing.T) {
+	https := dockernetwork.MustParsePort("443/tcp")
+	admin := dockernetwork.MustParsePort("2019/tcp")
+	expectedExposed := dockernetwork.PortSet{https: {}}
+	expectedBindings := dockernetwork.PortMap{https: []dockernetwork.PortBinding{{HostIP: netip.MustParseAddr("100.64.0.1"), HostPort: "443"}}}
+	config := &container.Config{ExposedPorts: dockernetwork.PortSet{https: {}, admin: {}}}
+	host := &container.HostConfig{PortBindings: expectedBindings}
+	if !caddyPortsMatch(config, host, expectedExposed, expectedBindings) {
+		t.Fatal("image-declared Admin port forced an unnecessary Caddy replacement")
+	}
+	host.PortBindings = dockernetwork.PortMap{https: []dockernetwork.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "443"}}}
+	if caddyPortsMatch(config, host, expectedExposed, expectedBindings) {
+		t.Fatal("changed host port binding was treated as current")
+	}
+}
+
+func TestWaitForCaddyAdminSocket(t *testing.T) {
+	directory, err := os.MkdirTemp("/tmp", "vastora-caddy-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(directory) })
+	path := filepath.Join(directory, "admin.sock")
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	if err := waitForCaddyAdminSocket(context.Background(), path); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/center/co_located_agent_test.go
+++ b/internal/center/co_located_agent_test.go
@@ -136,3 +136,86 @@ func TestRestoredTailnetAddressQueuesPrivateGatewayListener(t *testing.T) {
 		t.Fatalf("matching private listener was queued again: revision %d to %d", revision, unchanged)
 	}
 }
+
+func TestUnhealthyGatewayRequeuesFullStateWithoutComponentRace(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	node := enrollOrchestrationNode(t, store, "gateway-recovery", NodeCapabilities{Docker: true, Gateway: true}, []networking.Candidate{{Address: "10.0.0.10", Interface: "ens3", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.10", LANAddress: "10.0.0.10", EnabledKinds: []string{networking.KindLAN}})
+	if _, err := store.db.ExecContext(ctx, `UPDATE gateway_components SET status = 'ready', applied_generation = generation WHERE gateway_node_id = ?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	var generation, revision int64
+	if err := store.db.QueryRowContext(ctx, `SELECT generation FROM gateway_components WHERE gateway_node_id = ?`, node.ID).Scan(&generation); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT desired_revision FROM gateway_states WHERE gateway_node_id = ?`, node.ID).Scan(&revision); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE gateway_states SET applied_revision = desired_revision, status = 'ready' WHERE gateway_node_id = ?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	heartbeat := NodeHeartbeat{
+		Version: "test", Roles: []string{"worker", "gateway"}, Capabilities: NodeCapabilities{Docker: true, Gateway: true}, GatewayHealthy: false,
+		NetworkCandidates: []networking.Candidate{{Address: "10.0.0.10", Interface: "ens3", Kind: networking.KindLAN}},
+	}
+	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, heartbeat); err != nil {
+		t.Fatal(err)
+	}
+	var nextGeneration, nextRevision int64
+	var componentStatus, stateStatus string
+	if err := store.db.QueryRowContext(ctx, `SELECT generation, status FROM gateway_components WHERE gateway_node_id = ?`, node.ID).Scan(&nextGeneration, &componentStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT desired_revision, status FROM gateway_states WHERE gateway_node_id = ?`, node.ID).Scan(&nextRevision, &stateStatus); err != nil {
+		t.Fatal(err)
+	}
+	if nextGeneration != generation || componentStatus != "ready" {
+		t.Fatalf("unhealthy gateway component changed from generation %d to %d with status %q", generation, nextGeneration, componentStatus)
+	}
+	if nextRevision != revision+1 || stateStatus != "pending" {
+		t.Fatalf("unhealthy gateway state = revision %d status %q, want revision %d pending", nextRevision, stateStatus, revision+1)
+	}
+	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, heartbeat); err != nil {
+		t.Fatal(err)
+	}
+	var unchangedRevision int64
+	if err := store.db.QueryRowContext(ctx, `SELECT desired_revision FROM gateway_states WHERE gateway_node_id = ?`, node.ID).Scan(&unchangedRevision); err != nil {
+		t.Fatal(err)
+	}
+	if unchangedRevision != nextRevision {
+		t.Fatalf("pending gateway recovery queued again: revision %d to %d", nextRevision, unchangedRevision)
+	}
+}
+
+func TestUnhealthyGatewayWithoutDesiredStateRequeuesComponent(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	node := enrollOrchestrationNode(t, store, "gateway-bootstrap-recovery", NodeCapabilities{Docker: true, Gateway: true}, []networking.Candidate{{Address: "10.0.0.10", Interface: "ens3", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.10", LANAddress: "10.0.0.10", EnabledKinds: []string{networking.KindLAN}})
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM gateway_states WHERE gateway_node_id = ?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE gateway_components SET status = 'ready', applied_generation = generation WHERE gateway_node_id = ?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	var generation int64
+	if err := store.db.QueryRowContext(ctx, `SELECT generation FROM gateway_components WHERE gateway_node_id = ?`, node.ID).Scan(&generation); err != nil {
+		t.Fatal(err)
+	}
+	heartbeat := NodeHeartbeat{
+		Version: "test", Roles: []string{"worker", "gateway"}, Capabilities: NodeCapabilities{Docker: true, Gateway: true}, GatewayHealthy: false,
+		NetworkCandidates: []networking.Candidate{{Address: "10.0.0.10", Interface: "ens3", Kind: networking.KindLAN}},
+	}
+	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, heartbeat); err != nil {
+		t.Fatal(err)
+	}
+	var nextGeneration int64
+	var status, lastError string
+	if err := store.db.QueryRowContext(ctx, `SELECT generation, status, last_error FROM gateway_components WHERE gateway_node_id = ?`, node.ID).Scan(&nextGeneration, &status, &lastError); err != nil {
+		t.Fatal(err)
+	}
+	if nextGeneration != generation+1 || status != "failed" || lastError != "gateway health check failed; queued for reconcile" {
+		t.Fatalf("unhealthy gateway bootstrap = generation %d status %q error %q", nextGeneration, status, lastError)
+	}
+}

--- a/internal/center/store_agent.go
+++ b/internal/center/store_agent.go
@@ -377,19 +377,8 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 		}
 	}
 	if heartbeat.Capabilities.Gateway && !heartbeat.GatewayHealthy {
-		result, err := tx.ExecContext(ctx, `UPDATE gateway_components SET generation = generation + 1, status = 'failed', lease_expires_at = '', last_error = 'gateway health check failed; queued for reconcile', updated_at = ? WHERE gateway_node_id = ? AND desired_status = 'running' AND status = 'ready'`, now.Format(time.RFC3339Nano), id)
-		if err != nil {
-			return fmt.Errorf("center: queue unhealthy gateway reconcile: %w", err)
-		}
-		changed, _ := result.RowsAffected()
-		if changed != 0 {
-			var generation int64
-			if err := tx.QueryRowContext(ctx, `SELECT generation FROM gateway_components WHERE gateway_node_id = ?`, id).Scan(&generation); err != nil {
-				return err
-			}
-			if err := s.recordTaskEvent(ctx, tx, gatewayComponentTaskID(id, generation), id, "gateway.component.apply", generation, "queued", "gateway health check failed; queued for reconcile"); err != nil {
-				return err
-			}
+		if err := s.queueUnhealthyGatewayReconcile(ctx, tx, id, now); err != nil {
+			return err
 		}
 	}
 	if heartbeat.Capabilities.Gateway && reportedHeadscaleAddress {
@@ -413,6 +402,37 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 		return fmt.Errorf("center: record publication cleanup state: %w", err)
 	}
 	return nil
+}
+
+func (s *Store) queueUnhealthyGatewayReconcile(ctx context.Context, tx *sql.Tx, agentID string, now time.Time) error {
+	var desiredRevision, appliedRevision int64
+	var stateStatus string
+	err := tx.QueryRowContext(ctx, `SELECT desired_revision, applied_revision, status FROM gateway_states WHERE gateway_node_id = ?`, agentID).Scan(&desiredRevision, &appliedRevision, &stateStatus)
+	if err == nil {
+		if desiredRevision > appliedRevision || stateStatus != "ready" {
+			return nil
+		}
+		if err := s.queueGatewayState(ctx, tx, agentID, now); err != nil {
+			return fmt.Errorf("center: queue unhealthy gateway state: %w", err)
+		}
+		return nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("center: inspect unhealthy gateway state: %w", err)
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE gateway_components SET generation = generation + 1, status = 'failed', lease_expires_at = '', last_error = 'gateway health check failed; queued for reconcile', updated_at = ? WHERE gateway_node_id = ? AND desired_status = 'running' AND status = 'ready'`, now.Format(time.RFC3339Nano), agentID)
+	if err != nil {
+		return fmt.Errorf("center: queue unhealthy gateway component: %w", err)
+	}
+	changed, _ := result.RowsAffected()
+	if changed == 0 {
+		return nil
+	}
+	var generation int64
+	if err := tx.QueryRowContext(ctx, `SELECT generation FROM gateway_components WHERE gateway_node_id = ?`, agentID).Scan(&generation); err != nil {
+		return err
+	}
+	return s.recordTaskEvent(ctx, tx, gatewayComponentTaskID(agentID, generation), agentID, "gateway.component.apply", generation, "queued", "gateway health check failed; queued for reconcile")
 }
 
 func gatewayStateNeedsReportedHeadscaleListener(ctx context.Context, tx *sql.Tx, agentID string, candidates []networking.Candidate) (bool, error) {


### PR DESCRIPTION
## Summary
- reapply the full desired gateway state when an already-configured gateway reports unhealthy instead of repeatedly recreating an empty Caddy component
- leave an already pending or applying gateway state alone so component tasks cannot starve or race route reconciliation
- compare immutable Docker host bindings while allowing image-declared exposed ports such as Caddy's `2019/tcp`
- wait for the Caddy Admin Unix socket before loading the full configuration

## Runtime evidence
On production-center, the desired state already contained the Headscale, public, and loopback listeners. Repeated component reconciliation replaced Caddy without bindings, while route reconciliation then replaced it again because the image's extra exposed port made the runtime appear stale. This prevented the Admin socket from staying available long enough to load the desired configuration.

## Validation
- targeted race tests for unhealthy gateway recovery, idempotence, bootstrap fallback, Docker port matching, and Admin socket readiness
- `go test -race ./internal/...`
- `go vet ./internal/agent ./internal/center`