### PR TITLE
fix(agent): reconcile stale protected gateway state

### DIFF
--- a/internal/agent/caddy_driver.go
+++ b/internal/agent/caddy_driver.go
@@ -19,6 +19,8 @@ import (
 	"github.com/petauron/vastora/internal/gatewayruntime"
 )
 
+var errProtectedSystemGatewayStateIncomplete = errors.New("agent: protected system gateway state is incomplete")
+
 type CaddyGatewayDriver struct {
 	AdminURL        string
 	AdminListen     string
@@ -134,7 +136,7 @@ func validateProtectedSystemRoutes(desired gateway.DesiredState, services []stri
 		for _, expected := range required {
 			route, exists := routes[expected.id]
 			if !exists || !route.System || !route.TLSEnabled || route.ListenerKind != expected.listener || route.Path != expected.path {
-				return fmt.Errorf("agent: refusing to replace protected system gateway without %s route %q", expected.listener, expected.id)
+				return fmt.Errorf("%w: refusing to replace protected system gateway without %s route %q", errProtectedSystemGatewayStateIncomplete, expected.listener, expected.id)
 			}
 		}
 	}
@@ -147,7 +149,7 @@ func validateProtectedSystemRoutes(desired gateway.DesiredState, services []stri
 		for _, expected := range required {
 			route, exists := routes[expected.id]
 			if !exists || !route.System || !route.TLSEnabled || route.ListenerKind != "public" || route.Path != expected.path {
-				return errors.New("agent: refusing to replace protected system gateway without public Agent bootstrap routes")
+				return fmt.Errorf("%w: refusing to replace protected system gateway without public Agent bootstrap routes", errProtectedSystemGatewayStateIncomplete)
 			}
 		}
 	}

--- a/internal/agent/gateway.go
+++ b/internal/agent/gateway.go
@@ -80,6 +80,22 @@ func restoreGatewayState(ctx context.Context, store *Store, driver GatewayDriver
 		return restoreErr
 	}
 	if err := driver.ApplyConfiguration(ctx, state.Desired, state.Certificates); err != nil {
+		if errors.Is(err, errProtectedSystemGatewayStateIncomplete) {
+			// A protected system gateway is recreated by the Center deployment
+			// before the Agent starts. Keep that healthy live configuration when
+			// the Agent's persisted state predates a required system route, then
+			// let the authoritative Center revision reconcile it over the control
+			// plane. The rejected stale state is never applied.
+			healthErr := driver.Health(ctx)
+			if healthErr == nil {
+				return nil
+			}
+			restoreErr = errors.Join(
+				fmt.Errorf("agent: restore last known good gateway configuration: %w", err),
+				fmt.Errorf("agent: verify preserved protected system gateway: %w", healthErr),
+			)
+			return restoreErr
+		}
 		restoreErr = fmt.Errorf("agent: restore last known good gateway configuration: %w", err)
 		return restoreErr
 	}

--- a/internal/agent/gateway_test.go
+++ b/internal/agent/gateway_test.go
@@ -255,6 +255,61 @@ func TestGatewayStartupWithoutAppliedStateDoesNotRequireRuntime(t *testing.T) {
 	}
 }
 
+func TestGatewayStartupPreservesHealthyProtectedSystemGatewayWhenPersistedStateIsStale(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := store.RecordGatewayState(context.Background(), gatewayState(29, 3000), nil); err != nil {
+		t.Fatal(err)
+	}
+	admin := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/config/" {
+			t.Fatalf("unexpected Caddy request: %s %s", request.Method, request.URL.Path)
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer admin.Close()
+	driver, err := NewCaddyGatewayDriver(admin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver.SystemGateway = staticSystemGatewayInspector{"center", "headscale"}
+	if err := restoreGatewayState(context.Background(), store, driver); err != nil {
+		t.Fatalf("healthy protected gateway was not preserved: %v", err)
+	}
+	if err := store.requireGatewayStartup(); err != nil {
+		t.Fatalf("stale persisted state blocked Center reconciliation: %v", err)
+	}
+}
+
+func TestGatewayStartupFailsClosedWhenProtectedSystemGatewayCannotBeVerified(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := store.RecordGatewayState(context.Background(), gatewayState(29, 3000), nil); err != nil {
+		t.Fatal(err)
+	}
+	admin := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer admin.Close()
+	driver, err := NewCaddyGatewayDriver(admin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver.SystemGateway = staticSystemGatewayInspector{"center", "headscale"}
+	if err := restoreGatewayState(context.Background(), store, driver); err == nil || !strings.Contains(err.Error(), "verify preserved protected system gateway") {
+		t.Fatalf("unhealthy protected gateway did not fail closed: %v", err)
+	}
+	if err := store.requireGatewayStartup(); err == nil {
+		t.Fatal("failed protected gateway verification did not fence the control plane")
+	}
+}
+
 func TestGatewayStartupRestoreFencesNewerRevisionUntilRestoreFinishes(t *testing.T) {
 	assertGatewayStartupFence(t, gatewayState(7, 3000), nil, gatewayState(8, 3100), nil)
 }


### PR DESCRIPTION
## Summary
- identify incomplete protected-system gateway restores as a dedicated fail-closed condition
- preserve a healthy live system gateway when persisted Agent state predates required system routes
- allow the Center control plane to deliver the newer authoritative gateway revision
- keep startup fenced when the preserved gateway cannot be verified healthy

## Verification
- repository CI only, per AGENTS.md
- A1 runtime verification will follow after release