### PR TITLE
fix(agent): recover interrupted migration tasks

### DIFF
--- a/cmd/vastora/agent_cmd.go
+++ b/cmd/vastora/agent_cmd.go
@@ -612,15 +612,22 @@ func runAgent(arguments []string) error {
 		if err != nil {
 			return fmt.Errorf("restore ingress state before starting the Agent control plane: %w", err)
 		}
-		if err := client.Heartbeat(context.Background(), store); err != nil {
-			controlLogger.Error("Initial Agent heartbeat failed", "event", "control_plane.heartbeat", "error", controlplane.SafeError(err.Error()))
-		}
-		go client.RunHeartbeats(context.Background(), store, *heartbeatInterval, func(err error) {
-			controlLogger.Error("Agent heartbeat failed", "event", "control_plane.heartbeat", "error", controlplane.SafeError(err.Error()))
-		})
-		go client.RunTasks(context.Background(), store, func(err error) {
-			controlLogger.Error("Agent task channel failed", "event", "control_plane.task", "error", controlplane.SafeError(err.Error()))
-		})
+		go func() {
+			for {
+				if err := client.StartupHeartbeat(context.Background(), store); err != nil {
+					controlLogger.Error("Initial Agent heartbeat failed", "event", "control_plane.heartbeat", "error", controlplane.SafeError(err.Error()))
+					time.Sleep(time.Second)
+					continue
+				}
+				break
+			}
+			go client.RunHeartbeats(context.Background(), store, *heartbeatInterval, func(err error) {
+				controlLogger.Error("Agent heartbeat failed", "event", "control_plane.heartbeat", "error", controlplane.SafeError(err.Error()))
+			})
+			client.RunTasks(context.Background(), store, func(err error) {
+				controlLogger.Error("Agent task channel failed", "event", "control_plane.task", "error", controlplane.SafeError(err.Error()))
+			})
+		}()
 		fmt.Printf("Agent health listener on %s\n", *listen)
 		return http.ListenAndServe(*listen, store.Handler())
 	default:

--- a/internal/agent/control_plane.go
+++ b/internal/agent/control_plane.go
@@ -352,6 +352,7 @@ type ThreeXUIClientCommandResult struct {
 
 type ThreeXUINodeCommandTask struct {
 	Action              string `json:"action"`
+	MigrationID         string `json:"migrationId,omitempty"`
 	WorkerApplicationID string `json:"workerApplicationId"`
 	Name                string `json:"name"`
 	Address             string `json:"address"`
@@ -463,6 +464,18 @@ func (c Client) Heartbeat(ctx context.Context, store *Store) error {
 		}
 	}
 	_, err := c.heartbeat(ctx, store)
+	return err
+}
+
+// StartupHeartbeat reports a new Agent process before its task loop begins.
+// Center uses this boundary to release work leased to the previous process.
+func (c Client) StartupHeartbeat(ctx context.Context, store *Store) error {
+	if c.GatewayDriver != nil {
+		if err := store.requireGatewayStartup(); err != nil {
+			return err
+		}
+	}
+	_, err := c.heartbeatWithStartup(ctx, store, true)
 	return err
 }
 
@@ -774,19 +787,15 @@ func (c Client) RunHeartbeats(ctx context.Context, store *Store, interval time.D
 			return
 		}
 	}
-	startup := true
 	send := func() {
 		requestContext, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer cancel()
-		observeErr, err := c.heartbeatWithStartup(requestContext, store, startup)
+		observeErr, err := c.heartbeat(requestContext, store)
 		if observeErr != nil && report != nil {
 			report(observeErr)
 		}
 		if err != nil && report != nil {
 			report(err)
-		}
-		if err == nil {
-			startup = false
 		}
 	}
 	send()

