### PR TITLE
fix(upgrade): recover an unhealthy Center

### DIFF
--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -217,11 +217,7 @@ if [ -f "$agent_executable" ] && [ -f "$agent_unit" ] && grep -Fq 'Description=V
     echo "The Center image contains an unexpected Agent version; the upgrade was not started." >&2
     exit 1
   fi
-	if ! curl -fsS "$local_center_url/healthz" >/dev/null 2>&1; then
-	  echo "The host-only Center channel is not healthy; the co-located Agent was not changed." >&2
-	  exit 1
-	fi
-	echo "Moving the co-located Agent to the host-only Center channel..."
+	echo "Staging the co-located Agent for the host-only Center channel..."
 	if [ -f "$agent_data_dir/agent.db" ]; then
 	  agent_database_backup="$(mktemp "$agent_data_dir/.agent.db.pre-upgrade.$new_version.XXXXXX")"
 	  install -m 0600 "$agent_data_dir/agent.db" "$agent_database_backup"
@@ -236,12 +232,7 @@ if [ -f "$agent_executable" ] && [ -f "$agent_unit" ] && grep -Fq 'Description=V
 	agent_changed=yes
 	agent_database_opened=yes
 	"$agent_executable" agent configure-center --data-dir "$agent_data_dir" --center-url "$local_center_url"
-	if ! systemctl start vastora-agent.service || ! systemctl is-active --quiet vastora-agent.service; then
-	  echo "The updated Agent did not start; keeping its schema-compatible executable for recovery." >&2
-	  exit 1
-	fi
-	agent_stopped=no
-	echo "Co-located Agent updated to $new_version on the host-only Center channel."
+	echo "Co-located Agent $new_version is staged until the updated Center becomes healthy."
 fi
 
 for relative in install.sh setup.sh upgrade.sh uninstall.sh install-host-cli.sh install-update-service.sh update-center.sh compare-semver.awk runtime-network.sh compose.yaml release.env .env; do
@@ -284,6 +275,17 @@ until curl -fsS "http://127.0.0.1:$bootstrap_port/healthz" >/dev/null 2>&1; do
   fi
   sleep 2
 done
+
+if [ "$agent_changed" = yes ]; then
+	write_host_update_stage "Starting the co-located Agent."
+	echo "Starting the co-located Agent on the updated host-only Center channel..."
+	if ! systemctl start vastora-agent.service; then
+	  echo "The updated Agent did not start; keeping its schema-compatible executable for recovery." >&2
+	  exit 1
+	fi
+	agent_stopped=no
+	echo "Co-located Agent updated to $new_version on the host-only Center channel."
+fi
 
 write_host_update_stage "Finishing Center startup reconciliation."
 attempt=0

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -111,6 +111,8 @@ test -f "$temporary_dir/runtime-network.sh"
 test -f "$temporary_dir/compose.yaml"
 grep -Fq 'docker cp "$agent_container:/usr/local/bin/vastora"' "$temporary_dir/upgrade.sh"
 grep -Fq 'agent configure-center --data-dir "$agent_data_dir" --center-url "$local_center_url"' "$temporary_dir/upgrade.sh"
+grep -Fq 'Co-located Agent $new_version is staged until the updated Center becomes healthy.' "$temporary_dir/upgrade.sh"
+grep -Fq 'write_host_update_stage "Starting the co-located Agent."' "$temporary_dir/upgrade.sh"
 grep -Fq 'Co-located Agent updated to $new_version on the host-only Center channel.' "$temporary_dir/upgrade.sh"
 grep -Fq 'http://127.0.0.1:$bootstrap_port/readyz' "$temporary_dir/upgrade.sh"
 grep -Fq 'Co-located Agent remained connected through Center reconciliation.' "$temporary_dir/upgrade.sh"
@@ -168,6 +170,12 @@ if [ "${1:-}:${2:-}" = "network:inspect" ] && [ "${3:-}" = "--format" ]; then
   esac
   exit 0
 fi
+if [ "${1:-}" = "compose" ]; then
+  case " $* " in
+    *" up "*) : > "$FAKE_CENTER_STARTED" ;;
+  esac
+  exit 0
+fi
 case "${1:-}" in
   create) printf '%s\n' 'vastora-test-container'; exit 0 ;;
   cp) cp "$FAKE_VASTORA_BINARY" "$3"; exit 0 ;;
@@ -176,7 +184,7 @@ exit 0
 EOF
 cat > "$fake_bin/curl" <<'EOF'
 #!/bin/sh
-exit 0
+test -f "$FAKE_CENTER_STARTED"
 EOF
 cat > "$fake_bin/systemctl" <<'EOF'
 #!/bin/sh
@@ -235,6 +243,7 @@ VASTORA_AGENT_UNIT="$agent_unit" \
 VASTORA_AGENT_DATA_DIR="$agent_data_dir" \
 FAKE_AGENT_CONFIGURE_LOG="$temporary_dir/agent-configure.log" \
 FAKE_VASTORA_BINARY="$temporary_dir/fake-vastora" \
+FAKE_CENTER_STARTED="$temporary_dir/center-started" \
 PATH="$fake_bin:$PATH" \
   "$temporary_dir/upgrade.sh" --install-dir "$existing" >/dev/null
 grep -Fqx "VASTORA_CENTER_IMAGE=$image" "$existing/.env"


### PR DESCRIPTION
## Summary

- remove the circular requirement that the installed Center must already be healthy before an upgrade can replace it
- stage the matching co-located Agent while Center is stopped, then start it only after the updated Center passes health checks
- preserve the forward-only Agent database boundary and existing failure recovery behavior
- exercise the installer flow with an unavailable old Center and a healthy replacement Center

## Incident reproduced on A1

The 0.1.0-alpha.92 Center was crash-looping on an immutable CPA catalog mismatch. The 0.1.0-alpha.93 installer pulled the fixed image but stopped before changing managed files because it required the old host-only health endpoint to succeed.

## Verification

- no local tests were run, per repository instructions
- repository CI is the acceptance gate
- after release, the same official upgrade command will be retried on A1 before the 3x-ui application upgrade test continues