### PR TITLE
feat: show update progress and fix Cloudflare authorization

### DIFF
--- a/internal/center/cloudflare_oauth.go
+++ b/internal/center/cloudflare_oauth.go
@@ -568,7 +568,11 @@ func (s *Store) exchangeCloudflareCode(ctx context.Context, code, verifier strin
 	if err != nil {
 		return cloudflareOAuthToken{}, err
 	}
-	return s.normalizeCloudflareToken(response, "")
+	token, err := s.normalizeCloudflareToken(response, "")
+	if err == nil && strings.TrimSpace(token.Scope) == "" {
+		token.Scope = cloudflareOAuthScopes
+	}
+	return token, err
 }
 
 func (s *Store) refreshCloudflareToken(ctx context.Context, previous cloudflareOAuthToken) (cloudflareOAuthToken, error) {

--- a/internal/center/cloudflare_oauth_test.go
+++ b/internal/center/cloudflare_oauth_test.go
@@ -58,6 +58,33 @@ func TestCloudflareOAuthStartUsesPKCEWithoutExposingSecrets(t *testing.T) {
 	}
 }
 
+func TestCloudflareOAuthExchangePreservesRequestedScopeWhenOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if err := request.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if request.Form.Get("grant_type") != "authorization_code" || request.Form.Get("code") != "authorization-code" || request.Form.Get("code_verifier") != "pkce-verifier" {
+			t.Fatalf("unexpected token exchange request: %#v", request.Form)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"access_token":"access-secret","refresh_token":"refresh-secret","token_type":"bearer","expires_in":3600}`))
+	}))
+	defer server.Close()
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	store.cloudflareOAuth = cloudflareOAuthConfig{ClientID: "oauth-client", TokenURL: server.URL, HTTPClient: server.Client()}
+	token, err := store.exchangeCloudflareCode(context.Background(), "authorization-code", "pkce-verifier")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token.Scope != cloudflareOAuthScopes {
+		t.Fatalf("OAuth exchange scope = %q, want %q", token.Scope, cloudflareOAuthScopes)
+	}
+}
+
 func TestCloudflareOAuthRefreshPreservesGrantedScopeWhenOmitted(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if err := request.ParseForm(); err != nil {

--- a/web/src/components/ui/progress.tsx
+++ b/web/src/components/ui/progress.tsx
@@ -1,0 +1,81 @@
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  children,
+  value,
+  ...props
+}: ProgressPrimitive.Root.Props) {
+  return (
+    <ProgressPrimitive.Root
+      value={value}
+      data-slot="progress"
+      className={cn("flex flex-wrap gap-3", className)}
+      {...props}
+    >
+      {children}
+      <ProgressTrack>
+        <ProgressIndicator />
+      </ProgressTrack>
+    </ProgressPrimitive.Root>
+  )
+}
+
+function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props) {
+  return (
+    <ProgressPrimitive.Track
+      className={cn(
+        "relative flex h-1 w-full items-center overflow-x-hidden rounded-full bg-muted",
+        className
+      )}
+      data-slot="progress-track"
+      {...props}
+    />
+  )
+}
+
+function ProgressIndicator({
+  className,
+  ...props
+}: ProgressPrimitive.Indicator.Props) {
+  return (
+    <ProgressPrimitive.Indicator
+      data-slot="progress-indicator"
+      className={cn("h-full bg-primary transition-[width]", className)}
+      {...props}
+    />
+  )
+}
+
+function ProgressLabel({ className, ...props }: ProgressPrimitive.Label.Props) {
+  return (
+    <ProgressPrimitive.Label
+      className={cn("text-sm font-medium", className)}
+      data-slot="progress-label"
+      {...props}
+    />
+  )
+}
+
+function ProgressValue({ className, ...props }: ProgressPrimitive.Value.Props) {
+  return (
+    <ProgressPrimitive.Value
+      className={cn(
+        "ml-auto text-sm text-muted-foreground tabular-nums",
+        className
+      )}
+      data-slot="progress-value"
+      {...props}
+    />
+  )
+}
+
+export {
+  Progress,
+  ProgressTrack,
+  ProgressIndicator,
+  ProgressLabel,
+  ProgressValue,
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -144,12 +144,29 @@
     }
 }
 
+@keyframes progress-indeterminate {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(250%);
+  }
+}
+
+[data-slot="progress-indicator"][data-indeterminate] {
+  width: 40%;
+  animation: progress-indeterminate 1.4s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+  }
+  [data-slot="progress-indicator"][data-indeterminate] {
+    transform: translateX(75%);
   }
 }
 

--- a/web/src/views/CenterUpdateCard.tsx
+++ b/web/src/views/CenterUpdateCard.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { FieldError } from "@/components/ui/field";
+import { Progress, ProgressLabel } from "@/components/ui/progress";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -18,6 +19,9 @@ export function CenterUpdateCard({ language, onRefresh, onStatusChange, status }
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const running = status.state === "queued" || status.state === "applying";
+  const updateStage = status.state === "queued"
+    ? copy(language, "等待主机更新服务", "Waiting for the host update service")
+    : copy(language, "正在下载、校验与安装", "Downloading, verifying, and installing");
 
   useEffect(() => {
     if (!running) return;
@@ -55,7 +59,7 @@ export function CenterUpdateCard({ language, onRefresh, onStatusChange, status }
       <CardHeader><CardTitle className="flex items-center gap-2"><CircleArrowUpIcon />{copy(language, "Center 更新", "Center update")}</CardTitle><CardDescription>{copy(language, "自动检查官方完整版本，并沿用安装时的安全升级流程。", "Checks complete official releases and reuses the verified installation upgrade flow.")}</CardDescription><CardAction>{running ? <Spinner /> : status.updateAvailable ? <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">{copy(language, "有新版本", "Update available")}</span> : <CircleCheckIcon className="size-5 text-success" />}</CardAction></CardHeader>
       <CardContent className="flex flex-col gap-4">
         <dl className="grid gap-4 text-sm sm:grid-cols-2"><div><dt className="text-muted-foreground">{copy(language, "当前版本", "Current version")}</dt><dd className="mt-1 font-medium">{status.currentVersion}</dd></div><div><dt className="text-muted-foreground">{copy(language, "官方版本", "Official version")}</dt><dd className="mt-1 font-medium">{status.latestVersion || "—"}</dd></div></dl>
-        {running ? <Alert><Spinner /><AlertTitle>{copy(language, `正在更新到 ${status.targetVersion || status.latestVersion}`, `Updating to ${status.targetVersion || status.latestVersion}`)}</AlertTitle><AlertDescription>{copy(language, "Center 会短暂重启，本页会自动重新连接。请不要关闭服务器或 Docker。", "Center briefly restarts and this page reconnects automatically. Do not stop the server or Docker.")}</AlertDescription></Alert> : null}
+        {running ? <Alert><Spinner /><AlertTitle>{copy(language, `正在更新到 ${status.targetVersion || status.latestVersion}`, `Updating to ${status.targetVersion || status.latestVersion}`)}</AlertTitle><AlertDescription className="flex flex-col gap-3"><span>{copy(language, "Center 会短暂重启，本页会自动重新连接。请不要关闭服务器或 Docker。", "Center briefly restarts and this page reconnects automatically. Do not stop the server or Docker.")}</span><Progress value={null}><ProgressLabel>{updateStage}</ProgressLabel><span aria-hidden="true" className="ml-auto text-xs text-muted-foreground">{copy(language, "进行中", "In progress")}</span></Progress></AlertDescription></Alert> : null}
         {status.state === "succeeded" && !status.updateAvailable ? <Alert><ShieldCheckIcon /><AlertTitle>{copy(language, "更新完成", "Update complete")}</AlertTitle><AlertDescription>{copy(language, `Center 已安全更新到 ${status.currentVersion}。`, `Center was safely updated to ${status.currentVersion}.`)}</AlertDescription></Alert> : null}
         {status.state === "failed" ? <FieldError role="alert">{copy(language, "更新没有完成。系统保留了可诊断状态，请重试；若仍失败，请下载诊断报告。", "The update did not finish. Diagnostic state was preserved; retry, then download diagnostics if it still fails.")}</FieldError> : null}
         {status.error ? <FieldError role="alert">{copy(language, "暂时无法检查官方版本，请稍后重试。", "The official release cannot be checked right now. Try again shortly.")}</FieldError> : null}

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -1452,6 +1452,18 @@ describe("network and app views", () => {
     expect(onStatusChange).not.toHaveBeenCalled();
   });
 
+  it("shows an accessible indeterminate progress bar while Center updates", () => {
+    const status = { ...dashboard().centerUpdate, latestVersion: "0.1.0-alpha.68", updateAvailable: true, state: "applying" as const, targetVersion: "0.1.0-alpha.68" };
+    vi.spyOn(api, "centerUpdate").mockImplementation(() => new Promise(() => undefined));
+    const container = render(<CenterUpdateCard language="zh-CN" onRefresh={async () => undefined} onStatusChange={() => undefined} status={status} />);
+    const progress = container.querySelector('[role="progressbar"]');
+    expect(progress?.getAttribute("aria-valuenow")).toBeNull();
+    expect(progress?.getAttribute("data-indeterminate")).not.toBeNull();
+    expect(progress?.getAttribute("aria-labelledby")).not.toBeNull();
+    expect(container.textContent).toContain("正在下载、校验与安装");
+    expect(container.textContent).toContain("进行中");
+  });
+
   it("bypasses the official release cache when update checking is requested", async () => {
     const status = { ...dashboard().centerUpdate, latestVersion: "0.1.0-alpha.59", updateAvailable: true };
     const refreshed = { ...status, latestVersion: "0.1.0-alpha.60" };


### PR DESCRIPTION
## Summary
- show an accessible indeterminate progress bar while Center updates
- preserve the requested Cloudflare OAuth scopes when the initial token response omits an unchanged `scope`
- add regression coverage for both behaviors

## Validation
- `make web-check` (93 tests, lint, production build)
- `make web-security-check` (0 vulnerabilities)
- `go test -race ./internal/center`
- `go vet ./internal/center`
- `staticcheck ./internal/center`
- `govulncheck ./internal/center` (0 called vulnerabilities)
- rendered `/settings` smoke test and update-check interaction with no console warnings/errors

## Local platform note
The repository-wide Go check reaches the known macOS-only failure in two Linux Agent update tests (`TestAgentUpdateVerifiesAndKeepsRollbackBinary` and `TestAgentUpdateRestoresPreviousBinaryWhenRestartFails`). The changed Center package passes with the race detector; the required Linux CI gate remains authoritative.