### PR TITLE
fix(deployer): normalize Headscale API key prefixes

### DIFF
--- a/internal/deployer/headscale.go
+++ b/internal/deployer/headscale.go
@@ -431,7 +431,11 @@ func createHeadscaleAPIKey(ctx context.Context, docker *client.Client, container
 		return deployapi.HeadscaleAPIKeyRotation{}, cleanup(err)
 	}
 	for _, record := range records {
-		if record.Prefix != prefix {
+		recordPrefix, err := headscaleAPIKeyPrefix(record.Prefix)
+		if err != nil {
+			return deployapi.HeadscaleAPIKeyRotation{}, cleanup(err)
+		}
+		if recordPrefix != prefix {
 			continue
 		}
 		id, err := parseHeadscaleAPIKeyID(record.ID)
@@ -687,7 +691,11 @@ func parseHeadscaleAPIKeyExpiration(encoded json.RawMessage) (time.Time, error) 
 
 func findHeadscaleAPIKeyRecord(records []headscaleAPIKeyRecord, prefix string) (deployapi.HeadscaleAPIKeyRotation, bool, error) {
 	for _, record := range records {
-		if record.Prefix != prefix {
+		recordPrefix, err := headscaleAPIKeyPrefix(record.Prefix)
+		if err != nil {
+			return deployapi.HeadscaleAPIKeyRotation{}, false, err
+		}
+		if recordPrefix != prefix {
 			continue
 		}
 		id, err := parseHeadscaleAPIKeyID(record.ID)
@@ -698,7 +706,7 @@ func findHeadscaleAPIKeyRecord(records []headscaleAPIKeyRecord, prefix string) (
 		if err != nil {
 			return deployapi.HeadscaleAPIKeyRotation{}, false, err
 		}
-		return deployapi.HeadscaleAPIKeyRotation{APIKeyID: id, APIKeyPrefix: prefix, APIKeyExpiresAt: expiresAt}, true, nil
+		return deployapi.HeadscaleAPIKeyRotation{APIKeyID: id, APIKeyPrefix: recordPrefix, APIKeyExpiresAt: expiresAt}, true, nil
 	}
 	return deployapi.HeadscaleAPIKeyRotation{}, false, nil
 }

--- a/internal/deployer/headscale_api_key_test.go
+++ b/internal/deployer/headscale_api_key_test.go
@@ -36,3 +36,23 @@ func TestParseHeadscaleAPIKeyExpirationRejectsMalformedTimestamp(t *testing.T) {
 		}
 	}
 }
+
+func TestFindHeadscaleAPIKeyRecordNormalizesAuthoritativePrefix(t *testing.T) {
+	expiresAt := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Nanosecond)
+	records := []headscaleAPIKeyRecord{{
+		ID:         json.RawMessage(`1`),
+		Prefix:     "hskey-api-qmjwbNmFsG_f-***",
+		Expiration: json.RawMessage(`"` + expiresAt.Format(time.RFC3339Nano) + `"`),
+	}}
+
+	rotation, found, err := findHeadscaleAPIKeyRecord(records, "qmjwbNmFsG_f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected the masked authoritative prefix to match the canonical key prefix")
+	}
+	if rotation.APIKeyID != 1 || rotation.APIKeyPrefix != "qmjwbNmFsG_f" || !rotation.APIKeyExpiresAt.Equal(expiresAt) {
+		t.Fatalf("rotation = %#v", rotation)
+	}
+}


### PR DESCRIPTION
## Summary

- normalize masked prefixes returned by `headscale apikeys list --output json`
- verify newly created and pending API keys against the canonical 12-character prefix
- add a regression test for the Headscale 0.29 authoritative-list format

## Validation

- `GOCACHE=/private/tmp/vastora-headscale-fix-gocache go test ./internal/deployer`
- `git diff --check`

This fixes built-in Headscale API-key rotation being left in `preparing` with `created Headscale API key was not present in the authoritative key list`.