### PR TITLE
fix(upgrade): migrate legacy runtime network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ deployment-check:
 	sh -n scripts/assert-image-platforms.sh
 	sh -n scripts/check-runtime-image-platforms.sh
 	sh -n scripts/test-center-install.sh
+	sh -n scripts/test-runtime-network.sh
 	sh -n scripts/test-center-uninstall.sh
 	sh -n scripts/test-center-update.sh
 	sh -n scripts/test-release-metadata.sh
@@ -52,6 +53,7 @@ deployment-check:
 	scripts/publish-installer-r2.sh --help >/dev/null
 	scripts/verify-installer-release.sh --help >/dev/null
 	scripts/test-center-install.sh
+	scripts/test-runtime-network.sh
 	scripts/test-center-uninstall.sh
 	scripts/test-center-update.sh
 	scripts/test-release-metadata.sh

--- a/deploy/center/compose.yaml
+++ b/deploy/center/compose.yaml
@@ -4,6 +4,9 @@ services:
   center:
     image: ${VASTORA_CENTER_IMAGE:?set VASTORA_CENTER_IMAGE to a pinned Center image}
     restart: unless-stopped
+    labels:
+      io.vastora.managed: "true"
+      io.vastora.component: center
     command:
       - center
       - serve
@@ -37,6 +40,9 @@ services:
   deployer:
     image: ${VASTORA_CENTER_IMAGE:?set VASTORA_CENTER_IMAGE to a pinned Center image}
     restart: unless-stopped
+    labels:
+      io.vastora.managed: "true"
+      io.vastora.component: deployer
     user: "0:0"
     command:
       - deployer

--- a/deploy/center/runtime-network.sh
+++ b/deploy/center/runtime-network.sh
@@ -2,45 +2,255 @@
 
 vastora_runtime_network="vastora-runtime"
 
-validate_vastora_runtime_network() {
-  driver="$(docker network inspect --format '{{.Driver}}' "$vastora_runtime_network" 2>/dev/null || true)"
-  managed="$(docker network inspect --format '{{ index .Labels "io.vastora.managed" }}' "$vastora_runtime_network" 2>/dev/null || true)"
-  component="$(docker network inspect --format '{{ index .Labels "io.vastora.component" }}' "$vastora_runtime_network" 2>/dev/null || true)"
-  identity="$(docker network inspect --format '{{ index .Labels "io.vastora.network" }}' "$vastora_runtime_network" 2>/dev/null || true)"
-  if [ "$driver" != "bridge" ] || [ "$managed" != "true" ] || [ "$component" != "runtime-network" ] || [ "$identity" != "$vastora_runtime_network" ]; then
-    echo "Refusing to use Docker network $vastora_runtime_network because its driver or ownership labels do not match Vastora." >&2
-    return 1
-  fi
-  container_ids="$(docker network inspect --format '{{range $id, $_ := .Containers}}{{$id}}{{"\n"}}{{end}}' "$vastora_runtime_network" 2>/dev/null || true)"
-  for container_id in $container_ids; do
-    container_managed="$(docker container inspect --format '{{ index .Config.Labels "io.vastora.managed" }}' "$container_id" 2>/dev/null || true)"
-    container_component="$(docker container inspect --format '{{ index .Config.Labels "io.vastora.component" }}' "$container_id" 2>/dev/null || true)"
-    if [ "$container_managed" != "true" ] || [ -z "$container_component" ]; then
-      echo "Refusing to use Docker network $vastora_runtime_network because container $container_id is not owned by Vastora." >&2
-      return 1
+runtime_network_driver() {
+  docker network inspect --format '{{.Driver}}' "$1" 2>/dev/null || true
+}
+
+runtime_network_label() {
+  docker network inspect --format "{{ index .Labels \"$2\" }}" "$1" 2>/dev/null || true
+}
+
+runtime_network_container_ids() {
+  docker network inspect --format '{{range $id, $_ := .Containers}}{{$id}}{{"\n"}}{{end}}' "$1" 2>/dev/null || true
+}
+
+runtime_network_has_current_identity() {
+  [ "$(runtime_network_driver "$vastora_runtime_network")" = "bridge" ] &&
+    [ "$(runtime_network_label "$vastora_runtime_network" io.vastora.managed)" = "true" ] &&
+    [ "$(runtime_network_label "$vastora_runtime_network" io.vastora.component)" = "runtime-network" ] &&
+    [ "$(runtime_network_label "$vastora_runtime_network" io.vastora.network)" = "$vastora_runtime_network" ]
+}
+
+container_has_vastora_ownership() {
+  [ "$(docker container inspect --format '{{ index .Config.Labels "io.vastora.managed" }}' "$1" 2>/dev/null || true)" = "true" ] &&
+    [ -n "$(docker container inspect --format '{{ index .Config.Labels "io.vastora.component" }}' "$1" 2>/dev/null || true)" ]
+}
+
+container_is_legacy_center_service() {
+  vrn_container_id="$1"
+  vrn_install_dir="$2"
+  vrn_project="$(docker container inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$vrn_container_id" 2>/dev/null || true)"
+  vrn_service="$(docker container inspect --format '{{ index .Config.Labels "com.docker.compose.service" }}' "$vrn_container_id" 2>/dev/null || true)"
+  vrn_working_dir="$(docker container inspect --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' "$vrn_container_id" 2>/dev/null || true)"
+  vrn_config_files="$(docker container inspect --format '{{ index .Config.Labels "com.docker.compose.project.config_files" }}' "$vrn_container_id" 2>/dev/null || true)"
+  [ "$vrn_project" = "vastora" ] &&
+    { [ "$vrn_service" = "center" ] || [ "$vrn_service" = "deployer" ]; } &&
+    [ "$vrn_working_dir" = "$vrn_install_dir" ] &&
+    [ "$vrn_config_files" = "$vrn_install_dir/compose.yaml" ]
+}
+
+validate_runtime_network_containers() {
+  vrn_install_dir="${1:-}"
+  vrn_allow_legacy="${2:-no}"
+  vrn_container_ids="$(runtime_network_container_ids "$vastora_runtime_network")"
+  for vrn_container_id in $vrn_container_ids; do
+    case "$vrn_container_id" in
+      ''|*[!0-9a-f]*)
+        echo "Refusing Docker network $vastora_runtime_network because it contains an invalid container identity." >&2
+        return 1
+        ;;
+    esac
+    if container_has_vastora_ownership "$vrn_container_id"; then
+      continue
     fi
