### PR TITLE
fix(center): acknowledge superseded gateway results

### DIFF
--- a/internal/center/orchestration.go
+++ b/internal/center/orchestration.go
@@ -388,6 +388,12 @@ func (s *Store) CompleteGatewayState(ctx context.Context, agentID, credential st
 	if revision <= applied {
 		return nil
 	}
+	if revision < desired {
+		// The Agent durably retries task completions until Center acknowledges
+		// them. A newer complete desired state supersedes this result, so accept
+		// the obsolete receipt without projecting it onto the newer revision.
+		return nil
+	}
 	if revision != desired {
 		return errors.New("center: stale gateway result")
 	}

--- a/internal/center/orchestration_test.go
+++ b/internal/center/orchestration_test.go
@@ -98,6 +98,34 @@ func TestApplicationInstallAndPublicationAreIndependent(t *testing.T) {
 	}
 }
 
+func TestStaleGatewayCompletionIsAcknowledgedAfterDesiredStateAdvances(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	node := enrollOrchestrationNode(t, store, "gateway-restart", NodeCapabilities{Gateway: true}, []networking.Candidate{{Address: "10.0.0.42", Interface: "eth0", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.42", LANAddress: "10.0.0.42", EnabledKinds: []string{networking.KindLAN}})
+
+	if _, err := store.db.ExecContext(ctx, `UPDATE gateway_states
+		SET desired_revision = 36, applied_revision = 33, status = 'pending', attempt = 1164
+		WHERE gateway_node_id = ?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CompleteGatewayState(ctx, node.ID, node.Credential, 35, 1164, true, ""); err != nil {
+		t.Fatalf("superseded gateway completion was not acknowledged: %v", err)
+	}
+
+	var desired, applied, attempt int64
+	var status string
+	if err := store.db.QueryRowContext(ctx, `SELECT desired_revision, applied_revision, status, attempt FROM gateway_states WHERE gateway_node_id = ?`, node.ID).Scan(&desired, &applied, &status, &attempt); err != nil {
+		t.Fatal(err)
+	}
+	if desired != 36 || applied != 33 || status != "pending" || attempt != 1164 {
+		t.Fatalf("superseded completion changed current gateway state: desired=%d applied=%d status=%q attempt=%d", desired, applied, status, attempt)
+	}
+	if err := store.CompleteGatewayState(ctx, node.ID, node.Credential, 37, 1164, true, ""); err == nil || !strings.Contains(err.Error(), "stale gateway result") {
+		t.Fatalf("future gateway completion was accepted: %v", err)
+	}
+}
+
 func TestCloudflareWebPublicationRequiresConfiguredCenterAccess(t *testing.T) {
 	store := openOrchestrationStore(t)
 	defer store.Close()


### PR DESCRIPTION
## Summary

- acknowledge durable gateway task completions that have already been superseded by a newer complete desired state
- leave the current desired/applied projection unchanged while releasing the Agent outbox receipt
- reject impossible future-revision completions

## Runtime evidence

During the alpha.97 A1 upgrade, the Agent had durably applied an older gateway revision while Center had already advanced the desired revision. Center rejected the old completion as stale, so the Agent retried it every second and could not claim the newer desired-state task. A backed-up one-row recovery released the obsolete receipt, after which the Agent immediately applied the newer revision and the gateway returned to ready.

## Verification

Repository CI only; no local tests were run per AGENTS.md.