### PR TITLE
fix: recover catalog upgrades and update 3x-ui

### DIFF
--- a/catalog/apps/3x-ui/README.md
+++ b/catalog/apps/3x-ui/README.md
@@ -1,6 +1,6 @@
 # 3x-ui app package
 
-This package pins the official `ghcr.io/mhsanaei/3x-ui` v3.6.0 image by
+This package pins the official `ghcr.io/mhsanaei/3x-ui` v3.7.0 image by
 content digest. Its typed Agent executor follows the upstream storage layout:
 
 - `db` persists the default SQLite state at `/etc/x-ui`.
@@ -15,3 +15,8 @@ by default to enforce per-client IP limits.
 
 The Vastora Agent installs this package through an explicit typed handler. It
 does not expose arbitrary Docker, Compose, or shell execution.
+
+Upgrades preserve a durable database snapshot before the new container starts.
+The Agent records the API token returned after an upstream token rotation, so
+later panel, subscription, node-sync, and REALITY operations use the active
+credential.

--- a/catalog/apps/cpa/README.md
+++ b/catalog/apps/cpa/README.md
@@ -7,6 +7,9 @@ one self-contained JSON payload.
 The application image is pinned by digest. Cloudflare Tunnel is outside the
 current typed installation flow. The Agent owns `auths`, `logs`, and `plugins`
 as runtime data; these paths are not Center configuration and are not uploaded.
+The catalog `version` is the Vastora package identity and must be incremented
+whenever the canonical manifest changes, even if the pinned upstream image does
+not change.
 
 Center derives the timezone from the selected Agent's Site and generates
 separate management and client API keys. Those values are not catalog inputs;

