### PR TITLE
ci: update rebased gitleaks fingerprints

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,2 @@
-e739efc740828a7b2addcbe4dae70d6568c30975:web/src/api.test.ts:generic-api-key:67
-8503ea705229aef56178959cee4a1ef6c7f63516:web/src/api.test.ts:generic-api-key:68
+f4b353af85ed0c1656f8a9c0f1ebcd37ea19d68f:web/src/api.test.ts:generic-api-key:67
+8571649f7335c5a861a5b42ce2ed575950f49bda:web/src/api.test.ts:generic-api-key:68


### PR DESCRIPTION
## Summary

- replace the two obsolete pre-rebase Gitleaks fingerprints with the corresponding commit fingerprints now present on `main`
- keep the synthetic CPA test credentials redacted and allow the unchanged repository-wide secret scan to evaluate subsequent Dependabot PRs

## Verification

- `git diff --check`
- no local tests, builds, linters, type checks, or browser QA were run
- required CI and CodeQL checks will run on this PR

Tracks #273
