### PR TITLE
fix(center): recover updates and report progress

### DIFF
--- a/deploy/center/update-center.sh
+++ b/deploy/center/update-center.sh
@@ -72,7 +72,7 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
-write_status applying "$target_version" "Downloading and applying the verified release."
+write_status applying "$target_version" "Downloading the verified release metadata."
 release_base="https://vastora.petauron.com/releases/v$target_version"
 failure_message="The immutable Center installer could not be downloaded."
 if ! curl --proto '=https' --tlsv1.2 -fsS \
@@ -80,6 +80,7 @@ if ! curl --proto '=https' --tlsv1.2 -fsS \
   "$release_base/install.sh" -o "$installer"; then
   exit 1
 fi
+write_status applying "$target_version" "Verifying the immutable release."
 installer_version="$(awk '
   index($0, ":") > 0 && tolower(substr($0, 1, index($0, ":") - 1)) == "x-vastora-version" {
     value = substr($0, index($0, ":") + 1)
@@ -108,8 +109,11 @@ if ! printf '%s\n' "$expected_installer_digest" | grep -Eq '^[0-9a-f]{64}$' || \
   exit 1
 fi
 chmod 0700 "$installer"
+write_status applying "$target_version" "Installing the verified release."
 failure_message="The verified Center installer did not complete successfully."
-if ! /bin/sh "$installer" center \
+if ! VASTORA_UPDATE_STATUS_FILE="$status_file" \
+  VASTORA_UPDATE_TARGET_VERSION="$target_version" \
+  /bin/sh "$installer" center \
   --release-url "$release_base/vastora-center-install.tar.gz" \
   --install-dir "$install_dir" \
   --expected-version "$target_version"; then

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -168,10 +168,33 @@ bootstrap_port="$(awk -F= '$1 == "VASTORA_CENTER_BOOTSTRAP_PORT" {sub(/^[^=]*=/,
 if [ -z "$bootstrap_port" ]; then bootstrap_port=8080; fi
 local_center_url="http://127.0.0.1:$bootstrap_port"
 
+host_update_status_file="${VASTORA_UPDATE_STATUS_FILE:-}"
+host_update_target_version="${VASTORA_UPDATE_TARGET_VERSION:-}"
+if [ -n "$host_update_status_file" ] || [ -n "$host_update_target_version" ]; then
+  if [ "$host_update_status_file" != "$install_dir/.update-status.json" ] || [ "$host_update_target_version" != "$new_version" ]; then
+    echo "The host update status channel does not match this Center installation." >&2
+    exit 1
+  fi
+fi
+write_host_update_stage() {
+  if [ -z "$host_update_status_file" ]; then
+    return 0
+  fi
+  host_update_message="$1"
+  host_update_time="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  host_update_temporary="$(mktemp "$install_dir/.update-status.XXXXXX")"
+  chmod 0600 "$host_update_temporary"
+  printf '{"state":"applying","targetVersion":"%s","message":"%s","updatedAt":"%s"}\n' \
+    "$new_version" "$host_update_message" "$host_update_time" > "$host_update_temporary"
+  mv "$host_update_temporary" "$host_update_status_file"
+}
+
+write_host_update_stage "Validating the existing installation."
 echo "Validating the new deployment with the existing configuration..."
 migrate_legacy_vastora_runtime_network "$install_dir"
 ensure_vastora_runtime_network_for_upgrade "$install_dir"
 docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" config --quiet
+write_host_update_stage "Downloading the immutable Center image."
 echo "Downloading the immutable Center image..."
 docker compose --env-file "$candidate_env" -f "$source_dir/compose.yaml" pull center deployer
 
@@ -183,6 +206,7 @@ if [ -f "$agent_executable" ] && [ -f "$agent_unit" ] && grep -Fq 'Description=V
     echo "systemctl is required to update the co-located Vastora Agent." >&2
     exit 1
   fi
+  write_host_update_stage "Preparing the co-located Agent."
   echo "Preparing the matching Agent from the immutable Center image..."
   agent_container="$(docker create "$new_image")"
   docker cp "$agent_container:/usr/local/bin/vastora" "$temporary_dir/vastora-agent"
@@ -241,12 +265,14 @@ install -m 0644 "$source_dir/release.env" "$install_dir/release.env"
 install -m 0600 "$candidate_env" "$install_dir/.env"
 files_changed=yes
 
+write_host_update_stage "Restarting Center."
 echo "Starting the updated Center..."
 cd "$install_dir"
 center_started=yes
 docker compose up -d --remove-orphans deployer center
 validate_vastora_runtime_network
 
+write_host_update_stage "Waiting for Center health checks."
 attempt=0
 until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
   attempt=$((attempt + 1))
@@ -259,6 +285,7 @@ until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
   sleep 2
 done
 
+write_host_update_stage "Finishing Center startup reconciliation."
 attempt=0
 until curl -fsS "http://127.0.0.1:$bootstrap_port/readyz" >/dev/null 2>&1; do
   attempt=$((attempt + 1))
@@ -271,6 +298,7 @@ until curl -fsS "http://127.0.0.1:$bootstrap_port/readyz" >/dev/null 2>&1; do
 done
 
 if [ "$agent_changed" = yes ]; then
+	write_host_update_stage "Verifying the co-located Agent."
 	if ! systemctl is-active --quiet vastora-agent.service; then
 	  echo "The co-located Agent stopped during Center reconciliation." >&2
 	  exit 1

--- a/internal/center/center_update.go
+++ b/internal/center/center_update.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/petauron/vastora/internal/deployapi"
 	"golang.org/x/mod/semver"
 )
 