--- a/internal/agent/control_plane_contract_test.go
+++ b/internal/agent/control_plane_contract_test.go
@@ -1,0 +1,42 @@
+package agent_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/petauron/vastora/internal/agent"
+	"github.com/petauron/vastora/internal/center"
+)
+
+func TestThreeXUINodeMigrationTaskMatchesAgentContract(t *testing.T) {
+	payload, err := json.Marshal(center.AgentTask{
+		Kind:    "application.command",
+		ID:      "application-command-contract",
+		Attempt: 1,
+		NodeCommand: &center.ThreeXUINodeCommandTask{
+			Action:              "reconcile",
+			MigrationID:         "migration-contract",
+			WorkerApplicationID: "worker-contract",
+			Name:                "worker",
+			Address:             "100.64.0.2",
+			Port:                2053,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var task agent.DeploymentTask
+	if err := decoder.Decode(&task); err != nil {
+		t.Fatalf("Center node migration task does not match the Agent contract: %v", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("Center node migration task has trailing data: %v", err)
+	}
+	if task.NodeCommand == nil || task.NodeCommand.MigrationID != "migration-contract" {
+		t.Fatalf("Agent lost the node migration identity: %#v", task.NodeCommand)
+	}
+}

--- a/internal/agent/control_plane_test.go
+++ b/internal/agent/control_plane_test.go
@@ -208,9 +208,19 @@ func TestHeartbeatsRestoreGatewayStateOnlyAtStartup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	heartbeats := 0
+	startupHeartbeats := 0
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
 		case "/api/v1/agents/agent-1/heartbeat":
+			var payload struct {
+				Startup bool `json:"startup"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.Startup {
+				startupHeartbeats++
+			}
 			heartbeats++
 			response.Header().Set("Content-Type", "application/json")
 			_, _ = response.Write([]byte(`{}`))
@@ -250,6 +260,9 @@ func TestHeartbeatsRestoreGatewayStateOnlyAtStartup(t *testing.T) {
 	})
 	if heartbeats != 2 {
 		t.Fatalf("expected two heartbeat cycles, got %d", heartbeats)
+	}
+	if startupHeartbeats != 0 {
+		t.Fatalf("steady heartbeat loop repeated startup %d times", startupHeartbeats)
 	}
 	if len(driver.applied) != 1 || driver.applied[0].Revision != 3 {
 		t.Fatalf("persisted gateway state was restored %d times: %#v", len(driver.applied), driver.applied)
@@ -449,7 +462,7 @@ func TestInitialHeartbeatRequestsRealityGuardRevalidation(t *testing.T) {
 	if err := store.SaveConnection(context.Background(), testConnection(t, "agent-1", "test", server.URL, "credential")); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (Client{}).heartbeatWithStartup(context.Background(), store, true); err != nil {
+	if err := (Client{}).StartupHeartbeat(context.Background(), store); err != nil {
 		t.Fatal(err)
 	}
 	if !startup {

--- a/internal/center/store_agent.go
+++ b/internal/center/store_agent.go
@@ -619,6 +619,11 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 	if err := s.queueScheduledThreeXUIBackup(ctx, tx, id, now); err != nil {
 		return err
 	}
+	if heartbeat.Startup {
+		if err := expireAgentProcessTaskLeases(ctx, tx, id, now); err != nil {
+			return err
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return err
 	}
@@ -632,6 +637,30 @@ func (s *Store) RecordAgentHeartbeat(ctx context.Context, id, credential string,
 	}
 	if err := s.cleanupStoppedPublications(ctx, publicationCleanups); err != nil {
 		return fmt.Errorf("center: record publication cleanup state: %w", err)
+	}
+	return nil
+}
+
+// expireAgentProcessTaskLeases marks work owned by the previous Agent process
+// for immediate recovery. Host update and decommission tasks are deliberately
+// excluded because their durable system helpers survive an Agent restart.
+func expireAgentProcessTaskLeases(ctx context.Context, tx *sql.Tx, agentID string, now time.Time) error {
+	nowText := now.UTC().Format(time.RFC3339Nano)
+	statements := []struct {
+		query string
+		kind  string
+	}{
+		{`UPDATE deployments SET lease_expires_at = ? WHERE agent_id = ? AND state = 'running'`, "application task"},
+		{`UPDATE application_commands SET lease_expires_at = ? WHERE agent_id = ? AND state = 'running'`, "application command"},
+		{`UPDATE gateway_components SET lease_expires_at = ? WHERE gateway_node_id = ? AND status = 'applying'`, "gateway component task"},
+		{`UPDATE gateway_states SET lease_expires_at = ? WHERE gateway_node_id = ? AND status = 'applying'`, "gateway route task"},
+		{`UPDATE node_listener_states SET lease_expires_at = ? WHERE node_id = ? AND status = 'applying'`, "node listener task"},
+		{`UPDATE cloudflare_tunnels SET lease_expires_at = ? WHERE agent_id = ? AND status = 'applying'`, "Tunnel task"},
+	}
+	for _, statement := range statements {
+		if _, err := tx.ExecContext(ctx, statement.query, nowText, agentID); err != nil {
+			return fmt.Errorf("center: expire interrupted %s lease: %w", statement.kind, err)
+		}
 	}
 	return nil
 }

--- a/internal/center/task_lifecycle_test.go
+++ b/internal/center/task_lifecycle_test.go
@@ -377,6 +377,32 @@ func TestTaskLeaseRenewalKeepsAttemptActiveAndNeverResurrectsExpiredLease(t *tes
 	}
 }
 
+func TestAgentStartupImmediatelyRecoversProcessOwnedTaskLease(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	clock := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return clock }
+	node := enrollOrchestrationNode(t, store, "startup-lease-recovery", NodeCapabilities{Docker: true}, []networking.Candidate{{Address: "10.0.0.12", Interface: "eth0", Kind: networking.KindLAN}}, networking.Profile{ServiceAddress: "10.0.0.12", LANAddress: "10.0.0.12", EnabledKinds: []string{networking.KindLAN}})
+	if _, err := store.CreateDeployment(ctx, DeploymentRequest{AgentID: node.ID, AppKey: cpaAppKey, Config: json.RawMessage(`{"debug":false}`)}); err != nil {
+		t.Fatal(err)
+	}
+	first := claimTask(t, store, node)
+	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, NodeHeartbeat{
+		Version:                      "restarted",
+		Roles:                        []string{"worker"},
+		Capabilities:                 NodeCapabilities{Docker: true},
+		ApplicationRuntimeGeneration: platform.ApplicationRuntimeGeneration,
+		Startup:                      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second := claimTask(t, store, node)
+	if second.ID != first.ID || second.Attempt != first.Attempt+1 {
+		t.Fatalf("startup task recovery = %#v, first=%#v", second, first)
+	}
+}
+
 func TestDeploymentCompletionUsesCapturedServiceAddress(t *testing.T) {
 	store := openOrchestrationStore(t)
 	defer store.Close()

--- a/internal/center/three_x_ui_topology.go
+++ b/internal/center/three_x_ui_topology.go
@@ -519,7 +519,18 @@ func (s *Store) completeThreeXUINodeCommand(ctx context.Context, tx *sql.Tx, tas
 		_ = s.cleanupStoppedPublications(context.WithoutCancel(ctx), cleanups)
 	}
 	if input.MigrationID != "" {
-		s.startBackground(func() { _ = s.resumeThreeXUIControllerConvergence(s.backgroundCtx) })
+		s.startBackground(func() {
+			_ = s.resumeThreeXUIControllerConvergence(s.backgroundCtx)
+			var migrationState string
+			if err := s.db.QueryRowContext(s.backgroundCtx, `SELECT state FROM three_x_ui_migrations WHERE id = ?`, input.MigrationID).Scan(&migrationState); err != nil || migrationState != "ready" {
+				return
+			}
+			var activeMigrations int
+			if err := s.db.QueryRowContext(s.backgroundCtx, `SELECT COUNT(*) FROM three_x_ui_migrations WHERE state IN ('backing_up', 'restoring', 'switching')`).Scan(&activeMigrations); err != nil || activeMigrations != 0 {
+				return
+			}
+			_ = s.startRealityGuardHardening(s.backgroundCtx)
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- keep Center and Agent 3x-ui node migration task contracts aligned
- send the startup heartbeat before starting the task loop and immediately recover leases owned by the previous Agent process
- resume REALITY guard hardening as soon as controller consolidation completes so HAProxy can return without waiting for the periodic retry

## Root cause
The Center included `migrationId` in a strict encrypted `3xui.node.reconcile` task, but the Agent task schema did not accept that field. The task stayed leased and retried every five minutes while REALITY publications remained quarantined.

## Validation
- added cross-package task-contract coverage
- added startup lease recovery coverage
- added steady-heartbeat startup-boundary coverage
- local tests/builds intentionally not run per repository instructions; required CI is the validation gate