### PR TITLE
fix(center): preserve private DNS during Agent restarts

### DIFF
--- a/internal/center/co_located_agent_test.go
+++ b/internal/center/co_located_agent_test.go
@@ -33,7 +33,7 @@ func TestNetworkCandidatesAreCoLocatedOnlyForAssignedHostAddress(t *testing.T) {
 	}
 }
 
-func TestCoLocatedHeadscaleAddressRequiresCurrentAgentCandidate(t *testing.T) {
+func TestCoLocatedHeadscaleAddressSurvivesAgentReconnect(t *testing.T) {
 	store, err := Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -50,11 +50,12 @@ func TestCoLocatedHeadscaleAddressRequiresCurrentAgentCandidate(t *testing.T) {
 		t.Fatal(err)
 	}
 	timestamp := now.Format(time.RFC3339Nano)
+	staleHeartbeat := now.Add(-time.Hour).Format(time.RFC3339Nano)
 	statements := []struct {
 		query string
 		args  []any
 	}{
-		{`INSERT INTO agents(id, name, credential_hash, version, status, enrolled_at, last_seen_at, site_id) VALUES('center-node', 'Center', X'01', 'test', 'active', ?, ?, ?)`, []any{timestamp, timestamp, site.ID}},
+		{`INSERT INTO agents(id, name, credential_hash, version, status, enrolled_at, last_seen_at, site_id) VALUES('center-node', 'Center', X'01', 'test', 'active', ?, ?, ?)`, []any{timestamp, staleHeartbeat, site.ID}},
 		{`INSERT INTO agent_network_profiles(agent_id, service_address, headscale_address, enabled_kinds_json, confirmed_at, candidate_observed_at) VALUES('center-node', '100.64.0.1', '100.64.0.1', '["headscale"]', ?, ?)`, []any{timestamp, timestamp}},
 		{`INSERT INTO agent_network_candidates(agent_id, address, interface_name, kind, observed_at) VALUES('center-node', '10.0.0.10', 'ens3', 'lan', ?), ('center-node', '100.64.0.1', 'tailscale0', 'headscale', ?)`, []any{timestamp, timestamp}},
 	}

--- a/internal/center/headscale.go
+++ b/internal/center/headscale.go
@@ -585,12 +585,16 @@ func (s *Store) coLocatedHeadscaleAddress(ctx context.Context) (string, error) {
 			local[candidate.Kind+"\x00"+candidate.Address] = candidate.Address
 		}
 	}
+	// The confirmed co-located topology must survive a temporary Agent outage.
+	// This DNS record is what lets remote Agents reconnect after Center or the
+	// co-located Agent restarts, so gating it on recent heartbeats creates a
+	// circular dependency and can disconnect the entire tailnet.
 	rows, err := s.db.QueryContext(ctx, `SELECT n.headscale_address, c.kind, c.address
 		FROM agent_network_profiles n JOIN agents a ON a.id = n.agent_id
 		JOIN agent_network_candidates c ON c.agent_id = n.agent_id
-		WHERE a.status = 'active' AND a.last_seen_at >= ? AND n.headscale_address <> ''
+		WHERE a.status = 'active' AND n.headscale_address <> ''
 		AND EXISTS(SELECT 1 FROM agent_network_candidates h WHERE h.agent_id = n.agent_id AND h.kind = ? AND h.address = n.headscale_address)
-		ORDER BY a.enrolled_at, c.kind, c.address`, s.now().UTC().Add(-45*time.Second).Format(time.RFC3339Nano), networking.KindHeadscale)
+		ORDER BY a.enrolled_at, c.kind, c.address`, networking.KindHeadscale)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- keep the confirmed co-located Headscale address usable while its Agent reconnects
- prevent Center/Agent restart ordering from deleting the private Center DNS record
- retain the existing topology checks and remove only the circular recent-heartbeat requirement

## Runtime evidence
- alpha.95 rewrote the Headscale extra-record file to an empty array while the co-located Agent was restarting
- remote Agents immediately lost resolution for the private Center hostname
- restoring the existing A record brought E22 heartbeats and task delivery back

## Verification
- repository CI only, per AGENTS.md
- A1 runtime verification will follow after release