+    if [ "$vrn_allow_legacy" = "yes" ] && container_is_legacy_center_service "$vrn_container_id" "$vrn_install_dir"; then
+      continue
+    fi
+    echo "Refusing to use Docker network $vastora_runtime_network because container $vrn_container_id is not owned by Vastora." >&2
+    return 1
   done
 }
 
-ensure_vastora_runtime_network() {
-  driver="$(docker network inspect --format '{{.Driver}}' "$vastora_runtime_network" 2>/dev/null || true)"
-  if [ -n "$driver" ]; then
-    validate_vastora_runtime_network
-    return $?
+validate_vastora_runtime_network() {
+  if ! runtime_network_has_current_identity; then
+    echo "Refusing to use Docker network $vastora_runtime_network because its driver or ownership labels do not match Vastora." >&2
+    return 1
   fi
+  validate_runtime_network_containers "" no
+}
 
-  if docker network create \
+create_vastora_runtime_network() {
+  docker network create \
     --driver bridge \
     --label io.vastora.managed=true \
     --label io.vastora.component=runtime-network \
     --label io.vastora.network="$vastora_runtime_network" \
-    "$vastora_runtime_network" >/dev/null; then
-    return 0
+    "$vastora_runtime_network" >/dev/null
+}
+
+ensure_vastora_runtime_network() {
+  vrn_driver="$(runtime_network_driver "$vastora_runtime_network")"
+  if [ -n "$vrn_driver" ]; then
+    validate_vastora_runtime_network
+    return $?
   fi
 
+  if create_vastora_runtime_network; then
+    return 0
+  fi
   if validate_vastora_runtime_network; then
     return 0
   fi
   echo "Could not create the shared Docker bridge network $vastora_runtime_network." >&2
   return 1
+}
+
+ensure_vastora_runtime_network_for_upgrade() {
+  vrn_install_dir="$1"
+  vrn_driver="$(runtime_network_driver "$vastora_runtime_network")"
+  if [ -z "$vrn_driver" ]; then
+    if ! create_vastora_runtime_network && ! runtime_network_has_current_identity; then
+      echo "Could not create the shared Docker bridge network $vastora_runtime_network." >&2
+      return 1
+    fi
+  elif ! runtime_network_has_current_identity; then
+    echo "Refusing to upgrade with Docker network $vastora_runtime_network because its ownership identity is invalid." >&2
+    return 1
+  fi
+  validate_runtime_network_containers "$vrn_install_dir" yes
+}
+
+capture_runtime_network_endpoint() {
+  vrn_container_id="$1"
+  vrn_migration_dir="$2"
+  vrn_ipam="$(docker container inspect --format "{{json (index .NetworkSettings.Networks \"$vastora_runtime_network\").IPAMConfig}}" "$vrn_container_id" 2>/dev/null || true)"
+  vrn_links="$(docker container inspect --format "{{json (index .NetworkSettings.Networks \"$vastora_runtime_network\").Links}}" "$vrn_container_id" 2>/dev/null || true)"
+  vrn_driver_options="$(docker container inspect --format "{{json (index .NetworkSettings.Networks \"$vastora_runtime_network\").DriverOpts}}" "$vrn_container_id" 2>/dev/null || true)"
+  case "$vrn_ipam:$vrn_links:$vrn_driver_options" in
+    null:null:null|'{}':null:null) ;;
+    *)
+      echo "Refusing to migrate Docker network $vastora_runtime_network because container $vrn_container_id uses custom endpoint settings." >&2
+      return 1
+      ;;
+  esac
+  docker container inspect \
+    --format "{{range (index .NetworkSettings.Networks \"$vastora_runtime_network\").Aliases}}{{println .}}{{end}}" \
+    "$vrn_container_id" >"$vrn_migration_dir/$vrn_container_id.aliases"
+}
+
+connect_runtime_network_endpoint() {
+  vrn_network_name="$1"
+  vrn_container_id="$2"
+  vrn_aliases_file="$3"
+  set -- docker network connect
+  while IFS= read -r alias; do
+    if [ -n "$alias" ]; then
+      set -- "$@" --alias "$alias"
+    fi
+  done <"$vrn_aliases_file"
+  "$@" "$vrn_network_name" "$vrn_container_id"
+}
+
+restore_legacy_runtime_network() {
+  vrn_migration_dir="$1"
+  vrn_temporary_network="$2"
+  vrn_container_ids="$3"
+
+  for vrn_container_id in $vrn_container_ids; do
+    docker network disconnect -f "$vastora_runtime_network" "$vrn_container_id" >/dev/null 2>&1 || true
+  done
+  docker network rm "$vastora_runtime_network" >/dev/null 2>&1 || true
+  if ! docker network create \
+    --driver bridge \
+    --label io.vastora.managed=true \
+    --label io.vastora.component=runtime-network \
+    "$vastora_runtime_network" >/dev/null; then
+    echo "Automatic rollback could not recreate $vastora_runtime_network; containers remain connected to $vrn_temporary_network." >&2
+    return 1
+  fi
+  for vrn_container_id in $vrn_container_ids; do
+    if ! connect_runtime_network_endpoint "$vastora_runtime_network" "$vrn_container_id" "$vrn_migration_dir/$vrn_container_id.aliases"; then
+      echo "Automatic rollback could not reconnect container $vrn_container_id; it remains connected to $vrn_temporary_network." >&2
+      return 1
+    fi
+  done
+  for vrn_container_id in $vrn_container_ids; do
+    docker network disconnect -f "$vrn_temporary_network" "$vrn_container_id" >/dev/null 2>&1 || true
+  done
+  docker network rm "$vrn_temporary_network" >/dev/null 2>&1 || true
+}
+
+migrate_legacy_vastora_runtime_network() {
+  vrn_install_dir="$1"
+  vrn_driver="$(runtime_network_driver "$vastora_runtime_network")"
+  if [ -z "$vrn_driver" ] || runtime_network_has_current_identity; then
+    return 0
+  fi
+  vrn_managed="$(runtime_network_label "$vastora_runtime_network" io.vastora.managed)"
+  vrn_component="$(runtime_network_label "$vastora_runtime_network" io.vastora.component)"
+  vrn_identity="$(runtime_network_label "$vastora_runtime_network" io.vastora.network)"
+  if [ "$vrn_driver" != "bridge" ] || [ "$vrn_managed" != "true" ] || [ "$vrn_component" != "runtime-network" ] || [ -n "$vrn_identity" ]; then
+    echo "Refusing to migrate Docker network $vastora_runtime_network because it is not an exact legacy Vastora network." >&2
+    return 1
+  fi
+  if ! validate_runtime_network_containers "$vrn_install_dir" yes; then
+    return 1
+  fi
+
+  vrn_container_ids="$(runtime_network_container_ids "$vastora_runtime_network")"
+  vrn_migration_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-runtime-network.XXXXXX")"
+  vrn_temporary_network="vastora-runtime-migration-$$"
+  for vrn_container_id in $vrn_container_ids; do
+    if ! capture_runtime_network_endpoint "$vrn_container_id" "$vrn_migration_dir"; then
+      rm -rf "$vrn_migration_dir"
+      return 1
+    fi
+  done
+  if ! docker network create \
+    --driver bridge \
+    --label io.vastora.managed=true \
+    --label io.vastora.component=runtime-network-migration \
+    --label io.vastora.network="$vrn_temporary_network" \
+    "$vrn_temporary_network" >/dev/null; then
+    rm -rf "$vrn_migration_dir"
+    echo "Could not create the temporary network required to migrate $vastora_runtime_network." >&2
+    return 1
+  fi
+
+  for vrn_container_id in $vrn_container_ids; do
+    if ! connect_runtime_network_endpoint "$vrn_temporary_network" "$vrn_container_id" "$vrn_migration_dir/$vrn_container_id.aliases"; then
+      for vrn_cleanup_id in $vrn_container_ids; do
+        docker network disconnect -f "$vrn_temporary_network" "$vrn_cleanup_id" >/dev/null 2>&1 || true
+      done
+      docker network rm "$vrn_temporary_network" >/dev/null 2>&1 || true
+      rm -rf "$vrn_migration_dir"
+      echo "Could not attach every Vastora container to the temporary migration network." >&2
+      return 1
+    fi
+  done
+
+  vrn_migration_failed=no
+  for vrn_container_id in $vrn_container_ids; do
+    if ! docker network disconnect "$vastora_runtime_network" "$vrn_container_id" >/dev/null; then
+      vrn_migration_failed=yes
+      break
+    fi
+  done
+  if [ "$vrn_migration_failed" = no ] && ! docker network rm "$vastora_runtime_network" >/dev/null; then
+    vrn_migration_failed=yes
+  fi
+  if [ "$vrn_migration_failed" = no ] && ! create_vastora_runtime_network; then
+    vrn_migration_failed=yes
+  fi
+  if [ "$vrn_migration_failed" = no ]; then
+    for vrn_container_id in $vrn_container_ids; do
+      if ! connect_runtime_network_endpoint "$vastora_runtime_network" "$vrn_container_id" "$vrn_migration_dir/$vrn_container_id.aliases"; then
+        vrn_migration_failed=yes
+        break
+      fi
+    done
+  fi
+  if [ "$vrn_migration_failed" = yes ]; then
+    restore_legacy_runtime_network "$vrn_migration_dir" "$vrn_temporary_network" "$vrn_container_ids" || true
+    rm -rf "$vrn_migration_dir"
+    echo "The legacy $vastora_runtime_network migration failed and the upgrade was stopped." >&2
+    return 1
+  fi
+
+  for vrn_container_id in $vrn_container_ids; do
+    docker network disconnect -f "$vrn_temporary_network" "$vrn_container_id" >/dev/null
+  done
+  docker network rm "$vrn_temporary_network" >/dev/null
+  rm -rf "$vrn_migration_dir"
+  echo "Migrated the legacy $vastora_runtime_network network to the current ownership contract."
 }

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -169,7 +169,8 @@ if [ -z "$bootstrap_port" ]; then bootstrap_port=8080; fi
 local_center_url="http://127.0.0.1:$bootstrap_port"
 
 echo "Validating the new deployment with the existing configuration..."
-ensure_vastora_runtime_network
+migrate_legacy_vastora_runtime_network "$install_dir"
+ensure_vastora_runtime_network_for_upgrade "$install_dir"
 docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" config --quiet
 echo "Downloading the immutable Center image..."
 docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" pull center deployer
@@ -244,6 +245,7 @@ echo "Starting the updated Center..."
 cd "$install_dir"
 center_started=yes
 docker compose up -d --remove-orphans deployer center
+validate_vastora_runtime_network
 
 attempt=0
 until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -123,6 +123,9 @@ grep -Fq '127.0.0.1:${VASTORA_CENTER_BOOTSTRAP_PORT:-8080}' "$temporary_dir/comp
 grep -Fq 'name: vastora-runtime' "$temporary_dir/compose.yaml"
 grep -Fq 'external: true' "$temporary_dir/compose.yaml"
 grep -Fq 'ensure_vastora_runtime_network' "$temporary_dir/setup.sh"
+grep -Fq 'io.vastora.component: center' "$temporary_dir/compose.yaml"
+grep -Fq 'io.vastora.component: deployer' "$temporary_dir/compose.yaml"
+grep -Fq 'migrate_legacy_vastora_runtime_network "$install_dir"' "$temporary_dir/upgrade.sh"
 if grep -Fq 'network_mode: host' "$temporary_dir/compose.yaml"; then
   echo "Center install bundle still uses the host network" >&2
   exit 1
@@ -152,6 +155,17 @@ printf '%s\n' 'VASTORA_VERSION=0.1.0-test' 'VASTORA_CENTER_IMAGE=old-image' > "$
 printf '%s\n' 'VASTORA_CENTER_IMAGE=old-image' 'VASTORA_CENTER_BOOTSTRAP_PORT=19090' 'VASTORA_CUSTOM_VALUE=preserved' > "$existing/.env"
 cat > "$fake_bin/docker" <<'EOF'
 #!/bin/sh
+if [ "${1:-}:${2:-}" = "network:inspect" ] && [ "${3:-}" = "--format" ]; then
+  case "$4" in
+    '{{.Driver}}') printf '%s\n' bridge ;;
+    *io.vastora.managed*) printf '%s\n' true ;;
+    *io.vastora.component*) printf '%s\n' runtime-network ;;
+    *io.vastora.network*) printf '%s\n' vastora-runtime ;;
+    *'.Containers'*) : ;;
+    *) exit 2 ;;
+  esac
+  exit 0
+fi
 case "${1:-}" in
   create) printf '%s\n' 'vastora-test-container'; exit 0 ;;
   cp) cp "$FAKE_VASTORA_BINARY" "$3"; exit 0 ;;

