### PR TITLE
fix: restore protected panel publication

### DIFF
--- a/internal/center/orchestration_test.go
+++ b/internal/center/orchestration_test.go
@@ -98,6 +98,23 @@ func TestApplicationInstallAndPublicationAreIndependent(t *testing.T) {
 	}
 }
 
+func TestCloudflareWebPublicationRequiresConfiguredCenterAccess(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	storeCloudflareOAuthIntegration(t, store, cloudflareOAuthToken{})
+	node := enrollOrchestrationNode(t, store, "tunnel-node", NodeCapabilities{Docker: true, Tunnel: true}, []networking.Candidate{{Address: "10.0.0.12", Interface: "eth0", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.12", LANAddress: "10.0.0.12", EnabledKinds: []string{networking.KindLAN}})
+	applicationID := installCPA(t, store, node, "10.0.0.12")
+	services, err := store.ListServices(ctx)
+	if err != nil || len(services) != 1 || services[0].ApplicationID != applicationID {
+		t.Fatalf("unexpected services: %#v err=%v", services, err)
+	}
+	_, err = store.CreatePublication(ctx, PublicationInput{ServiceID: services[0].ID, Kind: publicationCloudflare, GatewayNodeID: node.ID, Hostname: "service-vastora.example.com", DNSProvider: "cloudflare"})
+	if err == nil || !strings.Contains(err.Error(), "enable the Center Cloudflare Access entry") {
+		t.Fatalf("unconfigured Center Access returned the wrong publication error: %v", err)
+	}
+}
+
 func TestAgentRuntimeGenerationQueuesOneApplicationReconcile(t *testing.T) {
 	store := openOrchestrationStore(t)
 	defer store.Close()

--- a/internal/center/publication.go
+++ b/internal/center/publication.go
@@ -225,7 +225,7 @@ func (s *Store) CreatePublication(ctx context.Context, input PublicationInput) (
 	cloudflareProtectedWeb := input.Kind == publicationCloudflare && !(appKey == threeXUIAppKey && serviceName == "subscription")
 	if cloudflareProtectedWeb {
 		var accessReady int
-		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM center_remote_access WHERE singleton = 1 AND status = 'configured' AND access_application_id <> '' AND identity_provider_id <> ''`).Scan(&accessReady); err != nil {
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM center_remote_access WHERE id = 1 AND status = 'configured' AND access_application_id <> '' AND otp_identity_provider_id <> ''`).Scan(&accessReady); err != nil {
 			return PublicationView{}, err
 		}
 		if accessReady == 0 {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,7 +19,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 export type { AppData, Screen } from "./types";
 type Phase = "loading" | "setup-admin" | "setup-wizard" | "login" | "ready" | "unavailable";
-export type Mutate = (operation: () => Promise<unknown>, success?: string) => Promise<void>;
+export type Mutate = (operation: () => Promise<unknown>, success?: string, options?: { reportError?: boolean }) => Promise<void>;
 
 const preferredLanguage = (): Language => {
   const saved = window.localStorage.getItem("vastora.language");
@@ -202,7 +202,8 @@ export function App() {
     return () => { cancelled = true; window.clearTimeout(timer); };
   }, [phase, screen, loadScreen]);
 
-  const mutate = useCallback<Mutate>(async (operation, success) => {
+  const mutate = useCallback<Mutate>(async (operation, success, options) => {
+    setNotice(null);
     try {
       await operation();
     } catch (error) {
@@ -214,7 +215,7 @@ export function App() {
         setConnection("reconnecting");
         setConnectionError(error);
       }
-      setNotice({ message: userError(language, error), detail: error instanceof Error ? error.message : undefined, error: true });
+      if (options?.reportError !== false) setNotice({ message: userError(language, error), detail: error instanceof Error ? error.message : undefined, error: true });
       throw error;
     }
     setNotice(success ? { message: success } : null);

--- a/web/src/views/AppsView.tsx
+++ b/web/src/views/AppsView.tsx
@@ -140,7 +140,7 @@ export function AppsView({ data, language, mutate }: { data: AppData; language: 
         if (result?.oneTimeCredentials && operationKey) setCredentials({ ...result.oneTimeCredentials, deploymentId: result.id, operationKey, scope });
         setDeploymentEditor(null);
       }} />
-      <PublicationSheet data={data} language={language} onClose={() => setPublicationService(null)} onSubmit={async (input) => { await mutate(() => api.createPublication(input), copy(language, "访问入口已创建。", "Access point created.")); setPublicationService(null); }} service={publicationService} />
+      <PublicationSheet data={data} language={language} onClose={() => setPublicationService(null)} onSubmit={async (input) => { await mutate(() => api.createPublication(input), copy(language, "访问入口已创建。", "Access point created."), { reportError: false }); setPublicationService(null); }} service={publicationService} />
 		<RealitySheet application={realityApplication} data={data} language={language} onClose={() => setRealityApplication(null)} siteTimezone={realityApplication ? data.sites.find((site) => site.id === realityApplication.siteId)?.timezone : undefined} />
 		<RealityRenameSheet data={data} language={language} mutate={mutate} onClose={() => setRealityRenameService(null)} service={realityRenameService} />
       <ThreeXUIInboundTrafficSheet controller={trafficController ?? null} language={language} onClose={() => setTrafficService(null)} service={trafficService} siteTimezone={trafficService ? data.sites.find((site) => site.id === trafficService.siteId)?.timezone : undefined} />

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -336,6 +336,29 @@ describe("network and app views", () => {
 	expect(document.body.textContent).toContain("自动启用 HAProxy");
   });
 
+  it("keeps public access submission errors inside the open sheet", async () => {
+    const data = dashboard();
+    data.integrations = [{ kind: "cloudflare", mode: "oauth", endpoint: "example.com", accountId: "account", zoneId: "zone", secretSet: true, accessManagement: true, status: "configured" }];
+    data.centerRemoteAccess = { available: true, enabled: true, hostname: "center-vastora.example.com", audienceKind: "email", audienceValue: "admin@example.com", status: "configured" };
+    data.services = [{ id: "panel", applicationId: "running", siteId: "site", name: "panel", protocol: "http", containerPort: 8317, hostPort: 8317, endpoint: "192.168.1.2:8317", source: "catalog", management: true, status: "ready", createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" }];
+    const create = vi.spyOn(api, "createPublication").mockRejectedValue(new APIError("center: publication failed", 400, "invalid_request"));
+    const mutate = vi.fn(async (operation: () => Promise<unknown>) => { await operation(); });
+    const container = render(<AppsView data={data} language="zh-CN" mutate={mutate} />);
+
+    act(() => [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("添加入口"))?.click());
+    act(() => document.querySelector<HTMLInputElement>('input[value="public_web"]')?.click());
+    const submit = [...document.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent?.includes("创建访问方式"))!;
+    expect(submit.disabled).toBe(false);
+    await act(async () => {
+      submit.click();
+      await Promise.resolve();
+    });
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ kind: "cloudflare_tunnel", hostname: "service-vastora.example.com" }));
+    expect(mutate).toHaveBeenCalledWith(expect.any(Function), "访问入口已创建。", { reportError: false });
+    expect(document.querySelector('[role="dialog"]')?.textContent).toContain("填写内容不完整或格式不正确");
+  });
+
 	it("shows a failed install with its reason and a retry action", () => {
     const data = dashboard();
     data.deployments = [{ id: "failed-install", agentId: "agent", appKey: "vastora-official/komari-agent", appVersion: "1.2.60", state: "failed", operation: "install", deleteData: false, error: "container could not start", applicationId: "failed", createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" }];


### PR DESCRIPTION
## Summary
- fix Center Access readiness query to use the released schema columns
- keep publication form failures inside the open modal instead of duplicating a global alert
- add focused backend and frontend regression coverage

## Validation
- `go test ./internal/center -run ^TestCloudflareWebPublicationRequiresConfiguredCenterAccess$ -count=1`
- web Vitest suite (107 tests) and catalog contract validation
- `git diff --check`