### PR TITLE
fix(gateway): route colocated 3x-ui through Docker DNS

### DIFF
--- a/internal/center/orchestration.go
+++ b/internal/center/orchestration.go
@@ -322,6 +322,7 @@ func (s *Store) desiredGatewayState(ctx context.Context, tx *sql.Tx, gatewayID s
 		return gateway.DesiredState{}, err
 	}
 	sharedRows, err := tx.QueryContext(ctx, `SELECT p.id, p.sni_hostname, s.endpoint, n.public_bind_address,
+		application.node_id, application.runtime, application.app_key, s.container_port,
 		CASE WHEN application.app_key = 'vastora-official/3x-ui' AND s.app_protocol = 'vless/tcp/reality' AND guard.status = 'ready' THEN 'v2' ELSE '' END
 		FROM publications p JOIN services s ON s.id = p.service_id
 		JOIN applications application ON application.id = s.application_id
@@ -335,11 +336,13 @@ func (s *Store) desiredGatewayState(ctx context.Context, tx *sql.Tx, gatewayID s
 	var shared *gateway.SharedHTTPS
 	for sharedRows.Next() {
 		var route gateway.Layer4Route
-		var endpoint, publicAddress string
-		if err := sharedRows.Scan(&route.ID, &route.Hostname, &endpoint, &publicAddress, &route.ProxyProtocol); err != nil {
+		var endpoint, publicAddress, applicationNodeID, runtime, appKey string
+		var containerPort int
+		if err := sharedRows.Scan(&route.ID, &route.Hostname, &endpoint, &publicAddress, &applicationNodeID, &runtime, &appKey, &containerPort, &route.ProxyProtocol); err != nil {
 			sharedRows.Close()
 			return gateway.DesiredState{}, err
 		}
+		endpoint = canonicalGatewayServiceEndpoint(appKey, runtime, applicationNodeID, gatewayID, containerPort, endpoint)
 		host, portValue, err := net.SplitHostPort(endpoint)
 		if err != nil {
 			sharedRows.Close()
@@ -425,7 +428,7 @@ func (s *Store) CompleteGatewayState(ctx context.Context, agentID, credential st
 		if _, err := tx.ExecContext(ctx, `UPDATE publications SET applied_revision = desired_revision,
 			status = CASE
 				WHEN kind = 'public_direct' AND status = 'failed' AND dns_provider <> 'manual' THEN 'failed'
-				WHEN kind = 'public_direct' THEN 'applying'
+				WHEN kind IN ('public_direct', 'cloudflare_tunnel') THEN 'applying'
 				ELSE 'ready'
 			END,
 			last_error = CASE WHEN status = 'failed' AND dns_provider <> 'manual' THEN last_error ELSE '' END,

--- a/internal/center/publication_routes.go
+++ b/internal/center/publication_routes.go
@@ -7,15 +7,22 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
+	"github.com/petauron/vastora/internal/dockerruntime"
 	"github.com/petauron/vastora/internal/networking"
 )
 
 func (s *Store) upsertPublicationRoute(ctx context.Context, tx *sql.Tx, publicationID, siteID, serviceID, gatewayID, hostname, pathPrefix, protocol, endpoint string, tlsEnabled bool, now time.Time) error {
+	var err error
+	endpoint, err = s.gatewayServiceEndpoint(ctx, tx, serviceID, gatewayID, endpoint)
+	if err != nil {
+		return err
+	}
 	upstreams, _ := json.Marshal([]string{endpoint})
 	var routeID string
-	err := tx.QueryRowContext(ctx, `SELECT id FROM routes WHERE publication_id = ? AND gateway_node_id = ?`, publicationID, gatewayID).Scan(&routeID)
+	err = tx.QueryRowContext(ctx, `SELECT id FROM routes WHERE publication_id = ? AND gateway_node_id = ?`, publicationID, gatewayID).Scan(&routeID)
 	if errors.Is(err, sql.ErrNoRows) {
 		routeID, err = randomToken(18)
 		if err != nil {
@@ -28,6 +35,92 @@ func (s *Store) upsertPublicationRoute(ctx context.Context, tx *sql.Tx, publicat
 	}
 	if err != nil {
 		return fmt.Errorf("center: save publication route: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) gatewayServiceEndpoint(ctx context.Context, tx *sql.Tx, serviceID, gatewayID, endpoint string) (string, error) {
+	var appKey, runtime, applicationNodeID string
+	var containerPort int
+	if err := tx.QueryRowContext(ctx, `SELECT a.app_key, a.runtime, a.node_id, s.container_port
+		FROM services s JOIN applications a ON a.id = s.application_id WHERE s.id = ?`, serviceID).Scan(&appKey, &runtime, &applicationNodeID, &containerPort); err != nil {
+		return "", fmt.Errorf("center: read publication service runtime: %w", err)
+	}
+	return canonicalGatewayServiceEndpoint(appKey, runtime, applicationNodeID, gatewayID, containerPort, endpoint), nil
+}
+
+func canonicalGatewayServiceEndpoint(appKey, runtime, applicationNodeID, gatewayID string, containerPort int, endpoint string) string {
+	if appKey == threeXUIAppKey && runtime == "docker" && applicationNodeID == gatewayID && containerPort > 0 && containerPort <= 65535 {
+		return net.JoinHostPort(dockerruntime.ThreeXUIAlias, strconv.Itoa(containerPort))
+	}
+	return endpoint
+}
+
+// reconcileDockerGatewayEndpoints upgrades persisted same-node routes to the
+// Docker bridge address that the managed gateway can actually reach. It only
+// queues gateways whose canonical upstream changed, so later Center restarts
+// are level-triggered no-ops.
+func (s *Store) reconcileDockerGatewayEndpoints(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	type routeEndpoint struct {
+		routeID, publicationID, gatewayID, appKey, runtime, applicationNodeID, endpoint string
+		containerPort                                                                   int
+		upstreams                                                                       []byte
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT r.id, r.publication_id, r.gateway_node_id, r.upstreams_json,
+		a.app_key, a.runtime, a.node_id, s.container_port, s.endpoint
+		FROM routes r
+		JOIN publications p ON p.id = r.publication_id
+		JOIN services s ON s.id = r.service_id
+		JOIN applications a ON a.id = s.application_id
+		WHERE p.status <> 'stopped' AND s.status <> 'stopped'`)
+	if err != nil {
+		return fmt.Errorf("center: inspect Docker gateway endpoints: %w", err)
+	}
+	values := []routeEndpoint{}
+	for rows.Next() {
+		var value routeEndpoint
+		if err := rows.Scan(&value.routeID, &value.publicationID, &value.gatewayID, &value.upstreams, &value.appKey, &value.runtime, &value.applicationNodeID, &value.containerPort, &value.endpoint); err != nil {
+			rows.Close()
+			return err
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	now := s.now().UTC()
+	gateways := map[string]bool{}
+	for _, value := range values {
+		canonical := canonicalGatewayServiceEndpoint(value.appKey, value.runtime, value.applicationNodeID, value.gatewayID, value.containerPort, value.endpoint)
+		var current []string
+		if json.Unmarshal(value.upstreams, &current) == nil && len(current) == 1 && current[0] == canonical {
+			continue
+		}
+		encoded, _ := json.Marshal([]string{canonical})
+		if _, err := tx.ExecContext(ctx, `UPDATE routes SET upstreams_json = ?, status = 'pending', last_error = '', updated_at = ? WHERE id = ?`, encoded, now.Format(time.RFC3339Nano), value.routeID); err != nil {
+			return fmt.Errorf("center: reconcile Docker gateway endpoint: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE publications SET status = 'pending', last_error = '', updated_at = ? WHERE id = ? AND status <> 'stopped'`, now.Format(time.RFC3339Nano), value.publicationID); err != nil {
+			return err
+		}
+		gateways[value.gatewayID] = true
+	}
+	for gatewayID := range gateways {
+		if err := s.queueGatewayState(ctx, tx, gatewayID, now); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/center/publication_routes_test.go
+++ b/internal/center/publication_routes_test.go
@@ -1,0 +1,26 @@
+package center
+
+import (
+	"testing"
+
+	"github.com/petauron/vastora/internal/dockerruntime"
+)
+
+func TestCanonicalGatewayServiceEndpointUsesDockerDNSForColocatedThreeXUI(t *testing.T) {
+	fallback := "100.64.0.1:2053"
+	endpoint := canonicalGatewayServiceEndpoint(threeXUIAppKey, "docker", "node-a", "node-a", 2053, fallback)
+	want := dockerruntime.ThreeXUIAlias + ":2053"
+	if endpoint != want {
+		t.Fatalf("endpoint = %q, want %q", endpoint, want)
+	}
+
+	for name, value := range map[string]string{
+		"cross-node":   canonicalGatewayServiceEndpoint(threeXUIAppKey, "docker", "node-a", "node-b", 2053, fallback),
+		"host-runtime": canonicalGatewayServiceEndpoint(threeXUIAppKey, "host", "node-a", "node-a", 2053, fallback),
+		"other-app":    canonicalGatewayServiceEndpoint("vastora-official/cpa", "docker", "node-a", "node-a", 8317, fallback),
+	} {
+		if value != fallback {
+			t.Fatalf("%s endpoint = %q, want fallback %q", name, value, fallback)
+		}
+	}
+}

--- a/internal/center/publication_verification_jobs.go
+++ b/internal/center/publication_verification_jobs.go
@@ -186,7 +186,7 @@ func (s *Store) finishPublicationVerification(ctx context.Context, id string, re
 
 func (s *Store) publicationVerificationTargetsForGateway(ctx context.Context, tx *sql.Tx, gatewayID string) ([]publicationVerificationTarget, error) {
 	rows, err := tx.QueryContext(ctx, `SELECT id, desired_revision FROM publications
-		WHERE gateway_node_id = ? AND kind IN ('public_direct', 'public_shared_443') AND status <> 'stopped'`, gatewayID)
+		WHERE gateway_node_id = ? AND kind IN ('public_direct', 'public_shared_443', 'cloudflare_tunnel') AND status <> 'stopped'`, gatewayID)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (s *Store) publicationVerificationTargetsForGateway(ctx context.Context, tx
 func (s *Store) resumePublicationVerifications(ctx context.Context) error {
 	rows, err := s.db.QueryContext(ctx, `SELECT p.id, p.desired_revision FROM publications p
 		WHERE p.kind IN ('public_direct', 'public_shared_443', 'cloudflare_tunnel') AND (
-			p.status IN ('pending', 'applying', 'degraded') OR
+			p.status IN ('pending', 'applying', 'ready', 'degraded') OR
 			(p.status = 'failed' AND p.dns_provider <> 'manual' AND ((p.kind = 'cloudflare_tunnel' AND p.dns_record_id = '') OR
 				p.applied_revision = p.desired_revision OR
 				(p.kind = 'public_direct' AND NOT EXISTS (SELECT 1 FROM routes r WHERE r.publication_id = p.id))
@@ -236,6 +236,9 @@ func (s *Store) resumePublicationVerifications(ctx context.Context) error {
 // serving Center. Offline commands such as backup deliberately do not call it,
 // so opening the database alone never performs external health checks.
 func (s *Store) StartPublicationVerifications(ctx context.Context) error {
+	if err := s.reconcileDockerGatewayEndpoints(ctx); err != nil {
+		return err
+	}
 	if err := s.startRealityGuardHardening(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- route same-node 3x-ui gateway traffic through the shared Docker network alias
- reconcile persisted host-IP upstreams and requeue only changed gateway state
- keep Cloudflare publications applying until external verification succeeds and resume checks after Center restarts
- apply the same container-aware origin selection to shared 443 routes

## Verification
- Local tests were not run, per repository policy; required CI is the release gate.