@@ -25,6 +26,8 @@ type CenterUpdateStatus struct {
 	Automatic       bool   `json:"automatic"`
 	State           string `json:"state"`
 	TargetVersion   string `json:"targetVersion,omitempty"`
+	Phase           string `json:"phase,omitempty"`
+	Progress        int    `json:"progress,omitempty"`
 	Message         string `json:"message,omitempty"`
 	CheckedAt       string `json:"checkedAt,omitempty"`
 	UpdatedAt       string `json:"updatedAt,omitempty"`
@@ -117,6 +120,7 @@ func (s *Server) handleStartCenterUpdate(writer http.ResponseWriter, request *ht
 	}
 	status.State = execution.State
 	status.TargetVersion = execution.TargetVersion
+	status.Phase, status.Progress = centerUpdateProgress(execution)
 	status.Message = execution.Message
 	status.UpdatedAt = execution.UpdatedAt
 	writeJSON(writer, http.StatusAccepted, status)
@@ -154,13 +158,51 @@ func (s *Server) centerUpdateStatus(ctx context.Context, refreshOfficial bool) C
 	if execution.State == "queued" || execution.State == "applying" || execution.TargetVersion == latest {
 		result.State = execution.State
 		result.TargetVersion = execution.TargetVersion
+		result.Phase, result.Progress = centerUpdateProgress(execution)
 		result.Message = execution.Message
 		result.UpdatedAt = execution.UpdatedAt
 	} else if execution.State == "succeeded" && execution.TargetVersion == strings.TrimPrefix(Version, "v") {
 		result.State = execution.State
 		result.TargetVersion = execution.TargetVersion
+		result.Phase, result.Progress = centerUpdateProgress(execution)
 		result.Message = execution.Message
 		result.UpdatedAt = execution.UpdatedAt
 	}
 	return result
+}
+
+func centerUpdateProgress(execution deployapi.CenterUpdateExecution) (string, int) {
+	if execution.State == "queued" {
+		return "queued", 5
+	}
+	if execution.State == "succeeded" {
+		return "completed", 100
+	}
+	if execution.State != "applying" {
+		return "", 0
+	}
+	switch execution.Message {
+	case "Downloading the verified release metadata.":
+		return "downloading", 10
+	case "Verifying the immutable release.":
+		return "verifying", 20
+	case "Installing the verified release.":
+		return "installing", 30
+	case "Validating the existing installation.":
+		return "validating", 40
+	case "Downloading the immutable Center image.":
+		return "pulling", 50
+	case "Preparing the co-located Agent.":
+		return "agent", 65
+	case "Restarting Center.":
+		return "restarting", 80
+	case "Waiting for Center health checks.":
+		return "health", 88
+	case "Finishing Center startup reconciliation.":
+		return "reconciling", 94
+	case "Verifying the co-located Agent.":
+		return "finalizing", 97
+	default:
+		return "installing", 30
+	}
 }

--- a/internal/center/center_update_test.go
+++ b/internal/center/center_update_test.go
@@ -96,6 +96,23 @@ func TestCenterUpdateStatusAndStartUseTheRestrictedUpdater(t *testing.T) {
 	}
 }
 
