### PR TITLE
fix(upgrade): defer loopback Center verification

### DIFF
--- a/cmd/vastora/agent_cmd.go
+++ b/cmd/vastora/agent_cmd.go
@@ -185,6 +185,7 @@ func runAgent(arguments []string) error {
 		centerURL := flags.String("center-url", "", "Center HTTPS URL or loopback HTTP URL")
 		caFingerprint := flags.String("ca-fingerprint", "", "expected Center CA SHA-256 public-key fingerprint")
 		caCertificate := flags.String("ca-certificate", "", "PEM certificate for a private Center CA")
+		deferLoopbackHealthVerification := flags.Bool("defer-loopback-health-verification", false, "save a loopback Center URL before the co-located Center restarts")
 		if err := flags.Parse(arguments[1:]); err != nil {
 			return err
 		}
@@ -198,7 +199,7 @@ func runAgent(arguments []string) error {
 		if err != nil {
 			return err
 		}
-		if err := configureAgentCenter(context.Background(), *dataDir, *centerURL, *caFingerprint, caCertificatePEM); err != nil {
+		if err := configureAgentCenter(context.Background(), *dataDir, *centerURL, *caFingerprint, caCertificatePEM, *deferLoopbackHealthVerification); err != nil {
 			return err
 		}
 		fmt.Println("Agent Center connection updated")
@@ -603,7 +604,7 @@ func runAgent(arguments []string) error {
 	}
 }
 
-func configureAgentCenter(ctx context.Context, dataDir, centerURL, caFingerprint, caCertificatePEM string) error {
+func configureAgentCenter(ctx context.Context, dataDir, centerURL, caFingerprint, caCertificatePEM string, deferLoopbackHealthVerification bool) error {
 	store, err := agent.Open(dataDir)
 	if err != nil {
 		return err
@@ -613,9 +614,20 @@ func configureAgentCenter(ctx context.Context, dataDir, centerURL, caFingerprint
 	if err != nil {
 		return errors.New("agent must be enrolled before its Center can be changed")
 	}
-	verified, err := (agent.Client{}).VerifyCenterURL(ctx, centerURL, caFingerprint, caCertificatePEM)
-	if err != nil {
-		return fmt.Errorf("verify requested Center URL: %w", err)
+	var verified agent.VerifiedCenter
+	if deferLoopbackHealthVerification {
+		if strings.TrimSpace(caFingerprint) != "" || strings.TrimSpace(caCertificatePEM) != "" {
+			return errors.New("deferred Center health verification does not accept CA options")
+		}
+		verified.URL, err = agent.NormalizeDeferredLoopbackCenterURL(centerURL)
+		if err != nil {
+			return err
+		}
+	} else {
+		verified, err = (agent.Client{}).VerifyCenterURL(ctx, centerURL, caFingerprint, caCertificatePEM)
+		if err != nil {
+			return fmt.Errorf("verify requested Center URL: %w", err)
+		}
 	}
 	if verified.URL == connection.CenterURL && verified.CAFingerprint == connection.CAFingerprint && verified.CACertificatePEM == connection.CACertificatePEM {
 		if agentLoopbackCenterURL(verified.URL) {

--- a/cmd/vastora/main.go
+++ b/cmd/vastora/main.go
@@ -79,7 +79,7 @@ Usage:
   vastora agent install --center-url URL --token-file FILE [--ca-certificate FILE] [--replace-existing]
   vastora agent status [--data-dir /var/lib/vastora/agent]
   vastora agent configure --roles worker[,gateway] --capabilities docker[,gateway,tunnel]
-  vastora agent configure-center --center-url URL [--ca-certificate FILE]
+  vastora agent configure-center --center-url URL [--ca-certificate FILE] [--defer-loopback-health-verification]
   vastora agent resolve-legacy-task --task-id ID --confirm-external-state-reviewed
   vastora agent adopt-tailscale --confirm-vastora-ownership
   vastora agent update [--data-dir /var/lib/vastora/agent] [--center-url URL]

--- a/deploy/center/upgrade.sh
+++ b/deploy/center/upgrade.sh
@@ -231,7 +231,7 @@ if [ -f "$agent_executable" ] && [ -f "$agent_unit" ] && grep -Fq 'Description=V
   mv "$agent_staged" "$agent_executable"
 	agent_changed=yes
 	agent_database_opened=yes
-	"$agent_executable" agent configure-center --data-dir "$agent_data_dir" --center-url "$local_center_url"
+	"$agent_executable" agent configure-center --data-dir "$agent_data_dir" --center-url "$local_center_url" --defer-loopback-health-verification
 	echo "Co-located Agent $new_version is staged until the updated Center becomes healthy."
 fi
 

--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -616,6 +616,21 @@ type VerifiedCenter struct {
 	CACertificatePEM string
 }
 
+// NormalizeDeferredLoopbackCenterURL validates the only Center address that
+// may be saved before it is reachable. The co-located upgrade script uses this
+// while the old Center is stopped and verifies the replacement before starting
+// the Agent. Remote addresses must always use VerifyCenterURL instead.
+func NormalizeDeferredLoopbackCenterURL(desired string) (string, error) {
+	normalized, err := normalizeCenterURL(desired)
+	if err != nil {
+		return "", err
+	}
+	if !loopbackCenterURL(normalized) {
+		return "", errors.New("agent: deferred Center health verification requires loopback HTTP")
+	}
+	return normalized, nil
+}
+
 func (c Client) VerifyCenterURL(ctx context.Context, desired, expectedCAFingerprint, caCertificatePEM string) (VerifiedCenter, error) {
 	normalized, err := normalizeCenterURL(desired)
 	if err != nil {

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -1120,3 +1120,15 @@ func TestPendingTaskCompletionReplaysAfterRestartAndAcknowledgesOnce(t *testing.
 		t.Fatalf("outbox deliveries = %d, want 1", deliveries)
 	}
 }
+
+func TestNormalizeDeferredLoopbackCenterURLRejectsRemoteAddresses(t *testing.T) {
+	normalized, err := NormalizeDeferredLoopbackCenterURL("http://127.0.0.1:8080/")
+	if err != nil || normalized != "http://127.0.0.1:8080" {
+		t.Fatalf("normalized loopback URL = %q, err=%v", normalized, err)
+	}
+	for _, candidate := range []string{"https://center.example.com", "http://192.0.2.10:8080", "http://127.0.0.1:8080/path?token=value"} {
+		if _, err := NormalizeDeferredLoopbackCenterURL(candidate); err == nil {
+			t.Fatalf("deferred verification accepted %q", candidate)
+		}
+	}
+}

--- a/scripts/test-center-install.sh
+++ b/scripts/test-center-install.sh
@@ -260,7 +260,7 @@ test -x "$agent_executable"
 test -f "$existing/.host-cli-installed"
 test -f "$temporary_dir/systemd/vastora-center-update.service"
 test -f "$temporary_dir/systemd/vastora-center-update.path"
-grep -Fqx "configure-center --data-dir $agent_data_dir --center-url http://127.0.0.1:19090" "$temporary_dir/agent-configure.log"
+grep -Fqx "configure-center --data-dir $agent_data_dir --center-url http://127.0.0.1:19090 --defer-loopback-health-verification" "$temporary_dir/agent-configure.log"
 grep -Fq "PathExists=$existing/.update-request" "$temporary_dir/systemd/vastora-center-update.path"
 grep -Fq "$existing/update-center.sh --install-dir $existing" "$temporary_dir/systemd/vastora-center-update.service"
 


### PR DESCRIPTION
## Summary

- add an upgrade-only deferred health path for a loopback HTTP Center URL
- keep normal remote Center changes fail-closed behind live health and trust verification
- reject deferred verification for remote addresses, HTTPS endpoints, CA options, query strings, credentials, and fragments
- have the Center upgrader use the deferred loopback path before it starts the replacement Center

## A1 verification finding

The alpha.94 upgrade correctly stopped requiring the old Center health endpoint in the shell workflow, but Agent configure-center still performed its own live health probe before the replacement Center was started. This change narrows the deferred path to the fixed co-located loopback channel.

## Verification

- no local tests were run, per repository instructions
- repository CI is the acceptance gate
- after release, A1 will retry the official Center upgrade before the 3x-ui application upgrade test continues