### PR TITLE
fix(deployer): normalize Headscale key commit prefixes

### DIFF
--- a/internal/deployer/headscale.go
+++ b/internal/deployer/headscale.go
@@ -541,20 +541,9 @@ func (installer DockerHeadscaleInstaller) CommitHeadscaleAPIKeyRotation(ctx cont
 	if err != nil {
 		return err
 	}
-	currentFound := false
-	previousFound := false
-	for _, record := range records {
-		if record.Prefix == input.CurrentPrefix {
-			expiresAt, parseErr := parseHeadscaleAPIKeyExpiration(record.Expiration)
-			if parseErr != nil || !expiresAt.After(time.Now()) {
-				return errors.New("deployer: replacement Headscale API key is expired")
-			}
-			currentFound = true
-		}
-		previousFound = previousFound || record.Prefix == input.PreviousPrefix
-	}
-	if !currentFound {
-		return errors.New("deployer: replacement Headscale API key is not present")
+	previousFound, err := validateHeadscaleAPIKeyRotationCommit(records, input.PreviousPrefix, input.CurrentPrefix, time.Now())
+	if err != nil {
+		return err
 	}
 	if previousFound {
 		if _, err := runHeadscaleCommand(ctx, docker, DefaultHeadscaleContainer, "headscale", "apikeys", "delete", "--prefix", input.PreviousPrefix); err != nil {
@@ -565,6 +554,29 @@ func (installer DockerHeadscaleInstaller) CommitHeadscaleAPIKeyRotation(ctx cont
 		return fmt.Errorf("deployer: clear pending Headscale API key rotation: %w", err)
 	}
 	return nil
+}
+
+func validateHeadscaleAPIKeyRotationCommit(records []headscaleAPIKeyRecord, previousPrefix, currentPrefix string, now time.Time) (bool, error) {
+	currentFound := false
+	previousFound := false
+	for _, record := range records {
+		recordPrefix, err := headscaleAPIKeyPrefix(record.Prefix)
+		if err != nil {
+			return false, err
+		}
+		if recordPrefix == currentPrefix {
+			expiresAt, parseErr := parseHeadscaleAPIKeyExpiration(record.Expiration)
+			if parseErr != nil || !expiresAt.After(now) {
+				return false, errors.New("deployer: replacement Headscale API key is expired")
+			}
+			currentFound = true
+		}
+		previousFound = previousFound || recordPrefix == previousPrefix
+	}
+	if !currentFound {
+		return false, errors.New("deployer: replacement Headscale API key is not present")
+	}
+	return previousFound, nil
 }
 
 func (installer DockerHeadscaleInstaller) apiKeyRotationSettings() (DockerHeadscaleInstaller, error) {

--- a/internal/deployer/headscale_api_key_test.go
+++ b/internal/deployer/headscale_api_key_test.go
@@ -56,3 +56,25 @@ func TestFindHeadscaleAPIKeyRecordNormalizesAuthoritativePrefix(t *testing.T) {
 		t.Fatalf("rotation = %#v", rotation)
 	}
 }
+
+func TestValidateHeadscaleAPIKeyRotationCommitNormalizesAuthoritativePrefixes(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 7, 0, 0, 0, time.UTC)
+	records := []headscaleAPIKeyRecord{
+		{
+			Prefix:     "hskey-api-qmjwbNmFsG_f-***",
+			Expiration: json.RawMessage(`"2027-08-28T06:18:12Z"`),
+		},
+		{
+			Prefix:     "hskey-api-7gUIqAqRwtL7-***",
+			Expiration: json.RawMessage(`"2027-08-31T06:53:58Z"`),
+		},
+	}
+
+	previousFound, err := validateHeadscaleAPIKeyRotationCommit(records, "qmjwbNmFsG_f", "7gUIqAqRwtL7", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !previousFound {
+		t.Fatal("expected the previous masked authoritative prefix to be found")
+	}
+}


### PR DESCRIPTION
## Summary
- normalize Headscale 0.29 masked API key prefixes during the rotation commit phase
- preserve expiry validation and previous-key deletion behavior
- add a regression test using the authoritative masked prefix format observed on A1

## Validation
- `GOCACHE=/private/tmp/vastora-headscale-commit-gocache go test ./internal/deployer`
- focused key-prefix regression tests
- `git diff --check`

This completes the prefix normalization applied in #256; A1 currently has a valid replacement key and a recoverable pending commit.