+func TestCenterUpdateStatusReportsVerifiedHostProgress(t *testing.T) {
+	previousVersion := Version
+	Version = "0.1.0-alpha.72"
+	defer func() { Version = previousVersion }()
+	updater := &fakeCenterUpdater{status: deployapi.CenterUpdateExecution{
+		Available:     true,
+		State:         "applying",
+		TargetVersion: "0.1.0-alpha.73",
+		Message:       "Downloading the immutable Center image.",
+	}}
+	server := &Server{updates: updater, releaseChecker: fixedReleaseChecker{version: "0.1.0-alpha.73"}}
+	status := server.centerUpdateStatus(context.Background(), false)
+	if status.State != "applying" || status.Phase != "pulling" || status.Progress != 50 {
+		t.Fatalf("unexpected update progress: %#v", status)
+	}
+}
+
 func TestOfficialReleaseCheckerBypassesItsCacheWhenRefreshIsRequested(t *testing.T) {
 	requests := 0
 	installer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {

--- a/internal/center/migrations/00042_catalog_v3_cache.sql
+++ b/internal/center/migrations/00042_catalog_v3_cache.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Catalog responses are a renewable cache. Version 27 already persisted the
+-- immutable manifest history, so discard only the superseded v2 transport and
+-- let the configured source provide a freshly signed v3 envelope.
+DELETE FROM catalog_cache
+WHERE json_extract(CAST(envelope AS TEXT), '$.schemaVersion') = 2;
+
+PRAGMA user_version = 42;
+
+-- +goose Down
+SELECT RAISE(ABORT, 'Vastora Center database downgrades are not supported');

--- a/internal/center/migrations_test.go
+++ b/internal/center/migrations_test.go
@@ -427,6 +427,67 @@ func TestVersion27MigrationBackfillsImmutableCatalogHistory(t *testing.T) {
 	}
 }
 
+func TestVersion42MigrationDropsOnlyLegacyCatalogCache(t *testing.T) {
+	directory := t.TempDir()
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	publicKey := make([]byte, ed25519.PublicKeySize)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO catalog_sources(
+		id, display_name, url, public_key, enabled, refresh_seconds, generation, revision, created_at, last_checked_at, last_error
+	) VALUES('legacy-catalog-v2', 'Legacy v2', 'https://catalog.example.invalid/v2', ?, 1, 3600, 'legacy-generation', 1, ?, ?, '')`, publicKey, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO catalog_cache(source_id, envelope, fetched_at)
+		VALUES('legacy-catalog-v2', '{"schemaVersion":2,"keyId":"legacy","payload":"","signature":""}', ?)`, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO catalog_manifest_history(source_id, app_id, version, manifest_sha256, first_seen_at)
+		VALUES('legacy-catalog-v2', 'legacy-app', '1.0.0', ?, ?)`, strings.Repeat("a", 64), now); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", filepath.Join(directory, "center.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM goose_db_version WHERE version_id = 42`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `PRAGMA user_version = 41`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrated.Close()
+	var cacheCount, historyCount int
+	if err := migrated.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_cache WHERE source_id = 'legacy-catalog-v2'`).Scan(&cacheCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrated.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_manifest_history WHERE source_id = 'legacy-catalog-v2'`).Scan(&historyCount); err != nil {
+		t.Fatal(err)
+	}
+	if cacheCount != 0 || historyCount != 1 {
+		t.Fatalf("legacy cache=%d immutable history=%d", cacheCount, historyCount)
+	}
+	version, err := sqliteSchemaVersion(ctx, migrated.db)
+	if err != nil || version != 42 {
+		t.Fatalf("schema version=%d err=%v", version, err)
+	}
+}
+
 func TestVersion11MigrationSelectsOneRunningThreeXUIControllerPerSite(t *testing.T) {
 	directory := t.TempDir()
 	createLegacyVersion3Database(t, directory)

--- a/internal/center/schema.go
+++ b/internal/center/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const centerSchemaVersion = 41
+const centerSchemaVersion = 42
 
 func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -126,6 +126,8 @@ grep -Fq 'ensure_vastora_runtime_network' "$temporary_dir/setup.sh"
 grep -Fq 'io.vastora.component: center' "$temporary_dir/compose.yaml"
 grep -Fq 'io.vastora.component: deployer' "$temporary_dir/compose.yaml"
 grep -Fq 'migrate_legacy_vastora_runtime_network "$install_dir"' "$temporary_dir/upgrade.sh"
+grep -Fq 'write_host_update_stage "Downloading the immutable Center image."' "$temporary_dir/upgrade.sh"
+grep -Fq 'VASTORA_UPDATE_STATUS_FILE="$status_file"' "$temporary_dir/update-center.sh"
 if grep -Fq 'network_mode: host' "$temporary_dir/compose.yaml"; then
   echo "Center install bundle still uses the host network" >&2
   exit 1

--- a/scripts/test-center-update.sh
+++ b/scripts/test-center-update.sh
@@ -33,6 +33,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ "$release_url" = "https://vastora.petauron.com/releases/v$expected_version/vastora-center-install.tar.gz" ]
+[ "$VASTORA_UPDATE_STATUS_FILE" = "$install_dir/.update-status.json" ]
+[ "$VASTORA_UPDATE_TARGET_VERSION" = "$expected_version" ]
+grep -Fq '"message":"Installing the verified release."' "$VASTORA_UPDATE_STATUS_FILE"
 printf '%s\n' "$release_url" > "$FAKE_INSTALLER_LOG"
 printf 'VASTORA_VERSION=%s\n' "$expected_version" > "$install_dir/release.env"
 EOF

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -87,6 +87,8 @@ export type CenterUpdateStatus = {
   automatic: boolean;
   state: "idle" | "queued" | "applying" | "succeeded" | "failed";
   targetVersion?: string;
+  phase?: "queued" | "downloading" | "verifying" | "installing" | "validating" | "pulling" | "agent" | "restarting" | "health" | "reconciling" | "finalizing" | "completed";
+  progress?: number;
   message?: string;
   checkedAt?: string;
   updatedAt?: string;

--- a/web/src/views/CenterUpdateCard.tsx
+++ b/web/src/views/CenterUpdateCard.tsx
@@ -13,15 +13,27 @@ import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetT
 import { Spinner } from "@/components/ui/spinner";
 
 const manualCommand = "curl -LsSf https://vastora.petauron.com/install.sh | sudo sh -s -- center";
+const updateStages: Readonly<Record<string, readonly [string, string]>> = {
+  queued: ["等待主机更新服务", "Waiting for the host update service"],
+  downloading: ["正在下载安装元数据", "Downloading release metadata"],
+  verifying: ["正在校验不可变版本", "Verifying the immutable release"],
+  installing: ["正在安装已验证版本", "Installing the verified release"],
+  validating: ["正在检查现有安装", "Validating the existing installation"],
+  pulling: ["正在下载 Center 镜像", "Downloading the Center image"],
+  agent: ["正在更新同机 Agent", "Updating the co-located Agent"],
+  restarting: ["正在重启 Center", "Restarting Center"],
+  health: ["正在等待健康检查", "Waiting for health checks"],
+  reconciling: ["正在完成启动协调", "Finishing startup reconciliation"],
+  finalizing: ["正在完成最终检查", "Finishing final checks"],
+};
 
 export function CenterUpdateCard({ language, onRefresh, onStatusChange, status }: { language: Language; onRefresh: () => Promise<void>; onStatusChange: (status: CenterUpdateStatus) => void; status: CenterUpdateStatus }) {
   const [confirming, setConfirming] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const running = status.state === "queued" || status.state === "applying";
-  const updateStage = status.state === "queued"
-    ? copy(language, "等待主机更新服务", "Waiting for the host update service")
-    : copy(language, "正在下载、校验与安装", "Downloading, verifying, and installing");
+  const stageCopy = updateStages[status.phase || (status.state === "queued" ? "queued" : "installing")] || updateStages.installing;
+  const updateStage = copy(language, stageCopy[0], stageCopy[1]);
 
   useEffect(() => {
     if (!running) return;
@@ -59,7 +71,7 @@ export function CenterUpdateCard({ language, onRefresh, onStatusChange, status }
       <CardHeader><CardTitle className="flex items-center gap-2"><CircleArrowUpIcon />{copy(language, "Center 更新", "Center update")}</CardTitle><CardDescription>{copy(language, "自动检查官方完整版本，并沿用安装时的安全升级流程。", "Checks complete official releases and reuses the verified installation upgrade flow.")}</CardDescription><CardAction>{running ? <Spinner /> : status.updateAvailable ? <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">{copy(language, "有新版本", "Update available")}</span> : <CircleCheckIcon className="size-5 text-success" />}</CardAction></CardHeader>
       <CardContent className="flex flex-col gap-4">
         <dl className="grid gap-4 text-sm sm:grid-cols-2"><div><dt className="text-muted-foreground">{copy(language, "当前版本", "Current version")}</dt><dd className="mt-1 font-medium">{status.currentVersion}</dd></div><div><dt className="text-muted-foreground">{copy(language, "官方版本", "Official version")}</dt><dd className="mt-1 font-medium">{status.latestVersion || "—"}</dd></div></dl>
-        {running ? <Alert><Spinner /><AlertTitle>{copy(language, `正在更新到 ${status.targetVersion || status.latestVersion}`, `Updating to ${status.targetVersion || status.latestVersion}`)}</AlertTitle><AlertDescription className="flex flex-col gap-3"><span>{copy(language, "Center 会短暂重启，本页会自动重新连接。请不要关闭服务器或 Docker。", "Center briefly restarts and this page reconnects automatically. Do not stop the server or Docker.")}</span><Progress value={null}><ProgressLabel>{updateStage}</ProgressLabel><span aria-hidden="true" className="ml-auto text-xs text-muted-foreground">{copy(language, "进行中", "In progress")}</span></Progress></AlertDescription></Alert> : null}
+        {running ? <Alert><Spinner /><AlertTitle>{copy(language, `正在更新到 ${status.targetVersion || status.latestVersion}`, `Updating to ${status.targetVersion || status.latestVersion}`)}</AlertTitle><AlertDescription className="flex flex-col gap-3"><span>{copy(language, "Center 会短暂重启，本页会自动重新连接。请不要关闭服务器或 Docker。", "Center briefly restarts and this page reconnects automatically. Do not stop the server or Docker.")}</span><Progress value={status.progress ?? null}><ProgressLabel>{updateStage}</ProgressLabel><span aria-hidden="true" className="ml-auto text-xs text-muted-foreground tabular-nums">{status.progress !== undefined ? `${status.progress}%` : copy(language, "进行中", "In progress")}</span></Progress></AlertDescription></Alert> : null}
         {status.state === "succeeded" && !status.updateAvailable ? <Alert><ShieldCheckIcon /><AlertTitle>{copy(language, "更新完成", "Update complete")}</AlertTitle><AlertDescription>{copy(language, `Center 已安全更新到 ${status.currentVersion}。`, `Center was safely updated to ${status.currentVersion}.`)}</AlertDescription></Alert> : null}
         {status.state === "failed" ? <FieldError role="alert">{copy(language, "更新没有完成。系统保留了可诊断状态，请重试；若仍失败，请下载诊断报告。", "The update did not finish. Diagnostic state was preserved; retry, then download diagnostics if it still fails.")}</FieldError> : null}
         {status.error ? <FieldError role="alert">{copy(language, "暂时无法检查官方版本，请稍后重试。", "The official release cannot be checked right now. Try again shortly.")}</FieldError> : null}

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -1646,16 +1646,16 @@ describe("network and app views", () => {
     expect(onStatusChange).not.toHaveBeenCalled();
   });
 
-  it("shows an accessible indeterminate progress bar while Center updates", () => {
-    const status = { ...dashboard().centerUpdate, latestVersion: "0.1.0-alpha.68", updateAvailable: true, state: "applying" as const, targetVersion: "0.1.0-alpha.68" };
+  it("shows the current verified update phase and progress", () => {
+    const status = { ...dashboard().centerUpdate, latestVersion: "0.1.0-alpha.68", updateAvailable: true, state: "applying" as const, targetVersion: "0.1.0-alpha.68", phase: "pulling" as const, progress: 50 };
     vi.spyOn(api, "centerUpdate").mockImplementation(() => new Promise(() => undefined));
     const container = render(<CenterUpdateCard language="zh-CN" onRefresh={async () => undefined} onStatusChange={() => undefined} status={status} />);
     const progress = container.querySelector('[role="progressbar"]');
-    expect(progress?.getAttribute("aria-valuenow")).toBeNull();
-    expect(progress?.getAttribute("data-indeterminate")).not.toBeNull();
+    expect(progress?.getAttribute("aria-valuenow")).toBe("50");
+    expect(progress?.getAttribute("data-indeterminate")).toBeNull();
     expect(progress?.getAttribute("aria-labelledby")).not.toBeNull();
-    expect(container.textContent).toContain("正在下载、校验与安装");
-    expect(container.textContent).toContain("进行中");
+    expect(container.textContent).toContain("正在下载 Center 镜像");
+    expect(container.textContent).toContain("50%");
   });
 
   it("bypasses the official release cache when update checking is requested", async () => {


### PR DESCRIPTION
## Summary

- add a forward-only schema migration that removes renewable Catalog v2 cache entries while preserving immutable history
- report verified Center update stages and determinate progress through the update API
- persist host-side update stages across metadata download, verification, image pull, restart, health checks, and reconciliation
- render localized stage labels and accessible percentage progress in Settings

## Root cause

The alpha.72 Center could restart into a crash loop when an older installation still had a cached Catalog v2 envelope. Because the Center process was unavailable, the already-loaded Settings page could not observe the failed host update status and remained in its previous loading state.

## Validation

- `go test ./internal/center`
- `go test ./internal/deployer`
- `make web-check`
- `make deployment-check`
- shell syntax checks for the updated installer scripts
- `git diff --check`