--- a/scripts/test-runtime-network.sh
+++ b/scripts/test-runtime-network.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+project_dir="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/vastora-runtime-network-test.XXXXXX")"
+cleanup() { rm -rf "$test_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+state_dir="$test_dir/state"
+mkdir -p "$state_dir/networks" "$state_dir/aliases"
+center_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+managed_id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+unowned_id="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+install_dir="/opt/vastora/center"
+
+network_file() { printf '%s/networks/%s.%s' "$state_dir" "$1" "$2"; }
+
+create_test_network() {
+  name="$1"
+  identity="$2"
+  printf '%s\n' bridge >"$(network_file "$name" driver)"
+  {
+    printf '%s\n' 'io.vastora.managed=true' 'io.vastora.component=runtime-network'
+    if [ -n "$identity" ]; then printf '%s\n' "io.vastora.network=$identity"; fi
+  } >"$(network_file "$name" labels)"
+  : >"$(network_file "$name" members)"
+}
+
+add_member() {
+  name="$1"
+  container_id="$2"
+  shift 2
+  printf '%s\n' "$container_id" >>"$(network_file "$name" members)"
+  : >"$state_dir/aliases/$name.$container_id"
+  for alias in "$@"; do printf '%s\n' "$alias" >>"$state_dir/aliases/$name.$container_id"; done
+}
+
+remove_member() {
+  name="$1"
+  container_id="$2"
+  members="$(network_file "$name" members)"
+  temporary="$members.next"
+  awk -v id="$container_id" '$0 != id' "$members" >"$temporary"
+  mv "$temporary" "$members"
+  rm -f "$state_dir/aliases/$name.$container_id"
+}
+
+label_value() {
+  name="$1"
+  key="$2"
+  awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "$(network_file "$name" labels)"
+}
+
+docker() {
+  object="${1:-}"
+  action="${2:-}"
+  shift 2 || true
+  case "$object:$action" in
+    network:inspect)
+      [ "${1:-}" = "--format" ] || return 2
+      format="$2"
+      name="$3"
+      [ -f "$(network_file "$name" driver)" ] || return 1
+      case "$format" in
+        '{{.Driver}}') cat "$(network_file "$name" driver)" ;;
+        *io.vastora.managed*) label_value "$name" io.vastora.managed ;;
+        *io.vastora.component*) label_value "$name" io.vastora.component ;;
+        *io.vastora.network*) label_value "$name" io.vastora.network ;;
+        *'.Containers'*) cat "$(network_file "$name" members)" ;;
+        *) return 2 ;;
+      esac
+      ;;
+    network:create)
+      labels_file="$test_dir/create-labels"
+      : >"$labels_file"
+      name=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --driver) driver="$2"; shift 2 ;;
+          --label) printf '%s\n' "$2" >>"$labels_file"; shift 2 ;;
+          *) name="$1"; shift ;;
+        esac
+      done
+      [ -n "$name" ] || return 2
+      [ ! -f "$(network_file "$name" driver)" ] || return 1
+      printf '%s\n' "${driver:-bridge}" >"$(network_file "$name" driver)"
+      cp "$labels_file" "$(network_file "$name" labels)"
+      : >"$(network_file "$name" members)"
+      ;;
+    network:connect)
+      aliases_file="$test_dir/connect-aliases"
+      : >"$aliases_file"
+      while [ "$#" -gt 2 ]; do
+        [ "$1" = "--alias" ] || return 2
+        printf '%s\n' "$2" >>"$aliases_file"
+        shift 2
+      done
+      name="$1"
+      container_id="$2"
+      if [ -f "$state_dir/fail-next-current-connect" ] &&
+         [ "$name" = "vastora-runtime" ] &&
+         [ "$(label_value "$name" io.vastora.network)" = "vastora-runtime" ]; then
+        rm -f "$state_dir/fail-next-current-connect"
+        return 1
+      fi
+      grep -Fqx "$container_id" "$(network_file "$name" members)" 2>/dev/null && return 1
+      printf '%s\n' "$container_id" >>"$(network_file "$name" members)"
+      cp "$aliases_file" "$state_dir/aliases/$name.$container_id"
+      ;;
+    network:disconnect)
+      if [ "${1:-}" = "-f" ]; then shift; fi
+      name="$1"
+      container_id="$2"
+      grep -Fqx "$container_id" "$(network_file "$name" members)" || return 1
+      remove_member "$name" "$container_id"
+      ;;
+    network:rm)
+      name="$1"
+      [ ! -s "$(network_file "$name" members)" ] || return 1
+      rm -f "$(network_file "$name" driver)" "$(network_file "$name" labels)" "$(network_file "$name" members)"
+      ;;
+    container:inspect)
+      [ "${1:-}" = "--format" ] || return 2
+      format="$2"
+      container_id="$3"
+      case "$format" in
+        *io.vastora.managed*)
+          if [ "$container_id" = "$managed_id" ] || { [ -f "$state_dir/center-current" ] && [ "$container_id" = "$center_id" ]; }; then printf '%s\n' true; fi
+          ;;
+        *io.vastora.component*)
+          if [ "$container_id" = "$managed_id" ]; then printf '%s\n' center-headscale
+          elif [ -f "$state_dir/center-current" ] && [ "$container_id" = "$center_id" ]; then printf '%s\n' center; fi
+          ;;
+        *com.docker.compose.project.working_dir*) [ "$container_id" = "$center_id" ] && printf '%s\n' "$install_dir" ;;
+        *com.docker.compose.project.config_files*) [ "$container_id" = "$center_id" ] && printf '%s\n' "$install_dir/compose.yaml" ;;
+        *com.docker.compose.project*) [ "$container_id" = "$center_id" ] && printf '%s\n' vastora ;;
+        *com.docker.compose.service*) [ "$container_id" = "$center_id" ] && printf '%s\n' center ;;
+        *'.IPAMConfig'*) printf '%s\n' null ;;
+        *'.Links'*) printf '%s\n' null ;;
+        *'.DriverOpts'*) printf '%s\n' null ;;
+        *'.Aliases'*) cat "$state_dir/aliases/vastora-runtime.$container_id" ;;
+        *) return 2 ;;
+      esac
+      ;;
+    *) return 2 ;;
+  esac
+}
+
+# shellcheck source=../deploy/center/runtime-network.sh
+. "$project_dir/deploy/center/runtime-network.sh"
+
+create_test_network vastora-runtime ""
+add_member vastora-runtime "$center_id" vastora-center-1 center vastora-center
+add_member vastora-runtime "$managed_id" vastora-center-headscale
+migrate_legacy_vastora_runtime_network "$install_dir" >/dev/null
+[ "$(label_value vastora-runtime io.vastora.network)" = vastora-runtime ]
+grep -Fqx "$center_id" "$(network_file vastora-runtime members)"
+grep -Fqx "$managed_id" "$(network_file vastora-runtime members)"
+grep -Fqx vastora-center "$state_dir/aliases/vastora-runtime.$center_id"
+test -z "$(find "$state_dir/networks" -name 'vastora-runtime-migration-*' -print -quit)"
+ensure_vastora_runtime_network_for_upgrade "$install_dir"
+if validate_vastora_runtime_network >/dev/null 2>&1; then
+  echo "Strict network validation accepted a legacy unlabeled Center container." >&2
+  exit 1
+fi
+touch "$state_dir/center-current"
+validate_vastora_runtime_network
+rm -f "$state_dir/center-current"
+
+rm -rf "$state_dir/networks" "$state_dir/aliases"
+mkdir -p "$state_dir/networks" "$state_dir/aliases"
+create_test_network vastora-runtime ""
+add_member vastora-runtime "$unowned_id" unrelated
+if migrate_legacy_vastora_runtime_network "$install_dir" >/dev/null 2>&1; then
+  echo "Legacy migration accepted an unowned attached container." >&2
+  exit 1
+fi
+[ -z "$(label_value vastora-runtime io.vastora.network)" ]
+grep -Fqx "$unowned_id" "$(network_file vastora-runtime members)"
+
+rm -rf "$state_dir/networks" "$state_dir/aliases"
+mkdir -p "$state_dir/networks" "$state_dir/aliases"
+create_test_network vastora-runtime ""
+add_member vastora-runtime "$center_id" vastora-center-1 center vastora-center
+add_member vastora-runtime "$managed_id" vastora-center-headscale
+touch "$state_dir/fail-next-current-connect"
+if migrate_legacy_vastora_runtime_network "$install_dir" >/dev/null 2>&1; then
+  echo "Legacy migration did not report a failed final reconnect." >&2
+  exit 1
+fi
+[ -z "$(label_value vastora-runtime io.vastora.network)" ]
+grep -Fqx "$center_id" "$(network_file vastora-runtime members)"
+grep -Fqx "$managed_id" "$(network_file vastora-runtime members)"
+test -z "$(find "$state_dir/networks" -name 'vastora-runtime-migration-*' -print -quit)"
+
+echo "Runtime network migration test passed"


### PR DESCRIPTION
## Summary

- migrate the exact legacy `vastora-runtime` bridge to the current ownership-label contract before upgrade
- fail closed for foreign containers or custom endpoint settings and roll back connectivity if migration fails
- add ownership labels to Center and deployer containers and validate the final network after restart
- add focused migration, rollback, alias-preservation, and installer regression coverage

## Regression

This fixes the alpha.70 → alpha.71 update failure:

> Refusing to use Docker network vastora-runtime because its driver or ownership labels do not match Vastora.

The legacy alpha.70 network was created with the managed/component labels but without the new `io.vastora.network` identity label. Docker network labels are immutable, so the upgrade must recreate the bridge safely instead of rejecting it.

## Validation

- `make deployment-check`
- `git diff --check`

No deployed machine is updated by this PR.