### PR TITLE
feat(agent): reconnect offline nodes in place

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4236,15 +4236,6 @@
               "application/json": {
                 "schema": {}
               }
-            },
-            "headers": {
-              "Cache-Control": {
-                "description": "Prevents storage of the one-time enrollment token.",
-                "schema": {
-                  "type": "string",
-                  "const": "no-store"
-                }
-              }
             }
           },
           "400": {
@@ -4319,19 +4310,10 @@
         ],
         "responses": {
           "201": {
-            "description": "A one-time enrollment that replaces the offline Agent identity while preserving its Center node ID and relationships.",
+            "description": "Created.",
             "content": {
               "application/json": {
                 "schema": {}
-              }
-            },
-            "headers": {
-              "Cache-Control": {
-                "description": "Prevents storage of the one-time enrollment token.",
-                "schema": {
-                  "type": "string",
-                  "const": "no-store"
-                }
               }
             }
           },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4236,6 +4236,15 @@
               "application/json": {
                 "schema": {}
               }
+            },
+            "headers": {
+              "Cache-Control": {
+                "description": "Prevents storage of the one-time enrollment token.",
+                "schema": {
+                  "type": "string",
+                  "const": "no-store"
+                }
+              }
             }
           },
           "400": {
@@ -4292,6 +4301,67 @@
             }
           }
         }