--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -74,7 +74,7 @@
     },
     {
       "id": "3x-ui",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "name": {
         "en": "3x-ui",
         "zh-CN": "3x-ui"
@@ -87,7 +87,7 @@
       "images": [
         {
           "name": "3x-ui",
-          "reference": "ghcr.io/mhsanaei/3x-ui:v3.6.0@sha256:652ef431a2d351cfcc7b5dc91798de5c1dd50da8c1b44f9e3afee1c60817035e"
+          "reference": "ghcr.io/mhsanaei/3x-ui:v3.7.0@sha256:3b3131f1876e6bf35063a9ec4dd1c594e4525180bfc2e1c477dcc8a3c9550ca1"
         }
       ],
       "services": [

--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -4,7 +4,7 @@
   "apps": [
     {
       "id": "cpa",
-      "version": "7.2.128",
+      "version": "7.2.129",
       "name": {
         "en": "CPA",
         "zh-CN": "CPA"

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -152,7 +152,7 @@ func TestObserveThreeXUISynchronizesEnabledInboundsWithoutChangingThem(t *testin
 	}
 	defer store.Close()
 	config, _ := json.Marshal(map[string]any{"timezone": "UTC", "panel_port": port, "enable_fail2ban": true, "vmess_aead_forced": false})
-	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{InstanceID: "3x-install", AppKey: threeXUIKey, Version: "3.6.0", Config: config, Secrets: json.RawMessage(`{"api_token":"local-token"}`), ServiceAddress: host}); err != nil {
+	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{InstanceID: "3x-install", AppKey: threeXUIKey, Version: "3.7.0", Config: config, Secrets: json.RawMessage(`{"api_token":"local-token"}`), ServiceAddress: host}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -371,7 +371,7 @@ func TestHeartbeatKeepsCenterConnectedWhenThreeXUIObservationFails(t *testing.T)
 		t.Fatal(err)
 	}
 	config := json.RawMessage(`{"timezone":"UTC","panel_port":2053,"enable_fail2ban":true,"vmess_aead_forced":false}`)
-	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{InstanceID: "3x-install", AppKey: threeXUIKey, Version: "3.6.0", Config: config, Secrets: json.RawMessage(`{}`), ServiceAddress: "127.0.0.1"}); err != nil {
+	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{InstanceID: "3x-install", AppKey: threeXUIKey, Version: "3.7.0", Config: config, Secrets: json.RawMessage(`{}`), ServiceAddress: "127.0.0.1"}); err != nil {
 		t.Fatal(err)
 	}
 	observationErr, heartbeatErr := (Client{}).heartbeat(context.Background(), store)

--- a/internal/agent/official_apps.go
+++ b/internal/agent/official_apps.go
@@ -8,7 +8,7 @@ import (
 
 var officialAppVersions = map[string]string{
 	"3x-ui":        "3.6.0",
-	"cpa":          "7.2.128",
+	"cpa":          "7.2.129",
 	"keeper":       "1.14.1",
 	"komari-agent": "1.2.60",
 }

--- a/internal/agent/official_apps.go
+++ b/internal/agent/official_apps.go
@@ -7,7 +7,7 @@ import (
 )
 
 var officialAppVersions = map[string]string{
-	"3x-ui":        "3.6.0",
+	"3x-ui":        "3.7.0",
 	"cpa":          "7.2.129",
 	"keeper":       "1.14.1",
 	"komari-agent": "1.2.60",

--- a/internal/agent/three_xui_clients_test.go
+++ b/internal/agent/three_xui_clients_test.go
@@ -363,7 +363,7 @@ func threeXUIClientTestStore(t *testing.T, server *httptest.Server, token string
 	}
 	config, _ := json.Marshal(map[string]any{"timezone": "UTC", "panel_port": port, "enable_fail2ban": true, "vmess_aead_forced": false})
 	secrets, _ := json.Marshal(map[string]string{"api_token": token})
-	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{InstanceID: "3x-install", AppKey: threeXUIKey, Version: "3.6.0", Config: config, Secrets: secrets, ServiceAddress: host}); err != nil {
+	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{InstanceID: "3x-install", AppKey: threeXUIKey, Version: "3.7.0", Config: config, Secrets: secrets, ServiceAddress: host}); err != nil {
 		store.Close()
 		t.Fatal(err)
 	}

--- a/internal/agent/three_xui_subscription_test.go
+++ b/internal/agent/three_xui_subscription_test.go
@@ -92,7 +92,7 @@ func TestApplySubscriptionCommandUpdatesOnlyPublicAddressSettings(t *testing.T) 
 	if _, err := store.RecordApplied(context.Background(), AppliedInstallation{
 		InstanceID:     "three-x-ui",
 		AppKey:         threeXUIKey,
-		Version:        "3.6.0",
+		Version:        "3.7.0",
 		Config:         json.RawMessage(`{"timezone":"UTC","panel_port":` + strconv.Itoa(port) + `}`),
 		Secrets:        json.RawMessage(`{"api_token":"local-api-token"}`),
 		ServiceAddress: host,

--- a/internal/center/task_lifecycle_test.go
+++ b/internal/center/task_lifecycle_test.go
@@ -567,7 +567,7 @@ func TestConfigureReusesInstalledVersionAndEncryptedValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if configured.AppVersion != "7.2.128" {
+	if configured.AppVersion != "7.2.129" {
 		t.Fatalf("configure changed installed version: %#v", configured)
 	}
 	task := claimTask(t, store, node)
@@ -599,11 +599,11 @@ func TestUpgradeRequiresANewerCatalogVersionAndRejectsDowngrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	upgrade, err := store.CreateDeployment(ctx, DeploymentRequest{AgentID: node.ID, AppKey: cpaAppKey, Operation: "upgrade"})
-	if err != nil || upgrade.AppVersion != "7.2.128" {
+	if err != nil || upgrade.AppVersion != "7.2.129" {
 		t.Fatalf("newer version was not accepted: %#v err=%v", upgrade, err)
 	}
 	completeNextTask(t, store, node, "application.apply", result)
-	if _, err := store.db.ExecContext(ctx, `UPDATE deployments SET app_version = '7.2.129' WHERE app_key = ? AND state = 'succeeded'`, cpaAppKey); err != nil {
+	if _, err := store.db.ExecContext(ctx, `UPDATE deployments SET app_version = '7.2.130' WHERE app_key = ? AND state = 'succeeded'`, cpaAppKey); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := store.CreateDeployment(ctx, DeploymentRequest{AgentID: node.ID, AppKey: cpaAppKey, Operation: "upgrade"}); err == nil || !strings.Contains(err.Error(), "downgrade is not allowed") {
@@ -630,7 +630,7 @@ func TestFailedChangeRemainsAnInstalledApplication(t *testing.T) {
 		t.Fatal(err)
 	}
 	applications, err := store.ListApplications(ctx)
-	if err != nil || len(applications) != 1 || applications[0].InstalledVersion != "7.2.128" || applications[0].Status != "failed" {
+	if err != nil || len(applications) != 1 || applications[0].InstalledVersion != "7.2.129" || applications[0].Status != "failed" {
 		t.Fatalf("failed change lost installed state: %#v err=%v", applications, err)
 	}
 }
@@ -649,7 +649,7 @@ func TestInstalledAppCanBeUninstalledAfterCatalogRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 	uninstall, err := store.CreateDeployment(ctx, DeploymentRequest{AgentID: node.ID, AppKey: cpaAppKey, Operation: "uninstall"})
-	if err != nil || uninstall.AppVersion != "7.2.128" {
+	if err != nil || uninstall.AppVersion != "7.2.129" {
 		t.Fatalf("installed app became unmanageable after catalog removal: %#v err=%v", uninstall, err)
 	}
 }

--- a/web/src/views/AssistantView.test.tsx
+++ b/web/src/views/AssistantView.test.tsx
@@ -46,7 +46,7 @@ it("renders the exact proposal and uses only the trusted approval action", async
     conversationId: "conversation-1",
     runId: "run-1",
     kind: "install_application" as const,
-    summary: { action: "install", agentId: "agent-1", agentName: "上海节点", appKey: "vastora-official/3x-ui", appName: { en: "3x-ui", "zh-CN": "3x-ui" }, version: "3.6.0", impact: "Install one app", dataRetention: "Data is retained" },
+    summary: { action: "install", agentId: "agent-1", agentName: "上海节点", appKey: "vastora-official/3x-ui", appName: { en: "3x-ui", "zh-CN": "3x-ui" }, version: "3.7.0", impact: "Install one app", dataRetention: "Data is retained" },
     digest: "a".repeat(64),
     targets: [{ kind: "agent", id: "agent-1" }],
     expectedRevision: "revision-1",
@@ -71,7 +71,7 @@ it("renders the exact proposal and uses only the trusted approval action", async
   const container = await renderAssistant();
   await vi.waitFor(() => expect(container.textContent).toContain("变更审批"));
   expect(container.textContent).toContain("上海节点");
-  expect(container.textContent).toContain("3.6.0");
+  expect(container.textContent).toContain("3.7.0");
   expect(container.textContent).toContain(proposal.digest);
   expect(container.textContent).toContain("聊天中的“确认”不会执行操作");
   const approve = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("批准此提案"));

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -54,8 +54,8 @@ const realityDashboard = () => {
   const data = dashboard();
   data.agents[0].networkProfile = { serviceAddress: "10.0.0.10", publicAddress: "203.0.113.10", publicBindAddress: "203.0.113.10", publicMode: "direct", enabledKinds: ["lan", "public"], directPublic: true };
   data.sites[0].domainSuffix = "vastora.example.com";
-  data.apps = [{ key: "vastora-official/3x-ui", sourceId: "vastora-official", fetchedAt: "2026-08-18T00:00:00Z", app: { id: "3x-ui", version: "3.6.0", name: { en: "3x-ui", "zh-CN": "3x-ui" }, description: { en: "Proxy management", "zh-CN": "代理管理" }, hostAccess: true, config: [] } }];
-  data.applications = [{ ...data.applications[0], id: "three-x-ui", name: "3x-ui", appKey: "vastora-official/3x-ui", role: "master", installedVersion: "3.6.0", availableVersion: "3.6.0" }];
+  data.apps = [{ key: "vastora-official/3x-ui", sourceId: "vastora-official", fetchedAt: "2026-08-18T00:00:00Z", app: { id: "3x-ui", version: "3.7.0", name: { en: "3x-ui", "zh-CN": "3x-ui" }, description: { en: "Proxy management", "zh-CN": "代理管理" }, hostAccess: true, config: [] } }];
+  data.applications = [{ ...data.applications[0], id: "three-x-ui", name: "3x-ui", appKey: "vastora-official/3x-ui", role: "master", installedVersion: "3.7.0", availableVersion: "3.7.0" }];
   return data;
 };
 
@@ -658,7 +658,7 @@ describe("network and app views", () => {
   it("automatically installs later 3x-ui instances as VLESS-only nodes", async () => {
     const data = realityDashboard();
     data.agents.push({ ...data.agents[0], id: "worker", name: "edge-worker", networkProfile: { serviceAddress: "100.64.0.20", headscaleAddress: "100.64.0.20", enabledKinds: ["headscale"], directPublic: false } });
-    const create = vi.spyOn(api, "createDeployment").mockResolvedValue({ id: "worker-deployment", agentId: "worker", appKey: "vastora-official/3x-ui", appVersion: "3.6.0", state: "pending", operation: "install", deleteData: false, createdAt: "2026-08-23T00:00:00Z", updatedAt: "2026-08-23T00:00:00Z" });
+    const create = vi.spyOn(api, "createDeployment").mockResolvedValue({ id: "worker-deployment", agentId: "worker", appKey: "vastora-official/3x-ui", appVersion: "3.7.0", state: "pending", operation: "install", deleteData: false, createdAt: "2026-08-23T00:00:00Z", updatedAt: "2026-08-23T00:00:00Z" });
     const mutate = async (operation: () => Promise<unknown>) => { await operation(); };
     const container = render(<AppsView data={data} language="zh-CN" mutate={mutate} />);
     act(() => [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("应用商店"))?.click());

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -291,7 +291,7 @@ describe("network and app views", () => {
   it("keeps CPA installation one-click and protects reveal and rotation", async () => {
     const data = dashboard();
     const reauthentication = ["test", "reauth"].join("-");
-    data.apps = [{ key: "vastora-official/cpa", sourceId: "vastora-official", fetchedAt: "2026-08-18T00:00:00Z", app: { id: "cpa", version: "7.2.128", name: { en: "CPA", "zh-CN": "CPA" }, description: { en: "Proxy API", "zh-CN": "代理 API" }, config: [{ key: "debug", label: { en: "Debug logging", "zh-CN": "调试日志" }, description: { en: "Extra logs", "zh-CN": "额外日志" }, type: "boolean", required: false, secret: false, default: false }] } }];
+    data.apps = [{ key: "vastora-official/cpa", sourceId: "vastora-official", fetchedAt: "2026-08-18T00:00:00Z", app: { id: "cpa", version: "7.2.129", name: { en: "CPA", "zh-CN": "CPA" }, description: { en: "Proxy API", "zh-CN": "代理 API" }, config: [{ key: "debug", label: { en: "Debug logging", "zh-CN": "调试日志" }, description: { en: "Extra logs", "zh-CN": "额外日志" }, type: "boolean", required: false, secret: false, default: false }] } }];
     data.applications = [];
     const container = render(<AppsView data={data} language="zh-CN" mutate={async () => undefined} />);
     act(() => [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === "安装")?.click());
@@ -301,7 +301,7 @@ describe("network and app views", () => {
     expect(document.body.textContent).not.toContain("时区");
     act(() => [...document.querySelectorAll("button")].find((button) => button.textContent?.trim() === "取消")?.click());
 
-    data.applications = [{ id: "cpa-application", name: "CPA", nodeId: "agent", siteId: "site", appKey: "vastora-official/cpa", image: "cpa", status: "running", runtime: "docker", installedVersion: "7.2.128", availableVersion: "7.2.128", updateAvailable: false, createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" }];
+    data.applications = [{ id: "cpa-application", name: "CPA", nodeId: "agent", siteId: "site", appKey: "vastora-official/cpa", image: "cpa", status: "running", runtime: "docker", installedVersion: "7.2.129", availableVersion: "7.2.129", updateAvailable: false, createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" }];
     const reveal = vi.spyOn(api, "revealApplicationCredentials").mockResolvedValue({ kind: "cpa", managementKey: "management-value", clientApiKey: "client-value" });
     const rotate = vi.spyOn(api, "rotateApplicationCredentials").mockResolvedValue({ id: "rotation-1", applicationId: "cpa-application", target: "management", state: "pending", createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" });
     act(() => root?.render(<ThemeProvider><AppsView data={data} language="zh-CN" mutate={async () => undefined} /></ThemeProvider>));


### PR DESCRIPTION
## Summary

- publish the modified CPA package under a new immutable package version
- update the official 3x-ui package from 3.6.0 to 3.7.0 using the verified multi-architecture image digest
- keep the existing durable database snapshot and persisted API-token upgrade path documented

## Verification

- no local tests were run, per repository instructions
- repository CI is the acceptance gate
- after release, A1 will be upgraded and its existing 3x-ui installation will be upgraded in place as the runtime verification

## Runtime checks after release

- Center and Agent recover from the immutable-catalog startup failure
- 3x-ui reports 3.7.0 while retaining its database and active API token
- existing panel, subscription, REALITY, and HAProxy-backed entry state remains healthy