+      }
+    },
+    "/api/v1/agents/{id}/reconnect": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Create Agent Reconnect Enrollment",
+        "operationId": "createAgentReconnectEnrollment_post",
+        "x-vastora-audience": "browser-admin",
+        "security": [
+          {
+            "AdminSession": [],
+            "AdminCSRF": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "A one-time enrollment that replaces the offline Agent identity while preserving its Center node ID and relationships.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "headers": {
+              "Cache-Control": {
+                "description": "Prevents storage of the one-time enrollment token.",
+                "schema": {
+                  "type": "string",
+                  "const": "no-store"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "409": {
+            "$ref": "#/components/responses/Error"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ]
       }
     },
     "/api/v1/agents/{id}": {

--- a/internal/center/agent_reconnect_test.go
+++ b/internal/center/agent_reconnect_test.go
@@ -1,0 +1,165 @@
+package center
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAgentReconnectEnrollmentReusesOfflineIdentity(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	clock := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return clock }
+	siteID := testSiteID(t, store)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO settings(key, value) VALUES(?, ?), (?, ?)`, agentConnectionModeSetting, "lan", agentConnectURLSetting, "https://center.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	originalEnrollment, err := store.CreateAgentEnrollment(ctx, AgentEnrollmentSpec{SiteID: siteID, Name: "DataWave 9929", CenterURL: "https://center.example.com", Gateway: true, Tunnel: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalKey := testAgentPublicKey(t)
+	original, err := store.EnrollAgent(ctx, originalEnrollment.Token, "0.1.0-alpha.103", "linux", "amd64", originalKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO site_gateways(site_id, agent_id, created_at) VALUES(?, ?, ?)`, siteID, original.ID, clock.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO agent_network_profiles(agent_id, service_address, lan_address, enabled_kinds_json, direct_public, confirmed_at, candidate_observed_at) VALUES(?, '10.0.0.7', '10.0.0.7', '["lan"]', 0, ?, ?)`, original.ID, clock.Format(time.RFC3339Nano), clock.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO applications(id, name, node_id, site_id, app_key, status, runtime, runtime_generation, created_at, updated_at) VALUES('preserved-app', 'Preserved app', ?, ?, 'test/preserved', 'running', 'docker', 7, ?, ?)`, original.ID, siteID, clock.Format(time.RFC3339Nano), clock.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateAgentReconnectEnrollment(ctx, original.ID); err == nil || !strings.Contains(err.Error(), "disconnect") {
+		t.Fatalf("connected Agent reconnect error = %v", err)
+	}
+
+	clock = clock.Add(time.Minute)
+	stale, err := store.CreateAgentReconnectEnrollment(ctx, original.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := store.CreateAgentReconnectEnrollment(ctx, original.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.EnrollAgent(ctx, stale.Token, "0.1.0-alpha.104", "linux", "amd64", testAgentPublicKey(t)); err == nil || !strings.Contains(err.Error(), "token is invalid") {
+		t.Fatalf("replaced reconnect command was accepted: %v", err)
+	}
+	if err := store.authenticateAgent(ctx, original.ID, original.Credential); err == nil {
+		t.Fatal("original Agent credential remained active after reconnect was requested")
+	}
+	profile, err := store.AgentEnrollmentInstallProfile(ctx, current.Token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.Name != "DataWave 9929" || !profile.Capabilities.Docker || !profile.Capabilities.Gateway || !profile.Capabilities.Tunnel || strings.Join(profile.Roles, ",") != "worker,gateway" {
+		t.Fatalf("reconnect profile changed: %#v", profile)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO agent_updates(id, agent_id, target_version, state, created_at, updated_at) VALUES('superseded-update', ?, '0.1.0-alpha.104', 'pending', ?, ?)`, original.ID, clock.Format(time.RFC3339Nano), clock.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	replacementKey := testAgentPublicKey(t)
+	replacement, err := store.EnrollAgentOperation(ctx, current.Token, "reconnect-operation-1", "0.1.0-alpha.104", "linux", "arm64", replacementKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacement.ID != original.ID || replacement.Credential == original.Credential || replacement.Name != "DataWave 9929" {
+		t.Fatalf("replacement identity = %#v, original ID = %q", replacement, original.ID)
+	}
+	replayed, err := store.EnrollAgentOperation(ctx, current.Token, "reconnect-operation-1", "0.1.0-alpha.104", "linux", "arm64", replacementKey)
+	if err != nil || replayed.ID != replacement.ID || replayed.Credential != replacement.Credential {
+		t.Fatalf("replayed reconnect = %#v, err = %v", replayed, err)
+	}
+	if err := store.authenticateAgent(ctx, replacement.ID, replacement.Credential); err != nil {
+		t.Fatalf("replacement credential was rejected: %v", err)
+	}
+	var agents, gateways, profiles, applications, applicationRuntimeGeneration int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agents`).Scan(&agents); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM site_gateways WHERE site_id = ? AND agent_id = ?`, siteID, original.ID).Scan(&gateways); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_network_profiles WHERE agent_id = ? AND service_address = '10.0.0.7'`, original.ID).Scan(&profiles); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*), COALESCE(MAX(runtime_generation), -1) FROM applications WHERE id = 'preserved-app' AND node_id = ?`, original.ID).Scan(&applications, &applicationRuntimeGeneration); err != nil {
+		t.Fatal(err)
+	}
+	if agents != 1 || gateways != 1 || profiles != 1 || applications != 1 || applicationRuntimeGeneration != 0 {
+		t.Fatalf("preserved records: agents=%d gateways=%d profiles=%d applications=%d appRuntime=%d", agents, gateways, profiles, applications, applicationRuntimeGeneration)
+	}
+	var name, storedSiteID, architecture, credentialRevokedAt, updateState string
+	var storedKey []byte
+	var appliedInstallations, runtimeGeneration, remoteUpdateSupported int
+	if err := store.db.QueryRowContext(ctx, `SELECT name, site_id, architecture, credential_revoked_at, x25519_public_key, applied_installations, runtime_generation, remote_update_supported FROM agents WHERE id = ?`, original.ID).Scan(&name, &storedSiteID, &architecture, &credentialRevokedAt, &storedKey, &appliedInstallations, &runtimeGeneration, &remoteUpdateSupported); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT state FROM agent_updates WHERE id = 'superseded-update'`).Scan(&updateState); err != nil {
+		t.Fatal(err)
+	}
+	if name != "DataWave 9929" || storedSiteID != siteID || architecture != "arm64" || credentialRevokedAt != "" || !bytes.Equal(storedKey, replacementKey) || appliedInstallations != 0 || runtimeGeneration != 0 || remoteUpdateSupported != 0 || updateState != "failed" {
+		t.Fatalf("reconnected Agent state changed incorrectly: name=%q site=%q arch=%q revoked=%q installs=%d runtime=%d update=%d updateState=%q", name, storedSiteID, architecture, credentialRevokedAt, appliedInstallations, runtimeGeneration, remoteUpdateSupported, updateState)
+	}
+}
+
+func TestMigration59AddsAgentReconnectTargetBinding(t *testing.T) {
+	directory := t.TempDir()
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siteID := testSiteID(t, store)
+	if _, err := store.CreateAgentEnrollment(context.Background(), AgentEnrollmentSpec{SiteID: siteID, Name: "existing enrollment", CenterURL: "https://center.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", filepath.Join(directory, "center.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DROP INDEX agent_enrollment_one_reconnect_idx;
+		ALTER TABLE agent_enrollment_tokens DROP COLUMN target_agent_id;
+		DELETE FROM goose_db_version WHERE version_id >= 59;
+		PRAGMA user_version = 58;`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrated.Close()
+	var columns, indexes, enrollments int
+	if err := migrated.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('agent_enrollment_tokens') WHERE name = 'target_agent_id'`).Scan(&columns); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrated.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'agent_enrollment_one_reconnect_idx'`).Scan(&indexes); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrated.db.QueryRow(`SELECT COUNT(*) FROM agent_enrollment_tokens WHERE target_agent_id IS NULL`).Scan(&enrollments); err != nil {
+		t.Fatal(err)
+	}
+	if columns != 1 || indexes != 1 || enrollments != 1 {
+		t.Fatalf("migration result: columns=%d indexes=%d enrollments=%d", columns, indexes, enrollments)
+	}
+}

--- a/internal/center/database_key_binding_test.go
+++ b/internal/center/database_key_binding_test.go
@@ -222,6 +222,8 @@ func makeLegacyUnboundCenter(t *testing.T, directory string) {
 		ALTER TABLE deployments DROP COLUMN change_proposal_id;
 		ALTER TABLE deployments DROP COLUMN executed_runtime_generation;
 		ALTER TABLE application_commands DROP COLUMN reconciliation_requested;
+		DROP INDEX agent_enrollment_one_reconnect_idx;
+		ALTER TABLE agent_enrollment_tokens DROP COLUMN target_agent_id;
 		ALTER TABLE agent_enrollment_tokens DROP COLUMN ca_certificate_pem;
 		ALTER TABLE agent_network_profiles DROP COLUMN public_verified_at;
 		ALTER TABLE agent_network_profiles DROP COLUMN public_mode;

--- a/internal/center/migrations/00059_agent_reconnect_enrollment.sql
+++ b/internal/center/migrations/00059_agent_reconnect_enrollment.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+ALTER TABLE agent_enrollment_tokens
+ADD COLUMN target_agent_id TEXT REFERENCES agents(id) ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX agent_enrollment_one_reconnect_idx
+ON agent_enrollment_tokens(target_agent_id)
+WHERE target_agent_id IS NOT NULL;
+
+PRAGMA user_version = 59;
+
+-- +goose Down
+SELECT RAISE(ABORT, 'Vastora Center database downgrades are not supported');

--- a/internal/center/migrations_test.go
+++ b/internal/center/migrations_test.go
@@ -184,6 +184,8 @@ func TestVersion56MigrationSeparatesNodeDirectIngressAndFailsClosedOnCrossNodeRo
 		DROP TABLE publications;
 		ALTER TABLE publications_v55 RENAME TO publications;
 		DROP TABLE node_listener_states;
+		DROP INDEX agent_enrollment_one_reconnect_idx;
+		ALTER TABLE agent_enrollment_tokens DROP COLUMN target_agent_id;
 		DELETE FROM goose_db_version WHERE version_id >= 56;
 		PRAGMA user_version = 55;
 		PRAGMA foreign_keys = ON;`)
@@ -688,6 +690,8 @@ func TestVersion42MigrationDropsOnlyLegacyCatalogCache(t *testing.T) {
 	}
 	for _, statement := range []string{
 		`DROP TABLE agent_updates`,
+		`DROP INDEX agent_enrollment_one_reconnect_idx`,
+		`ALTER TABLE agent_enrollment_tokens DROP COLUMN target_agent_id`,
 		`ALTER TABLE publications DROP COLUMN access_application_id`,
 		`ALTER TABLE application_commands DROP COLUMN reconciliation_requested`,
 		`ALTER TABLE agent_enrollment_tokens DROP COLUMN ca_certificate_pem`,
@@ -744,6 +748,8 @@ func TestVersion52MigrationPreservesBuiltinHeadscaleCloudflareDNS(t *testing.T) 
 		VALUES('headscale', 'builtin', 'https://headscale.example.com', NULL, 'failed', ?, ?);
 		DELETE FROM settings WHERE key IN ('headscale_dns_policy', 'headscale_dns_resolvers');
 		ALTER TABLE agent_decommissions DROP COLUMN callback_token_hash;
+		DROP INDEX agent_enrollment_one_reconnect_idx;
+		ALTER TABLE agent_enrollment_tokens DROP COLUMN target_agent_id;
 		DELETE FROM goose_db_version WHERE version_id >= 52;
 		PRAGMA user_version = 51`, now, now); err != nil {
 		t.Fatal(err)
@@ -1485,6 +1491,8 @@ func createLegacyVersion3Database(t *testing.T, directory string) {
 		`ALTER TABLE deployments DROP COLUMN runtime_generation`,
 		`ALTER TABLE deployments DROP COLUMN reconciliation_requested`,
 		`ALTER TABLE application_commands DROP COLUMN reconciliation_requested`,
+		`DROP INDEX agent_enrollment_one_reconnect_idx`,
+		`ALTER TABLE agent_enrollment_tokens DROP COLUMN target_agent_id`,
 		`ALTER TABLE agent_enrollment_tokens DROP COLUMN ca_certificate_pem`,
 		`ALTER TABLE deployments DROP COLUMN registry_credential_id`,
 		`ALTER TABLE deployments DROP COLUMN change_proposal_id`,

--- a/internal/center/schema.go
+++ b/internal/center/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const centerSchemaVersion = 58
+const centerSchemaVersion = 59
 
 func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
@@ -144,9 +144,11 @@ func (s *Store) initializeCurrentSchema(ctx context.Context) error {
 			bootstrap_secret_id TEXT REFERENCES secrets(id) ON DELETE SET NULL,
 			ca_fingerprint TEXT NOT NULL DEFAULT '',
 			ca_certificate_pem TEXT NOT NULL DEFAULT '',
+			target_agent_id TEXT REFERENCES agents(id) ON DELETE CASCADE,
 			expires_at TEXT NOT NULL,
 			used_at TEXT
 		)`,
+		`CREATE UNIQUE INDEX agent_enrollment_one_reconnect_idx ON agent_enrollment_tokens(target_agent_id) WHERE target_agent_id IS NOT NULL`,
 		`CREATE TABLE agents (
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,

--- a/internal/center/server.go
+++ b/internal/center/server.go
@@ -179,6 +179,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/v1/regions", s.requireAuth(false, s.handleListRegions))
 	mux.HandleFunc("GET /api/v1/agents/{id}/region-suggestion", s.requireAuth(false, s.handleSuggestAgentRegion))
 	mux.HandleFunc("POST /api/v1/agent-enrollments", s.requireAuth(true, s.handleCreateAgentEnrollment))
+	mux.HandleFunc("POST /api/v1/agents/{id}/reconnect", s.requireAuth(true, s.handleCreateAgentReconnectEnrollment))
 	mux.HandleFunc("PATCH /api/v1/agents/{id}", s.requireAuth(true, s.handleUpdateAgent))
 	mux.HandleFunc("POST /api/v1/agents/{id}/updates", s.requireAuth(true, s.handleQueueAgentUpdate))
 	mux.HandleFunc("DELETE /api/v1/agents/{id}", s.requireAuth(true, s.handleDisableAgent))

--- a/internal/center/server_agent.go
+++ b/internal/center/server_agent.go
@@ -96,6 +96,17 @@ func (s *Server) handleCreateAgentEnrollment(writer http.ResponseWriter, request
 		writeError(writer, http.StatusBadRequest, err)
 		return
 	}
+	writer.Header().Set("Cache-Control", "no-store")
+	writeJSON(writer, http.StatusCreated, enrollment)
+}
+
+func (s *Server) handleCreateAgentReconnectEnrollment(writer http.ResponseWriter, request *http.Request) {
+	enrollment, err := s.store.CreateAgentReconnectEnrollment(request.Context(), request.PathValue("id"))
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, err)
+		return
+	}
+	writer.Header().Set("Cache-Control", "no-store")
 	writeJSON(writer, http.StatusCreated, enrollment)
 }
 

--- a/internal/center/store_agent.go
+++ b/internal/center/store_agent.go
@@ -90,6 +90,59 @@ type AgentView struct {
 }
 
 func (s *Store) CreateAgentEnrollment(ctx context.Context, spec AgentEnrollmentSpec) (AgentEnrollment, error) {
+	roles := []string{"worker"}
+	if spec.Gateway {
+		roles = append(roles, "gateway")
+	}
+	capabilities := NodeCapabilities{Docker: true, Gateway: spec.Gateway, Tunnel: spec.Tunnel}
+	rolesJSON, _ := json.Marshal(roles)
+	capabilitiesJSON, _ := json.Marshal(capabilities)
+	return s.createAgentEnrollment(ctx, spec, rolesJSON, capabilitiesJSON, "")
+}
+
+func (s *Store) CreateAgentReconnectEnrollment(ctx context.Context, agentID string) (AgentEnrollment, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return AgentEnrollment{}, errors.New("center: Agent not found")
+	}
+	network, err := s.CenterNetworkConfig(ctx)
+	if err != nil {
+		return AgentEnrollment{}, err
+	}
+	var spec AgentEnrollmentSpec
+	var status, lastSeenAt, credentialRevokedAt string
+	var rolesJSON, capabilitiesJSON []byte
+	err = s.db.QueryRowContext(ctx, `SELECT site_id, name, status, last_seen_at, credential_revoked_at, roles_json, capabilities_json FROM agents WHERE id = ?`, agentID).Scan(
+		&spec.SiteID, &spec.Name, &status, &lastSeenAt, &credentialRevokedAt, &rolesJSON, &capabilitiesJSON,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentEnrollment{}, errors.New("center: Agent not found")
+	}
+	if err != nil {
+		return AgentEnrollment{}, fmt.Errorf("center: inspect Agent reconnect state: %w", err)
+	}
+	if status != "active" {
+		return AgentEnrollment{}, errors.New("center: only an active Agent can reconnect")
+	}
+	lastSeen, err := time.Parse(time.RFC3339Nano, lastSeenAt)
+	if err != nil {
+		return AgentEnrollment{}, errors.New("center: stored Agent heartbeat time is invalid")
+	}
+	if credentialRevokedAt == "" && lastSeen.After(s.now().UTC().Add(-agentConnectedMaxAge)) {
+		return AgentEnrollment{}, errors.New("center: disconnect the Agent before generating a reconnect command")
+	}
+	profile := AgentEnrollmentInstallProfile{Name: spec.Name}
+	if err := decodeAgentEnrollmentRuntime(rolesJSON, capabilitiesJSON, &profile); err != nil {
+		return AgentEnrollment{}, err
+	}
+	spec.CenterURL = network.AgentConnectURL
+	spec.UseHeadscale = network.AgentConnectionMode == "headscale"
+	spec.Gateway = profile.Capabilities.Gateway
+	spec.Tunnel = profile.Capabilities.Tunnel
+	return s.createAgentEnrollment(ctx, spec, rolesJSON, capabilitiesJSON, agentID)
+}
+
+func (s *Store) createAgentEnrollment(ctx context.Context, spec AgentEnrollmentSpec, rolesJSON, capabilitiesJSON []byte, targetAgentID string) (AgentEnrollment, error) {
 	spec.SiteID = strings.TrimSpace(spec.SiteID)
 	spec.Name = strings.TrimSpace(spec.Name)
 	if spec.Name == "" || len(spec.Name) > 128 {
@@ -129,13 +182,10 @@ func (s *Store) CreateAgentEnrollment(ctx context.Context, spec AgentEnrollmentS
 			return AgentEnrollment{}, errors.New("center: Agent CA fingerprint must be a SHA-256 public-key fingerprint")
 		}
 	}
-	roles := []string{"worker"}
-	if spec.Gateway {
-		roles = append(roles, "gateway")
+	profile := AgentEnrollmentInstallProfile{Name: spec.Name}
+	if err := decodeAgentEnrollmentRuntime(rolesJSON, capabilitiesJSON, &profile); err != nil {
+		return AgentEnrollment{}, err
 	}
-	capabilities := NodeCapabilities{Docker: true, Gateway: spec.Gateway, Tunnel: spec.Tunnel}
-	rolesJSON, _ := json.Marshal(roles)
-	capabilitiesJSON, _ := json.Marshal(capabilities)
 	if spec.SiteID == "" {
 		return AgentEnrollment{}, errors.New("center: enrollment site is required")
 	}
@@ -182,6 +232,41 @@ func (s *Store) CreateAgentEnrollment(ctx context.Context, spec AgentEnrollmentS
 	)`, now); err != nil {
 		return AgentEnrollment{}, fmt.Errorf("center: delete expired Agent enrollments: %w", err)
 	}
+	if targetAgentID != "" {
+		var currentStatus, currentLastSeenAt, currentCredentialRevokedAt string
+		var decommissioning int
+		if err := tx.QueryRowContext(ctx, `SELECT status, last_seen_at, credential_revoked_at,
+			EXISTS(SELECT 1 FROM agent_decommissions WHERE agent_id = agents.id AND state IN ('pending', 'running', 'cleaning'))
+			FROM agents WHERE id = ?`, targetAgentID).Scan(&currentStatus, &currentLastSeenAt, &currentCredentialRevokedAt, &decommissioning); errors.Is(err, sql.ErrNoRows) {
+			return AgentEnrollment{}, errors.New("center: Agent not found")
+		} else if err != nil {
+			return AgentEnrollment{}, fmt.Errorf("center: verify Agent reconnect state: %w", err)
+		}
+		currentLastSeen, err := time.Parse(time.RFC3339Nano, currentLastSeenAt)
+		if err != nil {
+			return AgentEnrollment{}, errors.New("center: stored Agent heartbeat time is invalid")
+		}
+		if currentStatus != "active" {
+			return AgentEnrollment{}, errors.New("center: only an active Agent can reconnect")
+		}
+		if decommissioning != 0 {
+			return AgentEnrollment{}, errors.New("center: Agent decommissioning must finish before reconnecting")
+		}
+		if currentCredentialRevokedAt == "" && currentLastSeen.After(s.now().UTC().Add(-agentConnectedMaxAge)) {
+			return AgentEnrollment{}, errors.New("center: disconnect the Agent before generating a reconnect command")
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id IN (
+			SELECT bootstrap_secret_id FROM agent_enrollment_tokens WHERE target_agent_id = ? AND bootstrap_secret_id IS NOT NULL
+		)`, targetAgentID); err != nil {
+			return AgentEnrollment{}, fmt.Errorf("center: delete replaced Agent reconnect secret: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_enrollment_tokens WHERE target_agent_id = ?`, targetAgentID); err != nil {
+			return AgentEnrollment{}, fmt.Errorf("center: invalidate replaced Agent reconnect command: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE agents SET credential_revoked_at = ? WHERE id = ?`, now, targetAgentID); err != nil {
+			return AgentEnrollment{}, fmt.Errorf("center: revoke replaced Agent credential: %w", err)
+		}
+	}
 	var bootstrapSecretID sql.NullString
 	if bootstrapCommand != "" {
 		secretID, err := s.putSecret(ctx, tx, []byte(bootstrapCommand), agentEnrollmentSecretContext(token))
@@ -190,11 +275,15 @@ func (s *Store) CreateAgentEnrollment(ctx context.Context, spec AgentEnrollmentS
 		}
 		bootstrapSecretID = sql.NullString{String: secretID, Valid: true}
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO agent_enrollment_tokens(token_hash, site_id, name, center_url, roles_json, capabilities_json, bootstrap_secret_id, ca_fingerprint, ca_certificate_pem, expires_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, tokenHash(token), spec.SiteID, spec.Name, centerURL, rolesJSON, capabilitiesJSON, bootstrapSecretID, spec.CAFingerprint, spec.CACertificatePEM, enrollment.ExpiresAt.Format(time.RFC3339Nano)); err != nil {
+	targetAgent := sql.NullString{String: targetAgentID, Valid: targetAgentID != ""}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO agent_enrollment_tokens(token_hash, site_id, name, center_url, roles_json, capabilities_json, bootstrap_secret_id, ca_fingerprint, ca_certificate_pem, target_agent_id, expires_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, tokenHash(token), spec.SiteID, spec.Name, centerURL, rolesJSON, capabilitiesJSON, bootstrapSecretID, spec.CAFingerprint, spec.CACertificatePEM, targetAgent, enrollment.ExpiresAt.Format(time.RFC3339Nano)); err != nil {
 		return AgentEnrollment{}, fmt.Errorf("center: create agent enrollment: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return AgentEnrollment{}, fmt.Errorf("center: commit agent enrollment: %w", err)
+	}
+	if targetAgentID != "" {
+		s.taskChanges.notify("agent:" + targetAgentID)
 	}
 	return enrollment, nil
 }
@@ -319,8 +408,8 @@ func (s *Store) EnrollAgentOperation(ctx context.Context, enrollmentToken, opera
 	defer tx.Rollback()
 	var expiresAt, siteID, name string
 	var rolesJSON, capabilitiesJSON []byte
-	var usedAt, bootstrapSecretID sql.NullString
-	err = tx.QueryRowContext(ctx, `SELECT expires_at, used_at, site_id, name, roles_json, capabilities_json, bootstrap_secret_id FROM agent_enrollment_tokens WHERE token_hash = ?`, enrollmentTokenHash).Scan(&expiresAt, &usedAt, &siteID, &name, &rolesJSON, &capabilitiesJSON, &bootstrapSecretID)
+	var usedAt, bootstrapSecretID, targetAgent sql.NullString
+	err = tx.QueryRowContext(ctx, `SELECT expires_at, used_at, site_id, name, roles_json, capabilities_json, bootstrap_secret_id, target_agent_id FROM agent_enrollment_tokens WHERE token_hash = ?`, enrollmentTokenHash).Scan(&expiresAt, &usedAt, &siteID, &name, &rolesJSON, &capabilitiesJSON, &bootstrapSecretID, &targetAgent)
 	if errors.Is(err, sql.ErrNoRows) {
 		return AgentCredential{}, errors.New("center: agent enrollment token is invalid")
 	}
@@ -338,9 +427,13 @@ func (s *Store) EnrollAgentOperation(ctx context.Context, enrollmentToken, opera
 	if err := decodeAgentEnrollmentRuntime(rolesJSON, capabilitiesJSON, &profile); err != nil {
 		return AgentCredential{}, err
 	}
-	id, err := randomToken(18)
-	if err != nil {
-		return AgentCredential{}, err
+	targetAgentID := targetAgent.String
+	id := targetAgentID
+	if id == "" {
+		id, err = randomToken(18)
+		if err != nil {
+			return AgentCredential{}, err
+		}
 	}
 	credential, err := randomToken(32)
 	if err != nil {
@@ -356,8 +449,28 @@ func (s *Store) EnrollAgentOperation(ctx context.Context, enrollmentToken, opera
 	if err != nil {
 		return AgentCredential{}, err
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO agents(id, name, credential_hash, x25519_public_key, version, operating_system, architecture, status, enrolled_at, last_seen_at, site_id, roles_json, capabilities_json) VALUES(?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)`, id, name, tokenHash(credential), append([]byte(nil), publicKey...), version, target.OS, target.Architecture, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano), siteID, rolesJSON, capabilitiesJSON); err != nil {
-		return AgentCredential{}, fmt.Errorf("center: save agent: %w", err)
+	if targetAgentID == "" {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO agents(id, name, credential_hash, x25519_public_key, version, operating_system, architecture, status, enrolled_at, last_seen_at, site_id, roles_json, capabilities_json) VALUES(?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)`, id, name, tokenHash(credential), append([]byte(nil), publicKey...), version, target.OS, target.Architecture, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano), siteID, rolesJSON, capabilitiesJSON); err != nil {
+			return AgentCredential{}, fmt.Errorf("center: save agent: %w", err)
+		}
+	} else {
+		result, err := tx.ExecContext(ctx, `UPDATE agents SET credential_hash = ?, x25519_public_key = ?, version = ?, operating_system = ?, architecture = ?, credential_revoked_at = '', applied_installations = 0, gateway_healthy = 0, runtime_generation = 0, tailscale_ownership = '', remote_update_supported = 0, last_seen_at = ? WHERE id = ? AND status = 'active' AND credential_revoked_at <> ''`, tokenHash(credential), append([]byte(nil), publicKey...), version, target.OS, target.Architecture, now.Format(time.RFC3339Nano), targetAgentID)
+		if err != nil {
+			return AgentCredential{}, fmt.Errorf("center: replace Agent identity: %w", err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return AgentCredential{}, errors.New("center: Agent reconnect command is no longer valid")
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_updates SET state = 'failed', lease_expires_at = '', last_error = 'superseded by Agent reconnect', updated_at = ? WHERE agent_id = ? AND state IN ('pending', 'running', 'installing')`, now.Format(time.RFC3339Nano), targetAgentID); err != nil {
+			return AgentCredential{}, fmt.Errorf("center: retire superseded Agent update: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE applications SET runtime_generation = 0 WHERE node_id = ?`, targetAgentID); err != nil {
+			return AgentCredential{}, fmt.Errorf("center: prepare Agent applications for reconnect reconciliation: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_enrollment_operations WHERE agent_id = ?`, targetAgentID); err != nil {
+			return AgentCredential{}, fmt.Errorf("center: replace Agent enrollment recovery operation: %w", err)
+		}
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO agent_enrollment_operations(token_hash, operation_id, request_hash, agent_id, response_secret_id, expires_at, created_at)
 		VALUES(?, ?, ?, ?, ?, ?, ?)`, enrollmentTokenHash, operationID, requestHash[:], id, responseSecretID, now.Add(agentEnrollmentReplayLifetime).Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -96,6 +96,7 @@ export const api = {
 	deleteRegistryCredential: (id: string) => request<{ deleted: boolean }>(`/api/v1/registry-credentials/${encodeURIComponent(id)}`, { method: "DELETE", body: "{}" }),
 	agents: (signal?: AbortSignal) => request<{ agents: AgentView[] }>("/api/v1/agents", { signal }),
 	createAgentEnrollment: (siteId: string, name: string, centerUrl: string, useHeadscale: boolean, gateway: boolean, tunnel: boolean, caCertificatePem = "") => request<AgentEnrollment>("/api/v1/agent-enrollments", { method: "POST", body: JSON.stringify({ siteId, name, centerUrl, useHeadscale, gateway, tunnel, caCertificatePem }) }),
+	createAgentReconnectEnrollment: (agentId: string) => request<AgentEnrollment>(`/api/v1/agents/${encodeURIComponent(agentId)}/reconnect`, { method: "POST", body: "{}" }),
   deployments: (signal?: AbortSignal) => request<{ deployments: Deployment[] }>("/api/v1/deployments", { signal }),
 	sites: (signal?: AbortSignal) => request<{ sites: Site[] }>("/api/v1/sites", { signal }),
 	organizations: () => request<{ organizations: Organization[] }>("/api/v1/organizations"),

--- a/web/src/views/NodesView.tsx
+++ b/web/src/views/NodesView.tsx
@@ -39,24 +39,44 @@ export function agentInstallCommand({ centerURL, enrollment, installerAvailable 
 export function NodesView({ data, language, mutate, onAddFirstNodeHandled, onNavigate, startAdding = false }: { data: AppData; language: Language; mutate: Mutate; onAddFirstNodeHandled?: () => void; onNavigate: (screen: Screen) => void; startAdding?: boolean }) {
   const [adding, setAdding] = useState(false);
   const [editing, setEditing] = useState<AgentView | null>(null);
+  const [reconnecting, setReconnecting] = useState<{ agent: AgentView; enrollment: AgentEnrollment | null; busy: boolean; error: string } | null>(null);
+  const reconnectRequest = useRef(0);
   const currentEditing = editing ? data.agents.find((agent) => agent.id === editing.id) ?? editing : null;
+  const currentReconnecting = reconnecting ? data.agents.find((agent) => agent.id === reconnecting.agent.id) ?? reconnecting.agent : null;
   useEffect(() => {
     if (startAdding) setAdding(true);
   }, [startAdding]);
+  const beginReconnect = async (agent: AgentView) => {
+    const request = ++reconnectRequest.current;
+    setReconnecting({ agent, enrollment: null, busy: true, error: "" });
+    try {
+      const enrollment = await api.createAgentReconnectEnrollment(agent.id);
+      if (reconnectRequest.current !== request) return;
+      setReconnecting({ agent, enrollment, busy: false, error: "" });
+    } catch (reconnectError) {
+      if (reconnectRequest.current !== request) return;
+      setReconnecting({ agent, enrollment: null, busy: false, error: userError(language, reconnectError) });
+    }
+  };
+  const closeReconnect = () => {
+    reconnectRequest.current += 1;
+    setReconnecting(null);
+  };
   const siteGroups = data.sites.map((site) => ({ site, agents: data.agents.filter((agent) => agent.siteId === site.id) })).filter((group) => group.agents.length > 0);
   return <section className="flex flex-col gap-7">
     <PageHeading title={copy(language, "节点", "Nodes")} description={copy(language, "节点是运行应用的设备。添加后，Center 会自动发现它的网络。", "Nodes are devices that run apps. Center discovers their networks after they join.")} action={<Button onClick={() => setAdding(true)}><PlusIcon data-icon="inline-start" />{copy(language, "添加节点", "Add node")}</Button>} />
-    {data.agents.length === 0 ? <Empty className="border"><EmptyHeader><EmptyMedia variant="icon"><ServerIcon /></EmptyMedia><EmptyTitle>{copy(language, "添加第一台节点", "Add your first node")}</EmptyTitle><EmptyDescription>{copy(language, "当前 Center 主机或另一台受支持的 Linux 设备都可以作为节点；复制一条命令即可按需安装 Docker 和 Agent。", "The current Center host or another supported Linux device can be a node. Copy one command to install Docker when needed and then install Agent.")}</EmptyDescription><Button className="mt-3" onClick={() => setAdding(true)}><PlusIcon data-icon="inline-start" />{copy(language, "开始添加", "Get started")}</Button></EmptyHeader></Empty> : <div className="flex flex-col gap-7">{siteGroups.map(({ site, agents }) => <section className="flex flex-col gap-3" key={site.id}><div className="flex items-center gap-2"><MapPinIcon className="size-4 text-muted-foreground" /><h2 className="text-sm font-semibold">{site.name}</h2><Badge variant="secondary">{site.code}</Badge><span className="text-xs text-muted-foreground">{copy(language, `${agents.length} 台节点`, `${agents.length} node${agents.length === 1 ? "" : "s"}`)}</span></div><div className="grid gap-4 lg:grid-cols-2">{agents.map((agent) => <NodeCard agent={agent} data={data} key={agent.id} language={language} onConfigure={() => setEditing(agent)} onNetwork={() => onNavigate("network")} />)}</div></section>)}</div>}
+    {data.agents.length === 0 ? <Empty className="border"><EmptyHeader><EmptyMedia variant="icon"><ServerIcon /></EmptyMedia><EmptyTitle>{copy(language, "添加第一台节点", "Add your first node")}</EmptyTitle><EmptyDescription>{copy(language, "当前 Center 主机或另一台受支持的 Linux 设备都可以作为节点；复制一条命令即可按需安装 Docker 和 Agent。", "The current Center host or another supported Linux device can be a node. Copy one command to install Docker when needed and then install Agent.")}</EmptyDescription><Button className="mt-3" onClick={() => setAdding(true)}><PlusIcon data-icon="inline-start" />{copy(language, "开始添加", "Get started")}</Button></EmptyHeader></Empty> : <div className="flex flex-col gap-7">{siteGroups.map(({ site, agents }) => <section className="flex flex-col gap-3" key={site.id}><div className="flex items-center gap-2"><MapPinIcon className="size-4 text-muted-foreground" /><h2 className="text-sm font-semibold">{site.name}</h2><Badge variant="secondary">{site.code}</Badge><span className="text-xs text-muted-foreground">{copy(language, `${agents.length} 台节点`, `${agents.length} node${agents.length === 1 ? "" : "s"}`)}</span></div><div className="grid gap-4 lg:grid-cols-2">{agents.map((agent) => <NodeCard agent={agent} data={data} key={agent.id} language={language} onConfigure={() => setEditing(agent)} onNetwork={() => onNavigate("network")} onReconnect={() => void beginReconnect(agent)} />)}</div></section>)}</div>}
     <AddNodeSheet data={data} language={language} onClose={() => { setAdding(false); onAddFirstNodeHandled?.(); }} onJoined={() => { setAdding(false); onAddFirstNodeHandled?.(); onNavigate("network"); }} open={adding} />
     <NodeSettingsSheet agent={currentEditing} data={data} language={language} mutate={mutate} onClose={() => setEditing(null)} />
+    <ReconnectNodeSheet agent={currentReconnecting} busy={reconnecting?.busy ?? false} enrollment={reconnecting?.enrollment ?? null} error={reconnecting?.error ?? ""} installerAvailable={data.status.agentInstallerAvailable} language={language} onClose={closeReconnect} onRetry={() => { if (currentReconnecting) void beginReconnect(currentReconnecting); }} />
   </section>;
 }
 
-function NodeCard({ agent, data, language, onConfigure, onNetwork }: { agent: AgentView; data: AppData; language: Language; onConfigure: () => void; onNetwork: () => void }) {
+function NodeCard({ agent, data, language, onConfigure, onNetwork, onReconnect }: { agent: AgentView; data: AppData; language: Language; onConfigure: () => void; onNetwork: () => void; onReconnect: () => void }) {
   const site = data.sites.find((value) => value.id === agent.siteId);
   const selectedGateway = Boolean(site?.gatewayNodes.includes(agent.id));
   const architecture = agent.architecture === "arm64" ? "ARM64" : "x64";
-  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><ServerIcon />{agent.name}</CardTitle><CardDescription>{copy(language, "位置", "Location")}：{site?.name ?? agent.siteId} · {agent.version}</CardDescription><CardAction><StateBadge value={agent.status === "disabled" ? "disabled" : agent.connected ? "connected" : "offline"} /></CardAction></CardHeader><CardContent className="flex flex-col gap-4"><div className="flex flex-wrap gap-2"><Badge variant="outline">{architecture}</Badge>{agent.capabilities.docker ? <Badge variant="secondary">{copy(language, "运行应用", "Runs apps")}</Badge> : null}{selectedGateway ? <Badge variant="default">{copy(language, "当前位置网关", "Location gateway")}</Badge> : agent.capabilities.gateway ? <Badge variant="outline">{copy(language, "可作为网关", "Gateway capable")}</Badge> : null}{agent.capabilities.tunnel ? <Badge variant="outline">Cloudflare</Badge> : null}</div><dl className="grid grid-cols-2 gap-4 text-sm"><div><dt className="text-muted-foreground">{copy(language, "网络", "Network")}</dt><dd className="mt-1 font-medium">{agent.networkProfile ? copy(language, "已确认", "Confirmed") : copy(language, "需要确认", "Needs confirmation")}</dd></div><div><dt className="text-muted-foreground">{copy(language, "最后在线", "Last seen")}</dt><dd className="mt-1 font-medium">{formatDate(language, agent.lastSeenAt)}</dd></div><div className="col-span-2"><dt className="text-muted-foreground">{copy(language, "私有服务地址", "Private service address")}</dt><dd className="mt-1 font-mono text-xs">{agent.networkProfile?.serviceAddress || "—"}</dd></div></dl></CardContent><CardFooter className="justify-end gap-2">{agent.status === "active" && !agent.networkProfile ? <Button onClick={onNetwork} size="sm"><NetworkIcon data-icon="inline-start" />{copy(language, "确认网络", "Confirm network")}</Button> : null}{agent.status === "active" ? <Button onClick={onConfigure} size="sm" variant="outline"><Settings2Icon data-icon="inline-start" />{copy(language, "管理", "Manage")}</Button> : null}</CardFooter></Card>;
+  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><ServerIcon />{agent.name}</CardTitle><CardDescription>{copy(language, "位置", "Location")}：{site?.name ?? agent.siteId} · {agent.version}</CardDescription><CardAction><StateBadge value={agent.status === "disabled" ? "disabled" : agent.connected ? "connected" : "offline"} /></CardAction></CardHeader><CardContent className="flex flex-col gap-4"><div className="flex flex-wrap gap-2"><Badge variant="outline">{architecture}</Badge>{agent.capabilities.docker ? <Badge variant="secondary">{copy(language, "运行应用", "Runs apps")}</Badge> : null}{selectedGateway ? <Badge variant="default">{copy(language, "当前位置网关", "Location gateway")}</Badge> : agent.capabilities.gateway ? <Badge variant="outline">{copy(language, "可作为网关", "Gateway capable")}</Badge> : null}{agent.capabilities.tunnel ? <Badge variant="outline">Cloudflare</Badge> : null}</div><dl className="grid grid-cols-2 gap-4 text-sm"><div><dt className="text-muted-foreground">{copy(language, "网络", "Network")}</dt><dd className="mt-1 font-medium">{agent.networkProfile ? copy(language, "已确认", "Confirmed") : copy(language, "需要确认", "Needs confirmation")}</dd></div><div><dt className="text-muted-foreground">{copy(language, "最后在线", "Last seen")}</dt><dd className="mt-1 font-medium">{formatDate(language, agent.lastSeenAt)}</dd></div><div className="col-span-2"><dt className="text-muted-foreground">{copy(language, "私有服务地址", "Private service address")}</dt><dd className="mt-1 font-mono text-xs">{agent.networkProfile?.serviceAddress || "—"}</dd></div></dl></CardContent><CardFooter className="justify-end gap-2">{agent.status === "active" && !agent.networkProfile ? <Button onClick={onNetwork} size="sm"><NetworkIcon data-icon="inline-start" />{copy(language, "确认网络", "Confirm network")}</Button> : null}{agent.status === "active" && !agent.connected ? <Button onClick={onReconnect} size="sm" variant="outline"><RotateCcwIcon data-icon="inline-start" />{copy(language, "重新接入", "Reconnect")}</Button> : null}{agent.status === "active" ? <Button onClick={onConfigure} size="sm" variant="outline"><Settings2Icon data-icon="inline-start" />{copy(language, "管理", "Manage")}</Button> : null}</CardFooter></Card>;
 }
 
 function AddNodeSheet({ data, language, onClose, onJoined, open }: { data: AppData; language: Language; onClose: () => void; onJoined: () => void; open: boolean }) {
@@ -134,6 +154,33 @@ function AddNodeSheet({ data, language, onClose, onJoined, open }: { data: AppDa
           </form>
         )}
         {enrollment ? <SheetFooter><Button onClick={joinedAgent ? onJoined : close}>{joinedAgent ? <><NetworkIcon data-icon="inline-start" />{copy(language, "继续确认网络", "Continue to network setup")}</> : copy(language, "完成", "Done")}</Button></SheetFooter> : null}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ReconnectNodeSheet({ agent, busy, enrollment, error, installerAvailable, language, onClose, onRetry }: { agent: AgentView | null; busy: boolean; enrollment: AgentEnrollment | null; error: string; installerAvailable: boolean; language: Language; onClose: () => void; onRetry: () => void }) {
+  const command = enrollment ? agentInstallCommand({ centerURL: enrollment.centerUrl ?? "", enrollment, installerAvailable }) : "";
+  const connected = Boolean(agent?.connected);
+  return (
+    <Sheet onOpenChange={(next) => { if (!next) onClose(); }} open={Boolean(agent)}>
+      <SheetContent className="sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>{copy(language, `重新接入 ${agent?.name ?? ""}`, `Reconnect ${agent?.name ?? ""}`)}</SheetTitle>
+          <SheetDescription>{copy(language, "在重装后的原服务器运行新命令，Center 会替换 Agent 凭据而不是创建另一台节点。", "Run the new command on the reinstalled original server. Center replaces its Agent credential instead of creating another node.")}</SheetDescription>
+        </SheetHeader>
+        <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-4">
+          {busy ? <div aria-live="polite" className="flex items-center gap-3 rounded-xl border p-4"><Spinner /><div><p className="text-sm font-medium">{copy(language, "正在生成安全接入命令…", "Generating a secure reconnect command…")}</p><p className="mt-1 text-xs text-muted-foreground">{copy(language, "原 Agent 凭据会失效，新命令只可使用一次。", "The previous Agent credential will be invalidated and the new command can be used only once.")}</p></div></div> : null}
+          {error ? <Alert variant="destructive"><RotateCcwIcon /><AlertTitle>{copy(language, "无法生成重新接入命令", "Could not create reconnect command")}</AlertTitle><AlertDescription><p>{error}</p><Button className="mt-3" onClick={onRetry} size="sm" variant="outline"><RotateCcwIcon data-icon="inline-start" />{copy(language, "重试", "Retry")}</Button></AlertDescription></Alert> : null}
+          {enrollment && connected ? <Alert><CheckCircle2Icon /><AlertTitle>{copy(language, `${agent?.name ?? "节点"} 已重新接入`, `${agent?.name ?? "Node"} reconnected`)}</AlertTitle><AlertDescription>{copy(language, "Center 已接收新 Agent 的连接，原节点信息和关联关系保持不变。", "Center received the new Agent connection. The original node details and relationships were preserved.")}</AlertDescription></Alert> : null}
+          {enrollment && !connected ? <>
+            <Alert><ShieldCheckIcon /><AlertTitle>{copy(language, "保留原节点，替换身份", "Preserve the node and replace its identity")}</AlertTitle><AlertDescription>{copy(language, "节点 ID、名称、位置、用途、应用关系和已确认网络保持不变；旧 Agent 凭据已失效。", "The node ID, name, location, purpose, app relationships, and confirmed network remain unchanged. The previous Agent credential is now invalid.")}</AlertDescription></Alert>
+            <div className="relative"><code className="block max-h-56 overflow-auto break-all rounded-xl bg-muted p-4 pr-14 text-xs leading-6">{command}</code><CopyButton className="absolute right-2 top-2" label={copy(language, "复制命令", "Copy command")} language={language} size="icon" value={command} /></div>
+            <div aria-live="polite" className="flex items-start gap-3 rounded-xl border p-4"><Spinner className="mt-0.5" /><div><p className="text-sm font-medium">{copy(language, "正在等待原节点重新上线…", "Waiting for the original node to reconnect…")}</p><p className="mt-1 text-xs text-muted-foreground">{copy(language, `命令将在 ${formatDate(language, enrollment.expiresAt)} 失效。`, `The command expires at ${formatDate(language, enrollment.expiresAt)}.`)}</p></div></div>
+            <Alert><TerminalIcon /><AlertTitle>{copy(language, "在原服务器运行一次", "Run once on the original server")}</AlertTitle><AlertDescription>{installerAvailable ? copy(language, "支持 Debian 12/13 或 Ubuntu 22.04/24.04/26.04（x64/ARM64）；脚本会按需安装 Docker 和安全私网组件。", "Supports Debian 12/13 or Ubuntu 22.04/24.04/26.04 (x64/ARM64). The script installs Docker and secure-network components when needed.") : copy(language, "当前 Center 没有内置 Agent 文件，请先把 vastora 放到 /usr/local/bin/vastora。", "This Center does not include Agent binaries. Put vastora at /usr/local/bin/vastora first.")}</AlertDescription></Alert>
+          </> : null}
+        </div>
+        <SheetFooter><Button onClick={onClose}>{connected ? copy(language, "完成", "Done") : copy(language, "关闭", "Close")}</Button></SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -1768,6 +1768,29 @@ describe("network and app views", () => {
     expect(document.body.textContent).not.toContain("通过 Center 更新");
   });
 
+  it("generates a one-time reconnect command for an offline Agent", async () => {
+    const data = dashboard();
+    data.agents[0].connected = false;
+    const reconnect = vi.spyOn(api, "createAgentReconnectEnrollment").mockResolvedValue({
+      token: "replacement-token",
+      siteId: "site",
+      centerUrl: "https://center.example.com",
+      installerUrl: "https://center.example.com",
+      expiresAt: "2026-09-03T12:10:00Z"
+    });
+    const container = render(<NodesView data={data} language="zh-CN" mutate={async () => undefined} onNavigate={() => undefined} />);
+    const reconnectButton = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("重新接入"));
+    await act(async () => {
+      reconnectButton?.click();
+      await Promise.resolve();
+    });
+    expect(reconnect).toHaveBeenCalledWith("agent");
+    expect(document.body.textContent).toContain("保留原节点，替换身份");
+    expect(document.body.textContent).toContain("节点 ID、名称、位置、用途、应用关系和已确认网络保持不变");
+    expect(document.body.textContent).toContain("replacement-token");
+    expect(document.body.textContent).toContain("正在等待原节点重新上线");
+  });
+
   it("does not ask for integration secrets again when editing", () => {
     const data = dashboard();
     data.integrations = [


### PR DESCRIPTION
## Summary

- add an admin-only reconnect action for offline Agents
- rotate the Agent credential and X25519 identity while retaining the existing node ID and Center relationships
- preserve site, gateway, network profile, and application ownership, then reconcile desired application state after the replacement Agent starts
- add the Nodes UI flow, one-time command handling, schema migration, API contract, and regression coverage

## Safety

- reject reconnect requests while the Agent is still online or decommissioning
- invalidate older reconnect commands and revoke the previous Agent credential
- return enrollment tokens with Cache-Control: no-store

## Validation

Local tests and builds were not run, following the repository instruction. Required GitHub CI checks are the release gate.