### PR TITLE
feat: configurable Cloudflare Access session duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       - run: make go-format-check go-static-check
       - name: Verify Agent update recovery invariants
         run: go test ./cmd/vastora ./internal/agent ./internal/center -run '^(TestHostUpdate|TestAgentUpdate|TestUninstall.*Updater|TestCancelledUpdater)' -count=1
+      - name: Verify Cloudflare Access session configuration
+        run: go test ./internal/center -run 'Test.*(AccessSession|CenterRemoteAccess|CloudflareIntegration)' -count=1
       - name: Verify recovery and REALITY invariants
         run: |
           ci_test_status=0

--- a/docs/cloudflare-access-sessions.md
+++ b/docs/cloudflare-access-sessions.md
@@ -1,0 +1,54 @@
+# Cloudflare Access 会话时长（#365）
+
+## 使用入口
+
+网络 → Center 远程备用入口 → 修改 → 入口保护选择 Cloudflare Access。
+“Access 会话时长”默认 24 小时，可选择 15/30 分钟、1/6/12/24 小时、2/3/7/30 天。
+这是 Cloudflare 支持范围内的固定选项，不接受任意字符串、零、负数或超范围值。
+直达 Center 登录（native）模式不显示该选项，也不修改已保存的 Access 设置。
+
+保存后显示上次同步的入口数量和未完成的域名。发生拒绝、超时或部分失败时，
+保持原来的入口保护，再次“保存并同步”即可重试，不需要先关闭入口。
+页面关闭或 Center 重启后仍保留所选时长和同步结果；中途退出的 pending 状态明确提示重试，
+不会把它描述成已经成功。接口返回的 `accessSessionSync.status` 是同步结果，
+不能只用 HTTP 200 或入口自身的 `configured` 状态判断全部同步成功。
+
+## 配置与同步边界
+
+- 既有 `PUT /api/v1/network/center-remote-access` 接收 `accessSessionDuration`；GET/PUT 返回该值及 `accessSessionSync`。
+- `cloudflare_access_settings` 单例保存系统期望值和上次同步结果，独立于可删除的 Center 入口记录。
+- 迁移 66 为旧安装补默认值，不对 Cloudflare 发请求、不改变既有资源 ID；沿用升级前备份和失败关闭流程，不支持降级。
+- 仅修改时长时，Center 与未停止的托管应用入口均按数据库保存的 Access application ID 原地更新。
+  不搜索账户中的同名应用、不删除/重建应用、不修改 Tunnel 或 DNS。
+- GET 读取并检查应用身份，保留应用其他设置和原有策略关联，PUT 只改变应用会话时长。
+  API 返回确认的 ID 和时长才计为成功；失败保留期望值和未完成入口。重试时读取已达到目标的应用但不重复 PUT。
+- 分页检查应用策略；发现显式策略会话时长，保留并提示管理员在 Cloudflare 中选择“与应用相同”。
+  不改独立策略、可复用策略、邮箱允许列表、IdP 或服务令牌。
+- 保存操作与新建托管 Access 应用串行，避免新入口在同步快照之后沿用旧时长。
+  新建 Center/应用入口直接使用保存的期望值。
+- 同步总预算 45 秒，每个应用预算 8 秒；失败域名保留在返回值与数据库，具体原因仅写服务端日志。
+
+## 会话语义
+
+此设置只管理 **应用会话**。不改变 Cloudflare 账户的全局 SSO 会话、Cloudflare One Client
+会话，也不改变 Vastora 自身的登录有效期。显式策略及 Client 会话可能优先。
+应用令牌到期时，如果全局登录仍有效且仍满足策略，Cloudflare 可以续发应用令牌；
+所以不能承诺到期后必定重新输入邮箱验证码。
+
+参考：[Cloudflare 会话管理](https://developers.cloudflare.com/cloudflare-one/access-controls/access-settings/session-management/)、
+[更新 Access 应用 API](https://developers.cloudflare.com/api/resources/zero_trust/subresources/access/subresources/applications/methods/update/)。
+
+## 验证记录与上线验收
+
+已编写但本轮未运行：默认值/持久化/校验、65→66 迁移和备份、创建时长、
+已有入口原地同步、无关设置保留、策略覆盖提示、部分失败重试、超时/拒绝/取消、
+错误身份、未确认更新，以及前端默认值、模式隐藏、错误和重试交互测试。
+仓库要求显式授权后才能运行本地测试、构建、类型检查和浏览器 QA。
+
+尚未执行真实 Cloudflare 账户验收。获准后应在受控入口上：
+
+1. 记录全局 SSO、应用、策略的原值；保存较短应用时长，核对 Center 和托管入口。
+2. 确认未触及无关应用、Tunnel、IdP 和策略内容；新建入口继承该时长。
+3. 验证应用会话过期而全局会话仍有效时的续发行为。
+4. 在不影响正常用户的测试会话中验证全局会话过期后的重新认证。
+5. 对独立策略和 Cloudflare One Client 场景核对提示，不将 API 同步成功当作登录行为验收。

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -508,6 +508,9 @@
                           },
                           "audienceValue": {
                             "type": "string"
+                          },
+                          "accessSessionDuration": {
+                            "type": "string"
                           }
                         }
                       },
@@ -4383,6 +4386,9 @@
                   },
                   "audienceValue": {
                     "type": "string"
+                  },
+                  "accessSessionDuration": {
+                    "type": "string"
                   }
                 }
               }
@@ -4447,6 +4453,9 @@
                     "type": "string"
                   },
                   "audienceValue": {
+                    "type": "string"
+                  },
+                  "accessSessionDuration": {
                     "type": "string"
                   }
                 }

--- a/internal/center/access_session.go
+++ b/internal/center/access_session.go
@@ -1,0 +1,211 @@
+package center
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const cloudflareAccessSettingsSchema = `CREATE TABLE cloudflare_access_settings (
+	id INTEGER PRIMARY KEY CHECK(id = 1),
+	session_duration TEXT NOT NULL DEFAULT '24h' CHECK(session_duration IN ('15m','30m','1h','6h','12h','24h','48h','72h','168h','720h')),
+	sync_json TEXT NOT NULL DEFAULT '{"status":"not_synced","total":0,"updated":0}' CHECK(json_valid(sync_json))
+)`
+
+// A deliberately bounded subset of Cloudflare's application-session durations.
+// This setting never changes organization, policy or Cloudflare One Client sessions.
+func validAccessSessionDuration(value string) bool {
+	switch value {
+	case "15m", "30m", "1h", "6h", "12h", "24h", "48h", "72h", "168h", "720h":
+		return true
+	}
+	return false
+}
+
+func validateAccessSessionInput(input CenterRemoteAccessInput) error {
+	duration := strings.TrimSpace(input.AccessSessionDuration)
+	if duration != "" && (!validAccessSessionDuration(duration) || !input.Enabled || strings.TrimSpace(input.ProtectionMode) == "native") {
+		return errors.New("center: select a supported session duration in Cloudflare Access mode")
+	}
+	return nil
+}
+
+type AccessSessionSync struct {
+	Status              string   `json:"status"`
+	Total               int      `json:"total"`
+	Updated             int      `json:"updated"`
+	FailedHosts         []string `json:"failedHosts,omitempty"`
+	PolicyOverrideHosts []string `json:"policyOverrideHosts,omitempty"`
+}
+
+func (s *Store) accessSessionSettings(ctx context.Context) (string, AccessSessionSync, error) {
+	var duration, encoded string
+	var sync AccessSessionSync
+	if err := s.db.QueryRowContext(ctx, `SELECT session_duration, sync_json FROM cloudflare_access_settings WHERE id = 1`).Scan(&duration, &encoded); err != nil {
+		return "", sync, err
+	}
+	if !validAccessSessionDuration(duration) {
+		return "", sync, errors.New("center: invalid stored Access session duration")
+	}
+	err := json.Unmarshal([]byte(encoded), &sync)
+	return duration, sync, err
+}
+
+func (s *Store) saveAccessSessionSettings(ctx context.Context, duration string, sync AccessSessionSync) error {
+	if !validAccessSessionDuration(duration) {
+		return errors.New("center: select a supported Access session duration")
+	}
+	encoded, err := json.Marshal(sync)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE cloudflare_access_settings SET session_duration = ?, sync_json = ? WHERE id = 1`, duration, string(encoded))
+	if err != nil {
+		return err
+	}
+	if affected, err := result.RowsAffected(); err != nil || affected != 1 {
+		return errors.New("center: Access session settings are missing")
+	}
+	return nil
+}
+
+// The caller holds remoteAccessMu, also used by service Access creation. Persist
+// desired state first; interrupted/partial sync remains visible and retryable.
+// newlyCreatedID already received this duration and has no policy overrides.
+func (s *Store) syncAccessSessions(ctx context.Context, client cloudflareClient, duration, newlyCreatedID string) error {
+	rows, err := s.db.QueryContext(ctx, `SELECT access_application_id, hostname FROM center_remote_access
+		WHERE protection_mode = 'access' AND access_application_id <> ''
+		UNION SELECT access_application_id, hostname FROM publications WHERE access_application_id <> '' AND status <> 'stopped'
+		ORDER BY 1`)
+	if err != nil {
+		return err
+	}
+	type target struct{ id, hostname string }
+	var targets []target
+	for rows.Next() {
+		var app target
+		if err := rows.Scan(&app.id, &app.hostname); err != nil {
+			rows.Close()
+			return err
+		}
+		targets = append(targets, app)
+	}
+	err = errors.Join(rows.Err(), rows.Close())
+	if err != nil {
+		return err
+	}
+	result := AccessSessionSync{Status: "pending", Total: len(targets)}
+	if err := s.saveAccessSessionSettings(ctx, duration, result); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+	for _, app := range targets {
+		var overridden bool
+		var updateErr error
+		if app.id != newlyCreatedID {
+			attempt, done := context.WithTimeout(ctx, 8*time.Second)
+			overridden, updateErr = client.updateAccessSession(attempt, app.id, app.hostname, duration)
+			done()
+		}
+		if overridden {
+			result.PolicyOverrideHosts = append(result.PolicyOverrideHosts, app.hostname)
+		}
+		if updateErr != nil {
+			result.FailedHosts = append(result.FailedHosts, app.hostname)
+			slog.WarnContext(ctx, "Access session synchronization failed", "hostname", app.hostname, "error", updateErr)
+		} else {
+			result.Updated++
+		}
+	}
+	result.Status = "synced"
+	if len(result.FailedHosts) != 0 {
+		result.Status = "partial"
+		if result.Updated == 0 {
+			result.Status = "failed"
+		}
+	}
+	// Retain the diagnostic outcome even when the browser disconnects or the
+	// remote request times out. Never change the working entry's own status.
+	saveCtx, done := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer done()
+	return s.saveAccessSessionSettings(saveCtx, duration, result)
+}
+
+func (client cloudflareClient) updateAccessSession(ctx context.Context, id, hostname, duration string) (bool, error) {
+	if !validAccessSessionDuration(duration) {
+		return false, errors.New("center: select a supported Access session duration")
+	}
+	path := "/accounts/" + url.PathEscape(client.accountID) + "/access/apps/" + url.PathEscape(id)
+	var app map[string]json.RawMessage
+	if err := client.do(ctx, http.MethodGet, path, nil, &app); err != nil {
+		return false, err
+	}
+	readString := func(key string) string {
+		var value string
+		_ = json.Unmarshal(app[key], &value)
+		return value
+	}
+	if readString("id") != id || readString("type") != "self_hosted" || readString("domain") != hostname {
+		return false, errors.New("center: managed Access application identity does not match")
+	}
+	// Read all attached policies, including reusable ones. Never rewrite their
+	// durations: an explicit override must remain visible to the administrator.
+	overridden := false
+	for page := 1; ; page++ {
+		var policies []struct {
+			SessionDuration string `json:"session_duration"`
+		}
+		if err := client.do(ctx, http.MethodGet, fmt.Sprintf("%s/policies?per_page=100&page=%d", path, page), nil, &policies); err != nil {
+			return overridden, err
+		}
+		for _, policy := range policies {
+			if strings.TrimSpace(policy.SessionDuration) != "" {
+				overridden = true
+			}
+		}
+		if len(policies) < 100 {
+			break
+		}
+	}
+	if readString("session_duration") == duration {
+		return overridden, nil
+	}
+	// Round-trip the application configuration, excluding response-only fields.
+	// Policy attachments are preserved by ID, not recreated or edited inline.
+	var policies []struct {
+		ID         string `json:"id"`
+		AccountID  string `json:"account_id,omitempty"`
+		Precedence int    `json:"precedence"`
+	}
+	if err := json.Unmarshal(app["policies"], &policies); err != nil || len(policies) == 0 {
+		return overridden, errors.New("center: cannot preserve Access policy attachments")
+	}
+	for _, policy := range policies {
+		if policy.ID == "" {
+			return overridden, errors.New("center: Access policy attachment has no ID")
+		}
+	}
+	app["policies"], _ = json.Marshal(policies)
+	for _, field := range []string{"id", "aud", "created_at", "updated_at"} {
+		delete(app, field)
+	}
+	app["session_duration"], _ = json.Marshal(duration)
+	var updated struct {
+		ID              string `json:"id"`
+		SessionDuration string `json:"session_duration"`
+	}
+	if err := client.do(ctx, http.MethodPut, path, app, &updated); err != nil {
+		return overridden, err
+	}
+	if updated.ID != id || updated.SessionDuration != duration {
+		return overridden, errors.New("center: Cloudflare did not confirm the Access session duration")
+	}
+	return overridden, nil
+}

--- a/internal/center/access_session_test.go
+++ b/internal/center/access_session_test.go
@@ -80,6 +80,10 @@ func (api *accessSessionAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer api.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 	respond := func(result any) { _ = json.NewEncoder(w).Encode(map[string]any{"success": true, "result": result}) }
+	if r.Method == "GET" && r.URL.Path == "/accounts/account/cfd_tunnel" && r.URL.Query().Get("per_page") == "1" {
+		respond([]any{})
+		return
+	}
 	if r.Method == "GET" && r.URL.Path == "/zones/zone" {
 		respond(map[string]string{"name": "example.com"})
 		return

--- a/internal/center/access_session_test.go
+++ b/internal/center/access_session_test.go
@@ -1,0 +1,353 @@
+package center
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAccessSessionDefaultsValidationAndPersistence(t *testing.T) {
+	directory := t.TempDir()
+	store, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	view, err := store.CenterRemoteAccess(ctx, false)
+	if err != nil || view.AccessSessionDuration != "24h" || view.AccessSessionSync.Status != "not_synced" {
+		t.Fatalf("default view: %+v, %v", view, err)
+	}
+	for _, value := range []string{"15m", "30m", "1h", "6h", "12h", "24h", "48h", "72h", "168h", "720h"} {
+		if !validAccessSessionDuration(value) {
+			t.Errorf("rejected %s", value)
+		}
+	}
+	for _, value := range []string{"", "0", "0s", "-1h", "24", "forever", "731h", "9999999999999999999999h", "1h<script>"} {
+		if validAccessSessionDuration(value) {
+			t.Errorf("accepted %q", value)
+		}
+		if err := store.saveAccessSessionSettings(ctx, value, AccessSessionSync{}); err == nil {
+			t.Errorf("stored invalid %q", value)
+		}
+	}
+	server := NewServer(store, "", false)
+	for _, input := range []CenterRemoteAccessInput{
+		{Enabled: true, AccessSessionDuration: "-1h"},
+		{Enabled: true, ProtectionMode: " native ", AccessSessionDuration: "6h"},
+		{Enabled: false, AccessSessionDuration: "6h"},
+	} {
+		if _, err := server.ConfigureCenterRemoteAccess(ctx, input, ""); err == nil || !strings.Contains(err.Error(), "session duration") {
+			t.Fatalf("invalid input reached remote configuration: %v", err)
+		}
+	}
+	want := AccessSessionSync{Status: "partial", Total: 2, Updated: 1, FailedHosts: []string{"panel.example.com"}}
+	if err := store.saveAccessSessionSettings(ctx, "6h", want); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err = Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	view, err = store.CenterRemoteAccess(ctx, true)
+	if err != nil || view.AccessSessionDuration != "6h" || !reflect.DeepEqual(view.AccessSessionSync, want) {
+		t.Fatalf("reopened settings: %+v, %v", view, err)
+	}
+}
+
+type accessSessionAPI struct {
+	mu           sync.Mutex
+	t            *testing.T
+	durations    map[string]string
+	puts         map[string]int
+	failService  bool
+	postDuration string
+}
+
+func (api *accessSessionAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	respond := func(result any) { _ = json.NewEncoder(w).Encode(map[string]any{"success": true, "result": result}) }
+	if r.Method == "GET" && r.URL.Path == "/zones/zone" {
+		respond(map[string]string{"name": "example.com"})
+		return
+	}
+	if r.Method == "POST" && r.URL.Path == "/accounts/account/access/apps" {
+		var app map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&app); err != nil {
+			api.t.Error(err)
+		}
+		api.postDuration, _ = app["session_duration"].(string)
+		respond(map[string]string{"id": "new-service-app"})
+		return
+	}
+	path := strings.TrimPrefix(r.URL.Path, "/accounts/account/access/apps/")
+	id := strings.TrimSuffix(path, "/policies")
+	domain := "center-vastora.example.com"
+	if id == "service-app" {
+		domain = "verification.example.test"
+	}
+	if _, ok := api.durations[id]; !ok {
+		api.t.Errorf("touched unrelated endpoint: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+		return
+	}
+	if strings.HasSuffix(path, "/policies") && r.Method == "GET" {
+		policy := map[string]any{"id": "existing-policy", "include": []any{map[string]any{"email_domain": map[string]string{"domain": "example.org"}}}}
+		if id == "service-app" {
+			policy["session_duration"] = "1h"
+		}
+		respond([]any{policy})
+		return
+	}
+	if r.Method == "GET" {
+		respond(map[string]any{
+			"id": id, "type": "self_hosted", "domain": domain, "name": "Original name", "aud": "unchanged-aud",
+			"session_duration": api.durations[id], "allowed_idps": []string{"otp"}, "auto_redirect_to_identity": true,
+			"app_launcher_visible": false, "http_only_cookie_attribute": true,
+			"policies": []any{map[string]any{"id": "existing-policy", "account_id": "account", "precedence": 3}},
+		})
+		return
+	}
+	if r.Method == "PUT" {
+		api.puts[id]++
+		if id == "service-app" && api.failService {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"success":false,"errors":[{"message":"temporary upstream failure"}]}`))
+			return
+		}
+		var app map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&app); err != nil {
+			api.t.Error(err)
+		}
+		if app["domain"] != domain || app["name"] != "Original name" || app["http_only_cookie_attribute"] != true || app["auto_redirect_to_identity"] != true || app["app_launcher_visible"] != false || !reflect.DeepEqual(app["allowed_idps"], []any{"otp"}) {
+			api.t.Errorf("unrelated app settings changed: %+v", app)
+		}
+		if !reflect.DeepEqual(app["policies"], []any{map[string]any{"id": "existing-policy", "account_id": "account", "precedence": float64(3)}}) {
+			api.t.Errorf("policy attachments changed: %+v", app["policies"])
+		}
+		if _, ok := app["aud"]; ok {
+			api.t.Error("sent response-only aud")
+		}
+		api.durations[id], _ = app["session_duration"].(string)
+		respond(map[string]string{"id": id, "session_duration": api.durations[id]})
+		return
+	}
+	api.t.Errorf("destructive/unexpected request: %s %s", r.Method, r.URL.Path)
+	http.Error(w, "unexpected", 500)
+}
+
+func seedAccessSessionCenter(t *testing.T, store *Store) {
+	t.Helper()
+	_, err := store.db.Exec(`INSERT INTO center_remote_access(id,hostname,audience_kind,audience_value,otp_identity_provider_id,access_application_id,protection_mode,status,created_at,updated_at)
+		VALUES(1,'center-vastora.example.com','email','admin@example.com','otp','center-app','access','configured','2026-09-09T00:00:00Z','2026-09-09T00:00:00Z')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccessSessionSaveSynchronizesManagedEntriesAndRetriesInPlace(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	seedAccessSessionCenter(t, store)
+	seedVerificationPublication(t, store, "public_direct", "cloudflare", 1, 1, "ready")
+	if _, err := store.db.Exec(`UPDATE publications SET kind = 'cloudflare_tunnel', ingress_owner = 'tunnel_connector', access_application_id = 'service-app' WHERE id = 'verification-publication'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO publications(id, service_id, kind, ingress_owner, entry_node_id, hostname, dns_provider, access_application_id, desired_revision, applied_revision, status, created_at, updated_at)
+		SELECT 'stopped-entry', service_id, kind, ingress_owner, entry_node_id, 'stopped.example.test', dns_provider, 'do-not-touch', 1, 1, 'stopped', created_at, updated_at FROM publications WHERE id = 'verification-publication'`); err != nil {
+		t.Fatal(err)
+	}
+	fake := &accessSessionAPI{t: t, durations: map[string]string{"center-app": "24h", "service-app": "24h"}, puts: map[string]int{}, failService: true}
+	remote := httptest.NewServer(fake)
+	defer remote.Close()
+	store.cloudflareOAuth = cloudflareOAuthConfig{APIURL: remote.URL, HTTPClient: remote.Client()}
+	storeCloudflareOAuthIntegration(t, store, cloudflareOAuthToken{AccessToken: "access", RefreshToken: "refresh", Scope: "zone.read access.write access-acct.write", ExpiresAt: time.Now().Add(time.Hour)})
+	server := NewServer(store, "", false).WithInfrastructureManager(&fakeBuiltinHeadscaleInstaller{})
+	input := CenterRemoteAccessInput{Enabled: true, ProtectionMode: "access", AudienceKind: "email", AudienceValue: "admin@example.com", AccessSessionDuration: "6h"}
+	view, err := server.ConfigureCenterRemoteAccess(context.Background(), input, "https://center.example.com")
+	if err != nil || !view.Enabled || view.Status != "configured" || view.AccessSessionDuration != "6h" || view.AccessSessionSync.Status != "partial" || view.AccessSessionSync.Updated != 1 || view.AccessSessionSync.Total != 2 {
+		t.Fatalf("partial sync lost working entry: %+v, %v", view, err)
+	}
+	if !reflect.DeepEqual(view.AccessSessionSync.FailedHosts, []string{"verification.example.test"}) || !reflect.DeepEqual(view.AccessSessionSync.PolicyOverrideHosts, []string{"verification.example.test"}) {
+		t.Fatalf("missing failure/override: %+v", view)
+	}
+	fake.mu.Lock()
+	fake.failService = false
+	fake.mu.Unlock()
+	// Omitted input preserves the saved duration rather than reverting to 24h.
+	input.AccessSessionDuration = ""
+	view, err = server.ConfigureCenterRemoteAccess(context.Background(), input, "https://center.example.com")
+	if err != nil || view.AccessSessionSync.Status != "synced" || view.AccessSessionSync.Updated != 2 || view.AccessSessionDuration != "6h" {
+		t.Fatalf("retry: %+v %v", view, err)
+	}
+	fake.mu.Lock()
+	if fake.puts["center-app"] != 1 || fake.puts["service-app"] != 2 {
+		t.Errorf("retry rewrote successful apps: %+v", fake.puts)
+	}
+	fake.mu.Unlock()
+	record, _, err := store.centerRemoteAccessRecord(context.Background())
+	if err != nil || record.ApplicationID != "center-app" || record.IdentityProviderID != "otp" {
+		t.Fatalf("identity changed: %+v %v", record, err)
+	}
+	// New service entries inherit the global duration after this change.
+	if _, err := store.db.Exec(`UPDATE publications SET access_application_id = '' WHERE id = 'verification-publication'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ensureCloudflareServiceAccess(context.Background(), "verification-publication", 1, "verification.example.test"); err != nil {
+		t.Fatal(err)
+	}
+	fake.mu.Lock()
+	if fake.postDuration != "6h" {
+		t.Errorf("new entry duration: %q", fake.postDuration)
+	}
+	fake.mu.Unlock()
+}
+
+func TestAccessSessionFailureRetainsDesiredSettingAndProtection(t *testing.T) {
+	for _, scenario := range []string{"timeout", "forbidden", "wrong-identity", "unconfirmed-update", "policy-read-failure"} {
+		t.Run(scenario, func(t *testing.T) {
+			store, err := Open(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			seedAccessSessionCenter(t, store)
+			remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" && r.Method != "PUT" {
+					t.Errorf("unexpected mutation: %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if scenario == "timeout" {
+					<-r.Context().Done()
+					return
+				}
+				if scenario == "forbidden" || scenario == "policy-read-failure" && strings.HasSuffix(r.URL.Path, "/policies") {
+					w.WriteHeader(403)
+					_, _ = w.Write([]byte(`{"success":false}`))
+					return
+				}
+				if strings.HasSuffix(r.URL.Path, "/policies") {
+					_, _ = w.Write([]byte(`{"success":true,"result":[]}`))
+					return
+				}
+				if scenario == "wrong-identity" {
+					_, _ = w.Write([]byte(`{"success":true,"result":{"id":"unrelated-app"}}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"success":true,"result":{"id":"center-app","domain":"center-vastora.example.com","type":"self_hosted","session_duration":"24h","policies":[{"id":"policy","precedence":1}]}}`))
+			}))
+			defer remote.Close()
+			client := cloudflareClient{accountID: "account", baseURL: remote.URL, http: &http.Client{Timeout: 50 * time.Millisecond}}
+			if err := store.syncAccessSessions(context.Background(), client, "6h", ""); err != nil {
+				t.Fatal(err)
+			}
+			view, err := store.CenterRemoteAccess(context.Background(), true)
+			if err != nil || !view.Enabled || view.AccessSessionDuration != "6h" || view.AccessSessionSync.Status != "failed" || view.AccessSessionSync.Updated != 0 {
+				t.Fatalf("failure result: %+v %v", view, err)
+			}
+		})
+	}
+}
+
+func TestAccessSessionMigrationFrom65PreservesEntriesAndBacksUp(t *testing.T) {
+	ctx := context.Background()
+	directory := t.TempDir()
+	createLegacyVersion3Database(t, directory)
+	db, err := sql.Open("sqlite", filepath.Join(directory, "center.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	legacy := &Store{db: db}
+	if err := legacy.initializeMigrationHistory(ctx, schemaBaselineVersion); err != nil {
+		t.Fatal(err)
+	}
+	provider, err := newMigrationProvider(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.UpTo(ctx, 65); err != nil {
+		t.Fatal(err)
+	}
+	seedAccessSessionCenter(t, legacy)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	current, err := Open(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer current.Close()
+	view, err := current.CenterRemoteAccess(ctx, true)
+	if err != nil || view.AccessSessionDuration != "24h" || !view.Enabled || view.AudienceValue != "admin@example.com" {
+		t.Fatalf("migration: %+v %v", view, err)
+	}
+	record, _, err := current.centerRemoteAccessRecord(ctx)
+	if err != nil || record.ApplicationID != "center-app" || record.IdentityProviderID != "otp" {
+		t.Fatalf("identity lost: %+v %v", record, err)
+	}
+	backups, err := filepath.Glob(filepath.Join(directory, "migration-backups", "center-v65-before-v66-*.db"))
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("backup missing: %v %v", backups, err)
+	}
+}
+
+func TestAccessSessionCreationUsesConfiguredDuration(t *testing.T) {
+	for _, duration := range []string{"24h", "15m", "720h"} {
+		t.Run(duration, func(t *testing.T) {
+			fake := &accessSessionAPI{t: t}
+			remote := httptest.NewServer(fake)
+			defer remote.Close()
+			client := cloudflareClient{accountID: "account", baseURL: remote.URL, http: remote.Client()}
+			id, err := client.createAccessApplication(context.Background(), "Vastora Center", "center-vastora.example.com", "email", "admin@example.com", "otp", duration)
+			if err != nil || id == "" {
+				t.Fatalf("create: %s %v", id, err)
+			}
+			fake.mu.Lock()
+			if fake.postDuration != duration {
+				t.Errorf("created duration: %s", fake.postDuration)
+			}
+			fake.mu.Unlock()
+		})
+	}
+}
+
+func TestAccessSessionCancellationPersistsRetryableResult(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	seedAccessSessionCenter(t, store)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancel()
+		<-r.Context().Done()
+	}))
+	defer remote.Close()
+	client := cloudflareClient{accountID: "account", baseURL: remote.URL, http: remote.Client()}
+	if err := store.syncAccessSessions(ctx, client, "12h", ""); err != nil {
+		t.Fatal(err)
+	}
+	view, err := store.CenterRemoteAccess(context.Background(), true)
+	if err != nil || view.AccessSessionDuration != "12h" || view.AccessSessionSync.Status != "failed" || !view.Enabled {
+		t.Fatalf("lost canceled result: %+v %v", view, err)
+	}
+}

--- a/internal/center/center_remote_access.go
+++ b/internal/center/center_remote_access.go
@@ -20,23 +20,26 @@ var cloudflareTurnstileScopes = []string{"turnstile.write"}
 const centerRemoteAccessLabel = "center-vastora"
 
 type CenterRemoteAccessInput struct {
-	Enabled        bool   `json:"enabled"`
-	ProtectionMode string `json:"protectionMode,omitempty"`
-	AudienceKind   string `json:"audienceKind,omitempty"`
-	AudienceValue  string `json:"audienceValue,omitempty"`
+	Enabled               bool   `json:"enabled"`
+	ProtectionMode        string `json:"protectionMode,omitempty"`
+	AudienceKind          string `json:"audienceKind,omitempty"`
+	AudienceValue         string `json:"audienceValue,omitempty"`
+	AccessSessionDuration string `json:"accessSessionDuration,omitempty"`
 }
 
 type CenterRemoteAccessView struct {
-	Available        bool      `json:"available"`
-	Enabled          bool      `json:"enabled"`
-	Hostname         string    `json:"hostname,omitempty"`
-	ProtectionMode   string    `json:"protectionMode,omitempty"`
-	TurnstileSiteKey string    `json:"turnstileSiteKey,omitempty"`
-	AudienceKind     string    `json:"audienceKind,omitempty"`
-	AudienceValue    string    `json:"audienceValue,omitempty"`
-	Status           string    `json:"status"`
-	LastError        string    `json:"lastError,omitempty"`
-	UpdatedAt        time.Time `json:"updatedAt,omitempty"`
+	Available             bool              `json:"available"`
+	Enabled               bool              `json:"enabled"`
+	Hostname              string            `json:"hostname,omitempty"`
+	ProtectionMode        string            `json:"protectionMode,omitempty"`
+	TurnstileSiteKey      string            `json:"turnstileSiteKey,omitempty"`
+	AudienceKind          string            `json:"audienceKind,omitempty"`
+	AudienceValue         string            `json:"audienceValue,omitempty"`
+	Status                string            `json:"status"`
+	LastError             string            `json:"lastError,omitempty"`
+	UpdatedAt             time.Time         `json:"updatedAt,omitempty"`
+	AccessSessionDuration string            `json:"accessSessionDuration"`
+	AccessSessionSync     AccessSessionSync `json:"accessSessionSync"`
 }
 
 type centerRemoteAccessRecord struct {
@@ -55,7 +58,11 @@ func (s *Store) CenterRemoteAccess(ctx context.Context, available bool) (CenterR
 		return CenterRemoteAccessView{}, err
 	}
 	if !exists {
-		return CenterRemoteAccessView{Available: available, Status: "disabled"}, nil
+		record.CenterRemoteAccessView = CenterRemoteAccessView{Status: "disabled"}
+	}
+	record.AccessSessionDuration, record.AccessSessionSync, err = s.accessSessionSettings(ctx)
+	if err != nil {
+		return CenterRemoteAccessView{}, err
 	}
 	record.Available = available
 	record.Enabled = record.Status == "configured"
@@ -87,6 +94,10 @@ func (s *Store) centerRemoteAccessRecord(ctx context.Context) (centerRemoteAcces
 }
 
 func normalizeCenterRemoteAccess(input CenterRemoteAccessInput, centerURL, zoneName string) (CenterRemoteAccessInput, string, error) {
+	if err := validateAccessSessionInput(input); err != nil {
+		return CenterRemoteAccessInput{}, "", err
+	}
+	input.AccessSessionDuration = strings.TrimSpace(input.AccessSessionDuration)
 	if !input.Enabled {
 		return CenterRemoteAccessInput{}, "", nil
 	}
@@ -138,6 +149,11 @@ func (s *Server) ConfigureCenterRemoteAccess(ctx context.Context, input CenterRe
 	defer s.store.domainSwitchMu.Unlock()
 	s.store.remoteAccessMu.Lock()
 	defer s.store.remoteAccessMu.Unlock()
+	input.AccessSessionDuration = strings.TrimSpace(input.AccessSessionDuration)
+	input.ProtectionMode = strings.TrimSpace(input.ProtectionMode)
+	if err := validateAccessSessionInput(input); err != nil {
+		return CenterRemoteAccessView{}, err
+	}
 	if !input.Enabled {
 		_, exists, err := s.store.centerRemoteAccessRecord(ctx)
 		if err != nil {
@@ -183,12 +199,29 @@ func (s *Server) ConfigureCenterRemoteAccess(ctx context.Context, input CenterRe
 		return CenterRemoteAccessView{}, err
 	}
 	audienceMatches := normalized.ProtectionMode == "native" || current.AudienceKind == normalized.AudienceKind && current.AudienceValue == normalized.AudienceValue
+	duration, _, err := s.store.accessSessionSettings(ctx)
+	if err != nil {
+		return CenterRemoteAccessView{}, err
+	}
+	if normalized.AccessSessionDuration != "" {
+		duration = normalized.AccessSessionDuration
+	}
 	if exists && current.Status == "configured" && current.Hostname == hostname && current.ProtectionMode == normalized.ProtectionMode && audienceMatches && (normalized.ProtectionMode != "native" || (current.TurnstileSiteKey != "" && current.TurnstileSecretID != "")) {
+		if normalized.ProtectionMode == "access" {
+			if err := s.store.syncAccessSessions(ctx, client, duration, ""); err != nil {
+				return CenterRemoteAccessView{}, err
+			}
+		}
 		return s.store.CenterRemoteAccess(ctx, s.infrastructure != nil)
 	}
 	if exists {
 		if err := s.disableCenterRemoteAccess(ctx); err != nil {
 			return CenterRemoteAccessView{}, fmt.Errorf("center: remove the previous remote access configuration: %w", err)
+		}
+	}
+	if normalized.ProtectionMode == "access" {
+		if err := s.store.saveAccessSessionSettings(ctx, duration, AccessSessionSync{Status: "pending"}); err != nil {
+			return CenterRemoteAccessView{}, err
 		}
 	}
 	now := s.store.now().UTC().Format(time.RFC3339Nano)
@@ -206,6 +239,15 @@ func (s *Server) ConfigureCenterRemoteAccess(ctx context.Context, input CenterRe
 		message := failure.Error()
 		_, statusErr := s.store.db.ExecContext(context.WithoutCancel(ctx), `UPDATE center_remote_access SET status = 'failed', last_error = ?, updated_at = ? WHERE id = 1`, message, s.store.now().UTC().Format(time.RFC3339Nano))
 		return CenterRemoteAccessView{}, errors.Join(failure, statusErr)
+	}
+	if normalized.ProtectionMode == "access" {
+		created, _, err := s.store.centerRemoteAccessRecord(ctx)
+		if err != nil {
+			return CenterRemoteAccessView{}, err
+		}
+		if err := s.store.syncAccessSessions(ctx, client, duration, created.ApplicationID); err != nil {
+			return CenterRemoteAccessView{}, err
+		}
 	}
 	return s.store.CenterRemoteAccess(ctx, s.infrastructure != nil)
 }
@@ -234,7 +276,11 @@ func (s *Server) applyCenterRemoteAccess(ctx context.Context, client cloudflareC
 		if err := s.store.updateCenterRemoteAccessResource(ctx, "otp_identity_provider_id", identityProviderID); err != nil {
 			return err
 		}
-		applicationID, err := client.createAccessApplication(ctx, "Vastora Center", record.Hostname, record.AudienceKind, record.AudienceValue, identityProviderID)
+		duration, _, err := s.store.accessSessionSettings(ctx)
+		if err != nil {
+			return err
+		}
+		applicationID, err := client.createAccessApplication(ctx, "Vastora Center", record.Hostname, record.AudienceKind, record.AudienceValue, identityProviderID, duration)
 		if err != nil {
 			return err
 		}

--- a/internal/center/center_remote_access_test.go
+++ b/internal/center/center_remote_access_test.go
@@ -31,7 +31,7 @@ func TestCenterRemoteAccessCreatesAccessBeforePublishingDNS(t *testing.T) {
 			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
-			if body["domain"] != "center-vastora.example.com" || !strings.Contains(mustJSONString(t, body["policies"]), `"email_domain":{"domain":"example.org"}`) {
+			if body["session_duration"] != "24h" || body["domain"] != "center-vastora.example.com" || !strings.Contains(mustJSONString(t, body["policies"]), `"email_domain":{"domain":"example.org"}`) {
 				t.Fatalf("unexpected Access application: %#v", body)
 			}
 			_, _ = writer.Write([]byte(`{"success":true,"errors":[],"result":{"id":"access-app"}}`))

--- a/internal/center/cloudflare.go
+++ b/internal/center/cloudflare.go
@@ -367,6 +367,8 @@ func (s *Store) reusePublicationDNSRecord(ctx context.Context, publicationID, ki
 }
 
 func (s *Store) ensureCloudflareServiceAccess(ctx context.Context, publicationID string, revision int64, hostname string) error {
+	s.remoteAccessMu.Lock()
+	defer s.remoteAccessMu.Unlock()
 	record, exists, err := s.centerRemoteAccessRecord(ctx)
 	if err != nil {
 		return err
@@ -378,7 +380,11 @@ func (s *Store) ensureCloudflareServiceAccess(ctx context.Context, publicationID
 	if err != nil {
 		return err
 	}
-	applicationID, err := client.createAccessApplication(ctx, "Vastora "+hostname, hostname, record.AudienceKind, record.AudienceValue, record.IdentityProviderID)
+	duration, _, err := s.accessSessionSettings(ctx)
+	if err != nil {
+		return err
+	}
+	applicationID, err := client.createAccessApplication(ctx, "Vastora "+hostname, hostname, record.AudienceKind, record.AudienceValue, record.IdentityProviderID, duration)
 	if err != nil {
 		return err
 	}
@@ -664,7 +670,10 @@ func (client cloudflareClient) ensureOneTimePINIdentityProvider(ctx context.Cont
 	return created.ID, nil
 }
 
-func (client cloudflareClient) createAccessApplication(ctx context.Context, name, domain, audienceKind, audienceValue, identityProviderID string) (string, error) {
+func (client cloudflareClient) createAccessApplication(ctx context.Context, name, domain, audienceKind, audienceValue, identityProviderID, duration string) (string, error) {
+	if !validAccessSessionDuration(duration) {
+		return "", errors.New("center: select a supported Access session duration")
+	}
 	selector := map[string]any{}
 	switch audienceKind {
 	case "email":
@@ -678,7 +687,7 @@ func (client cloudflareClient) createAccessApplication(ctx context.Context, name
 		"name":                      name,
 		"domain":                    domain,
 		"type":                      "self_hosted",
-		"session_duration":          "24h",
+		"session_duration":          duration,
 		"auto_redirect_to_identity": true,
 		"allowed_idps":              []string{identityProviderID},
 		"policies": []map[string]any{{

--- a/internal/center/migrations/00066_access_session.sql
+++ b/internal/center/migrations/00066_access_session.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE TABLE cloudflare_access_settings (
+    id INTEGER PRIMARY KEY CHECK(id = 1),
+    session_duration TEXT NOT NULL DEFAULT '24h' CHECK(session_duration IN ('15m','30m','1h','6h','12h','24h','48h','72h','168h','720h')),
+    sync_json TEXT NOT NULL DEFAULT '{"status":"not_synced","total":0,"updated":0}' CHECK(json_valid(sync_json))
+);
+INSERT INTO cloudflare_access_settings(id) VALUES(1);
+PRAGMA user_version = 66;
+
+-- +goose Down
+SELECT RAISE(ABORT, 'Vastora Center database downgrades are not supported');

--- a/internal/center/migrations_test.go
+++ b/internal/center/migrations_test.go
@@ -1380,6 +1380,7 @@ func createLegacyVersion3Database(t *testing.T, directory string) {
 	}
 	defer tx.Rollback()
 	for _, statement := range []string{
+		`DROP TABLE cloudflare_access_settings`,
 		`DROP TABLE reality_security_checks`,
 		`DROP TABLE node_listener_states`,
 		`DROP TABLE landing_server_states`,

--- a/internal/center/schema.go
+++ b/internal/center/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const centerSchemaVersion = 65
+const centerSchemaVersion = 66
 
 func (s *Store) initializeSchema(ctx context.Context, existing bool) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
@@ -31,6 +31,8 @@ func (s *Store) initializeCurrentSchema(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 	statements := []string{
+		cloudflareAccessSettingsSchema,
+		`INSERT INTO cloudflare_access_settings(id) VALUES(1)`,
 		landingServerSchema,
 		landingProxySchema,
 		`CREATE TABLE recovery_evidence (

--- a/web/src/lib/access-session.test.ts
+++ b/web/src/lib/access-session.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { accessSessionOptions, validAccessSessionDuration } from "./access-session";
+
+describe("Access session durations", () => {
+  it("offers bounded Cloudflare durations and a 24-hour default", () => {
+    expect(accessSessionOptions("zh-CN").find((option) => option.value === "24h")?.label).toContain("默认");
+    expect(accessSessionOptions("en").find((option) => option.value === "24h")?.label).toContain("default");
+    for (const option of accessSessionOptions("zh-CN")) expect(validAccessSessionDuration(option.value)).toBe(true);
+  });
+
+  it.each(["", "-1h", "0s", "24", "forever", "731h", "<script>"])("rejects unsupported input %s", (value) => {
+    expect(validAccessSessionDuration(value)).toBe(false);
+  });
+});

--- a/web/src/lib/access-session.ts
+++ b/web/src/lib/access-session.ts
@@ -1,0 +1,22 @@
+import type { Language } from "../translations";
+
+const durations = [
+  ["15m", "15 分钟", "15 minutes"],
+  ["30m", "30 分钟", "30 minutes"],
+  ["1h", "1 小时", "1 hour"],
+  ["6h", "6 小时", "6 hours"],
+  ["12h", "12 小时", "12 hours"],
+  ["24h", "24 小时（默认）", "24 hours (default)"],
+  ["48h", "2 天", "2 days"],
+  ["72h", "3 天", "3 days"],
+  ["168h", "7 天", "7 days"],
+  ["720h", "30 天", "30 days"],
+] as const;
+
+export function accessSessionOptions(language: Language) {
+  return durations.map(([value, zh, en]) => ({ value, label: language === "zh-CN" ? zh : en }));
+}
+
+export function validAccessSessionDuration(value: string) {
+  return durations.some(([duration]) => duration === value);
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -217,6 +217,15 @@ export type CenterRemoteAccessInput = {
   protectionMode?: "access" | "native";
   audienceKind?: "email" | "email_domain";
   audienceValue?: string;
+  accessSessionDuration?: string;
+};
+
+export type AccessSessionSync = {
+  status: "not_synced" | "pending" | "synced" | "partial" | "failed";
+  total: number;
+  updated: number;
+  failedHosts?: string[];
+  policyOverrideHosts?: string[];
 };
 
 export type CenterRemoteAccess = {
@@ -230,6 +239,8 @@ export type CenterRemoteAccess = {
   status: "disabled" | "pending" | "configured" | "failed";
   lastError?: string;
   updatedAt?: string;
+  accessSessionDuration?: string;
+  accessSessionSync?: AccessSessionSync;
 };
 
 export type TailscaleFixedEndpointInput = {

--- a/web/src/views/AccessSessionStatus.tsx
+++ b/web/src/views/AccessSessionStatus.tsx
@@ -1,0 +1,18 @@
+import type { AccessSessionSync } from "../types";
+import type { Language } from "../translations";
+import { copy } from "./shared";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export function AccessSessionStatus({ sync, language }: { sync?: AccessSessionSync; language: Language }) {
+  if (!sync || sync.status === "not_synced") return null;
+  const incomplete = sync.status !== "synced";
+  const overrides = sync.policyOverrideHosts ?? [];
+  return <Alert role={incomplete ? "alert" : "status"} variant={incomplete ? "destructive" : "default"}>
+    <AlertTitle>{incomplete ? copy(language, "会话时长已保存，部分入口尚未同步", "Session duration saved; some entries are not synchronized") : copy(language, "会话时长已同步", "Session duration synchronized")}</AlertTitle>
+    <AlertDescription>
+      <p>{copy(language, `上次保存：${sync.updated}/${sync.total} 个入口已同步。`, `Last save: ${sync.updated}/${sync.total} entries synchronized.`)}{incomplete ? copy(language, "请保存重试；原有访问保护仍保留。", "Save again to retry. Existing access protection is retained.") : null}</p>
+      {sync.failedHosts?.length ? <details><summary className="cursor-pointer">{copy(language, "查看未完成的入口", "View unfinished entries")}</summary><ul className="mt-2 list-inside list-disc break-all">{sync.failedHosts.map((host) => <li key={host}>{host}</li>)}</ul></details> : null}
+      {overrides.length ? <p className="break-words">{copy(language, `以下入口有单独的策略时长，未被覆盖：${overrides.join("、")}。若希望统一时长，请在 Cloudflare 中将对应策略设为“与应用相同”。`, `These entries have separate policy durations, which were preserved: ${overrides.join(", ")}. To use the application duration, set those policies to “Same as application” in Cloudflare.`)}</p> : null}
+    </AlertDescription>
+  </Alert>;
+}

--- a/web/src/views/CenterRemoteAccessSheet.tsx
+++ b/web/src/views/CenterRemoteAccessSheet.tsx
@@ -3,11 +3,13 @@ import { ShieldCheckIcon } from "lucide-react";
 import type { CenterRemoteAccess, CenterRemoteAccessInput, CloudflareZone, Integration } from "../types";
 import type { Language } from "../translations";
 import { centerRemoteAccessHostname, validRemoteAccessAudience } from "../lib/center-remote-access";
+import { accessSessionOptions, validAccessSessionDuration } from "../lib/access-session";
+import { AccessSessionStatus } from "./AccessSessionStatus";
 import { copy, userError } from "./shared";
 import { CloudflareOAuthConnect } from "./CloudflareOAuthConnect";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel, FieldSet } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { SelectControl } from "@/components/SelectControl";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -21,7 +23,7 @@ type Props = {
   open: boolean;
   onClose: () => void;
   onCloudflareConnected: (zone: CloudflareZone) => Promise<void>;
-  onSave: (input: CenterRemoteAccessInput) => Promise<void>;
+  onSave: (input: CenterRemoteAccessInput) => Promise<CenterRemoteAccess | void>;
 };
 
 export function CenterRemoteAccessSheet({ access, cloudflare, language, open, onClose, onCloudflareConnected, onSave }: Props) {
@@ -29,6 +31,8 @@ export function CenterRemoteAccessSheet({ access, cloudflare, language, open, on
   const [protectionMode, setProtectionMode] = useState<"access" | "native">(access.protectionMode ?? "native");
   const [audienceKind, setAudienceKind] = useState<"email" | "email_domain">(access.audienceKind ?? "email");
   const [audienceValue, setAudienceValue] = useState(access.audienceValue ?? "");
+  const [sessionDuration, setSessionDuration] = useState(access.accessSessionDuration ?? "24h");
+  const [savedAccess, setSavedAccess] = useState<CenterRemoteAccess>();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
@@ -38,27 +42,31 @@ export function CenterRemoteAccessSheet({ access, cloudflare, language, open, on
     setProtectionMode(access.protectionMode ?? "native");
     setAudienceKind(access.audienceKind ?? "email");
     setAudienceValue(access.audienceValue ?? "");
+    setSessionDuration(access.accessSessionDuration ?? "24h");
+    setSavedAccess(undefined);
     setError("");
-  }, [open, access.enabled, access.protectionMode, access.audienceKind, access.audienceValue]);
+  }, [open, access.enabled, access.protectionMode, access.audienceKind, access.audienceValue, access.accessSessionDuration]);
 
   const cloudflareOAuthConnected = cloudflare.status === "configured" && cloudflare.mode === "oauth";
   const requiredPermissionGranted = protectionMode === "native" ? cloudflare.turnstileManagement === true : cloudflare.accessManagement === true;
   const cloudflareConnected = cloudflareOAuthConnected && requiredPermissionGranted;
   const cloudflareRequired = enabled && !cloudflareConnected;
   const audienceValid = !enabled || protectionMode === "native" || validRemoteAccessAudience(audienceKind, audienceValue);
+  const durationValid = !enabled || protectionMode !== "access" || validAccessSessionDuration(sessionDuration);
   const remoteHostname = centerRemoteAccessHostname(cloudflare.endpoint ?? "");
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError("");
-    if (enabled && (!cloudflareConnected || !audienceValid)) return;
+    if (busy || enabled && (!cloudflareConnected || !audienceValid || !durationValid)) return;
     setBusy(true);
     try {
-      await onSave({
+      const saved = await onSave({
         enabled,
         ...(enabled ? { protectionMode } : {}),
-        ...(enabled && protectionMode === "access" ? { audienceKind, audienceValue: audienceValue.trim().toLowerCase().replace(/^@/, "") } : {})
+        ...(enabled && protectionMode === "access" ? { audienceKind, audienceValue: audienceValue.trim().toLowerCase().replace(/^@/, ""), accessSessionDuration: sessionDuration } : {})
       });
+      if (saved) setSavedAccess(saved);
     } catch (failure) {
       setError(userError(language, failure));
     } finally {
@@ -74,7 +82,7 @@ export function CenterRemoteAccessSheet({ access, cloudflare, language, open, on
       </SheetHeader>
       <form className="flex min-h-0 min-w-0 flex-1 flex-col" onSubmit={(event) => void submit(event)}>
         <div className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-4">
-          <FieldGroup>
+          <FieldSet disabled={busy}><FieldGroup>
             <Field orientation="horizontal">
               <FieldLabel htmlFor="center-remote-access-enabled"><span>{copy(language, "启用远程备用入口", "Enable remote fallback")}</span><span className="text-xs font-normal text-muted-foreground">{copy(language, "默认关闭；安全私网仍是首选路径", "Off by default; the secure private network remains preferred")}</span></FieldLabel>
               <Switch checked={enabled} disabled={!access.available} id="center-remote-access-enabled" onCheckedChange={setEnabled} />
@@ -92,18 +100,26 @@ export function CenterRemoteAccessSheet({ access, cloudflare, language, open, on
               <Alert><ShieldCheckIcon aria-hidden="true" /><AlertTitle>{protectionMode === "native" ? copy(language, "Tunnel 直连已加固", "Hardened direct Tunnel") : copy(language, "Access 外层 + Center 内层", "Access outside + Center inside")}</AlertTitle><AlertDescription>{copy(language, `公网浏览器入口使用 ${remoteHostname || "center-vastora.example.com"}；不会改变 Agent 使用的私网 Center 地址。`, `The public browser entry uses ${remoteHostname || "center-vastora.example.com"}. It does not change the private Center address used by Agents.`)}</AlertDescription></Alert>
               {!cloudflareConnected ? <>{cloudflareOAuthConnected ? <Alert><AlertTitle>{copy(language, "需要补充 Cloudflare 授权", "Additional Cloudflare permission required")}</AlertTitle><AlertDescription>{protectionMode === "native" ? copy(language, "重新连接一次，为 Vastora 增加创建专用 Turnstile 组件的权限。", "Reconnect once so Vastora can create a dedicated Turnstile widget.") : copy(language, "重新连接一次，为 Vastora 增加管理 Access 应用和登录策略的权限。", "Reconnect once so Vastora can manage Access applications and policies.")}</AlertDescription></Alert> : null}<CloudflareOAuthConnect available connected={cloudflareOAuthConnected} language={language} onConnected={onCloudflareConnected} zoneName={cloudflare.endpoint} /></> : null}
               {protectionMode === "access" ? <>
+                <Field data-invalid={!durationValid} data-disabled={busy}>
+                  <FieldLabel htmlFor="center-access-session-duration">{copy(language, "Access 会话时长", "Access session duration")}</FieldLabel>
+                  <SelectControl aria-invalid={!durationValid} disabled={busy} id="center-access-session-duration" onValueChange={setSessionDuration} options={accessSessionOptions(language)} value={sessionDuration} />
+                  <FieldDescription>{copy(language, "统一用于 Center 和 Vastora 管理的受保护应用入口。保存后同步已有入口。", "Applies to Center and protected application entries managed by Vastora. Saving also synchronizes existing entries.")}</FieldDescription>
+                  {!durationValid ? <FieldError>{copy(language, "请选择支持的会话时长。", "Select a supported session duration.")}</FieldError> : null}
+                  <details className="text-xs text-muted-foreground"><summary className="cursor-pointer">{copy(language, "生效范围", "How this applies")}</summary><p className="mt-2 leading-5">{copy(language, "这是应用会话时长，不改变 Cloudflare 全局单点登录或 Vastora 登录时长。单独的访问策略、Cloudflare One Client 会话设置可能优先；到期不一定需要重新输入邮箱验证码。", "This is the application session duration, not Cloudflare global SSO or Vastora sign-in duration. Separate policies and Cloudflare One Client sessions can take precedence; expiry does not necessarily require another email code.")}</p></details>
+                </Field>
+                <AccessSessionStatus language={language} sync={(savedAccess ?? access).accessSessionSync} />
                 <Field><FieldLabel htmlFor="center-remote-access-kind">{copy(language, "允许谁登录", "Who can sign in")}</FieldLabel><SelectControl id="center-remote-access-kind" onValueChange={(value) => setAudienceKind(value as "email" | "email_domain")} options={[{ value: "email", label: copy(language, "指定邮箱（推荐）", "Specific email (recommended)") }, { value: "email_domain", label: copy(language, "整个邮箱域", "Entire email domain") }]} value={audienceKind} /><FieldDescription>{audienceKind === "email" ? copy(language, "仅允许一个明确邮箱。", "Allow one explicit email address.") : copy(language, "该域下所有可接收一次性验证码的邮箱都会被允许。", "Allow every mailbox in the domain that can receive a one-time PIN.")}</FieldDescription></Field>
                 <Field data-invalid={!audienceValid}><FieldLabel htmlFor="center-remote-access-audience">{audienceKind === "email" ? copy(language, "登录邮箱", "Sign-in email") : copy(language, "邮箱域名", "Email domain")}</FieldLabel><Input aria-invalid={!audienceValid} autoCapitalize="none" autoCorrect="off" id="center-remote-access-audience" onChange={(event) => setAudienceValue(event.target.value)} placeholder={audienceKind === "email" ? "admin@example.com" : "example.com"} spellCheck={false} type={audienceKind === "email" ? "email" : "text"} value={audienceValue} />{!audienceValid ? <FieldError>{audienceKind === "email" ? copy(language, "请输入有效邮箱。", "Enter a valid email address.") : copy(language, "请输入有效邮箱域名。", "Enter a valid email domain.")}</FieldError> : null}</Field>
               </> : null}
             </> : null}
             {access.status === "failed" && access.lastError ? <Alert variant="destructive"><AlertTitle>{copy(language, "上次配置没有完成", "The previous configuration did not finish")}</AlertTitle><AlertDescription className="break-words">{access.lastError}</AlertDescription></Alert> : null}
             {error ? <FieldError role="alert">{error}</FieldError> : null}
-          </FieldGroup>
+          </FieldGroup></FieldSet>
         </div>
         <SheetFooter>
           {cloudflareRequired ? <p className="text-xs leading-5 text-muted-foreground" id="center-remote-access-save-help" role="status">{copy(language, "请先在上方重新连接 Cloudflare 并授予所需权限。", "Reconnect Cloudflare above and grant the required permission first.")}</p> : null}
           <Button onClick={onClose} type="button" variant="outline">{copy(language, "取消", "Cancel")}</Button>
-          <Button aria-describedby={cloudflareRequired ? "center-remote-access-save-help" : undefined} disabled={busy || !access.available || enabled && (!cloudflareConnected || !audienceValid)} type="submit">{busy ? <Spinner data-icon="inline-start" /> : null}{enabled ? copy(language, "保存并启用", "Save and enable") : copy(language, "关闭入口", "Disable entry")}</Button>
+          <Button aria-describedby={cloudflareRequired ? "center-remote-access-save-help" : undefined} disabled={busy || !access.available || enabled && (!cloudflareConnected || !audienceValid || !durationValid)} type="submit">{busy ? <Spinner data-icon="inline-start" /> : null}{busy ? copy(language, "正在保存", "Saving") : enabled ? access.enabled && protectionMode === "access" ? copy(language, "保存并同步", "Save and synchronize") : copy(language, "保存并启用", "Save and enable") : copy(language, "关闭入口", "Disable entry")}</Button>
         </SheetFooter>
       </form>
     </SheetContent>

--- a/web/src/views/NetworkView.tsx
+++ b/web/src/views/NetworkView.tsx
@@ -2,12 +2,13 @@ import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "re
 import { CableIcon, CloudIcon, Globe2Icon, KeyRoundIcon, NetworkIcon, RouterIcon, ServerIcon, ShieldCheckIcon, TerminalIcon } from "lucide-react";
 import { api } from "../api";
 import type { AppData, Mutate } from "../App";
-import type { AgentView, HeadscaleJoin, Integration, NetworkKind, NetworkProfile, TailscaleFixedEndpoint, TailscaleFixedEndpointInput } from "../types";
+import type { AgentView, CenterRemoteAccess, HeadscaleJoin, Integration, NetworkKind, NetworkProfile, TailscaleFixedEndpoint, TailscaleFixedEndpointInput } from "../types";
 
 import type { Language } from "../translations";
 import { CopyButton, PageHeading, StateBadge, copy, formatDate, userError } from "./shared";
 import { CloudflareOAuthConnect } from "./CloudflareOAuthConnect";
 import { CenterRemoteAccessSheet } from "./CenterRemoteAccessSheet";
+import { AccessSessionStatus } from "./AccessSessionStatus";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -79,6 +80,7 @@ export function NetworkView({ data, language, mutate }: { data: AppData; languag
         {centerRemoteAccess ? <Card>
           <CardHeader><CardTitle className="flex items-center gap-2"><ShieldCheckIcon />{copy(language, "Center 远程备用入口", "Center remote fallback")}</CardTitle><CardDescription>{copy(language, "安全私网不可用时，通过 Cloudflare Tunnel 登录专用的一层 HTTPS 域名。", "Sign in through a dedicated first-level HTTPS hostname over Cloudflare Tunnel when the secure private network is unavailable.")}</CardDescription><CardAction><StateBadge value={centerRemoteAccess.status} /></CardAction></CardHeader>
           <CardContent><p className="text-sm text-muted-foreground">{centerRemoteAccess.enabled ? centerRemoteAccess.protectionMode === "native" ? copy(language, `${centerRemoteAccess.hostname} 直达 Center 登录，并由 Turnstile、失败退避和锁定保护。`, `${centerRemoteAccess.hostname} opens Center sign-in directly with Turnstile, failure backoff, and lockout.`) : copy(language, `已保护 ${centerRemoteAccess.hostname}，允许 ${centerRemoteAccess.audienceKind === "email" ? "邮箱" : "邮箱域"} ${centerRemoteAccess.audienceValue}。`, `${centerRemoteAccess.hostname} is protected for ${centerRemoteAccess.audienceKind === "email" ? "email" : "email domain"} ${centerRemoteAccess.audienceValue}.`) : copy(language, "当前关闭，Center 仅通过已配置的私网或本地入口访问。", "Currently off. Center is reachable only through its configured private or local entry.")}</p>{centerRemoteAccess.status === "failed" && centerRemoteAccess.lastError ? <Alert className="mt-3" variant="destructive"><AlertTitle>{copy(language, "需要处理", "Action required")}</AlertTitle><AlertDescription className="break-words">{centerRemoteAccess.lastError}</AlertDescription></Alert> : null}</CardContent>
+          {centerRemoteAccess.protectionMode === "access" ? <CardContent><AccessSessionStatus language={language} sync={centerRemoteAccess.accessSessionSync} /></CardContent> : null}
           <CardFooter className="justify-end"><Button disabled={!centerRemoteAccess.available} onClick={() => setEditor("center-remote-access")} size="sm" variant="outline">{centerRemoteAccess.enabled ? copy(language, "修改", "Edit") : copy(language, "设置", "Set up")}</Button></CardFooter>
         </Card> : null}
         <Card>
@@ -102,7 +104,13 @@ export function NetworkView({ data, language, mutate }: { data: AppData; languag
       <HeadscaleSheet integration={headscale} language={language} open={editor === "headscale"} onClose={() => setEditor(null)} onSave={async (input) => { await mutate(() => api.configureHeadscale(input), copy(language, "Headscale 已连接。", "Headscale connected.")); setEditor(null); }} />
       {tailscaleFixedEndpoint?.available ? <TailscaleFixedEndpointSheet endpoint={tailscaleFixedEndpoint} language={language} open={editor === "tailscale-endpoint"} onClose={() => setEditor(null)} onSave={async (input) => { await mutate(() => api.configureTailscaleFixedEndpoint(input), copy(language, "固定直连端点配置已保存。", "Fixed direct endpoint settings saved.")); setEditor(null); }} /> : null}
       <CloudflareSheet integration={cloudflare} language={language} open={editor === "cloudflare"} onClose={() => setEditor(null)} onConnected={async () => { await mutate(async () => undefined, copy(language, "Cloudflare 已连接。", "Cloudflare connected.")); setEditor(null); }} />
-      {centerRemoteAccess ? <CenterRemoteAccessSheet access={centerRemoteAccess} cloudflare={cloudflare} language={language} open={editor === "center-remote-access"} onClose={() => setEditor(null)} onCloudflareConnected={async () => { await mutate(async () => undefined, copy(language, "Cloudflare 已重新授权。", "Cloudflare reauthorized.")); }} onSave={async (input) => { await mutate(() => api.configureCenterRemoteAccess(input), input.enabled ? copy(language, "Center 远程备用入口已启用。", "Center remote fallback enabled.") : copy(language, "Center 远程备用入口已关闭。", "Center remote fallback disabled.")); setEditor(null); }} /> : null}
+      {centerRemoteAccess ? <CenterRemoteAccessSheet access={centerRemoteAccess} cloudflare={cloudflare} language={language} open={editor === "center-remote-access"} onClose={() => setEditor(null)} onCloudflareConnected={async () => { await mutate(async () => undefined, copy(language, "Cloudflare 已重新授权。", "Cloudflare reauthorized.")); }} onSave={async (input) => {
+        let saved: CenterRemoteAccess | undefined;
+        const accessMode = input.enabled && input.protectionMode === "access";
+        await mutate(async () => { saved = await api.configureCenterRemoteAccess(input); }, accessMode ? undefined : input.enabled ? copy(language, "Center 远程备用入口已启用。", "Center remote fallback enabled.") : copy(language, "Center 远程备用入口已关闭。", "Center remote fallback disabled."), { reportError: false });
+        if (!accessMode) setEditor(null);
+        return saved;
+      }} /> : null}
     </section>
   );
 }

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -15,6 +15,7 @@ import { SettingsView } from "./SettingsView";
 import { SetupWizard } from "./SetupWizard";
 import { CloudflareOAuthConnect } from "./CloudflareOAuthConnect";
 import { CenterUpdateCard } from "./CenterUpdateCard";
+import { CenterRemoteAccessSheet } from "./CenterRemoteAccessSheet";
 import { ThemeProvider } from "../components/theme";
 import { defaultPublicationHostname } from "./appAccess";
 import { CopyButton, userError } from "./shared";
@@ -280,6 +281,61 @@ describe("network and app views", () => {
     expect(document.body.textContent).toContain("需要补充 Cloudflare 授权");
     expect(document.body.textContent).toContain("创建专用 Turnstile 组件");
     expect([...document.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent?.includes("保存并启用"))?.disabled).toBe(true);
+  });
+
+  it("saves Access duration and leaves partial synchronization visible for retry", async () => {
+    const data = dashboard();
+    data.integrations = [{ kind: "cloudflare", mode: "oauth", endpoint: "example.com", accountId: "account", zoneId: "zone", secretSet: true, accessManagement: true, status: "configured" }];
+    const access = { available: true, enabled: true, hostname: "center-vastora.example.com", protectionMode: "access" as const, audienceKind: "email" as const, audienceValue: "admin@example.com", status: "configured" as const, accessSessionDuration: "6h" };
+    data.centerRemoteAccess = access;
+    const configure = vi.spyOn(api, "configureCenterRemoteAccess")
+      .mockResolvedValueOnce({ ...access, accessSessionSync: { status: "partial", total: 2, updated: 1, failedHosts: ["panel.example.com"], policyOverrideHosts: ["panel.example.com"] } })
+      .mockResolvedValueOnce({ ...access, accessSessionSync: { status: "synced", total: 2, updated: 2, policyOverrideHosts: ["panel.example.com"] } });
+    const container = render(<NetworkView data={data} language="zh-CN" mutate={async (operation) => { await operation(); }} />);
+    const card = [...container.querySelectorAll<HTMLElement>('[data-slot="card"]')].find((item) => item.textContent?.includes("Center 远程备用入口"));
+    act(() => card?.querySelector<HTMLButtonElement>("button")?.click());
+    expect(document.querySelector("#center-access-session-duration")).not.toBeNull();
+    expect(document.body.textContent).toContain("6 小时");
+    const save = [...document.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent?.includes("保存并同步"))!;
+    await act(async () => { save.click(); });
+    expect(configure).toHaveBeenLastCalledWith({ enabled: true, protectionMode: "access", audienceKind: "email", audienceValue: "admin@example.com", accessSessionDuration: "6h" });
+    expect(document.body.textContent).toContain("部分入口尚未同步");
+    expect(document.body.textContent).toContain("panel.example.com");
+    expect(document.body.textContent).toContain("未被覆盖");
+    expect(document.body.textContent).toContain("到期不一定需要重新输入邮箱验证码");
+    expect(document.querySelector("#center-access-session-duration")).not.toBeNull();
+    await act(async () => { save.click(); });
+    expect(document.body.textContent).toContain("2/2 个入口已同步");
+    expect(document.body.textContent).not.toContain("部分入口尚未同步");
+  });
+
+  it("defaults Access duration to 24h and hides it in native mode", async () => {
+    const base = { available: true, enabled: true, protectionMode: "access" as const, audienceKind: "email" as const, audienceValue: "admin@example.com", status: "configured" as const };
+    const cloudflare = { kind: "cloudflare" as const, mode: "oauth" as const, secretSet: true, accessManagement: true, turnstileManagement: true, status: "configured" };
+    const save = vi.fn(async () => undefined);
+    const props = { cloudflare, language: "zh-CN" as const, open: true, onClose: vi.fn(), onCloudflareConnected: async () => undefined, onSave: save };
+    render(<CenterRemoteAccessSheet {...props} access={base} />);
+    expect(document.body.textContent).toContain("24 小时（默认）");
+    await act(async () => { document.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })); });
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ accessSessionDuration: "24h" }));
+    act(() => root!.render(<ThemeProvider><CenterRemoteAccessSheet {...props} access={{ ...base, protectionMode: "native" }} /></ThemeProvider>));
+    expect(document.querySelector("#center-access-session-duration")).toBeNull();
+    await act(async () => { document.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })); });
+    expect(save).toHaveBeenLastCalledWith({ enabled: true, protectionMode: "native" });
+  });
+
+  it("blocks unsupported Access duration and keeps request errors in the sheet", async () => {
+    const access = { available: true, enabled: true, protectionMode: "access" as const, audienceKind: "email" as const, audienceValue: "admin@example.com", status: "configured" as const, accessSessionDuration: "-1h" };
+    const props = { access, cloudflare: { kind: "cloudflare" as const, mode: "oauth" as const, secretSet: true, accessManagement: true, status: "configured" }, language: "zh-CN" as const, open: true, onClose: vi.fn(), onCloudflareConnected: async () => undefined, onSave: vi.fn(async () => { throw new Error("request failed"); }) };
+    render(<CenterRemoteAccessSheet {...props} />);
+    await act(async () => { document.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })); });
+    expect(props.onSave).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("请选择支持的会话时长");
+    act(() => root!.render(<ThemeProvider><CenterRemoteAccessSheet {...props} access={{ ...access, accessSessionDuration: "24h" }} /></ThemeProvider>));
+    await act(async () => { document.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })); });
+    expect(props.onSave).toHaveBeenCalledOnce();
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')).not.toBeNull();
   });
 
   it("shows only successful applications and marks host-privileged packages", () => {

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -311,7 +311,7 @@ describe("network and app views", () => {
 
   it("defaults Access duration to 24h and hides it in native mode", async () => {
     const base = { available: true, enabled: true, protectionMode: "access" as const, audienceKind: "email" as const, audienceValue: "admin@example.com", status: "configured" as const };
-    const cloudflare = { kind: "cloudflare" as const, mode: "oauth" as const, secretSet: true, accessManagement: true, turnstileManagement: true, status: "configured" };
+    const cloudflare = { kind: "cloudflare" as const, mode: "oauth" as const, secretSet: true, accessManagement: true, turnstileManagement: true, status: "configured" as const };
     const save = vi.fn(async () => undefined);
     const props = { cloudflare, language: "zh-CN" as const, open: true, onClose: vi.fn(), onCloudflareConnected: async () => undefined, onSave: save };
     render(<CenterRemoteAccessSheet {...props} access={base} />);
@@ -326,7 +326,7 @@ describe("network and app views", () => {
 
   it("blocks unsupported Access duration and keeps request errors in the sheet", async () => {
     const access = { available: true, enabled: true, protectionMode: "access" as const, audienceKind: "email" as const, audienceValue: "admin@example.com", status: "configured" as const, accessSessionDuration: "-1h" };
-    const props = { access, cloudflare: { kind: "cloudflare" as const, mode: "oauth" as const, secretSet: true, accessManagement: true, status: "configured" }, language: "zh-CN" as const, open: true, onClose: vi.fn(), onCloudflareConnected: async () => undefined, onSave: vi.fn(async () => { throw new Error("request failed"); }) };
+    const props = { access, cloudflare: { kind: "cloudflare" as const, mode: "oauth" as const, secretSet: true, accessManagement: true, status: "configured" as const }, language: "zh-CN" as const, open: true, onClose: vi.fn(), onCloudflareConnected: async () => undefined, onSave: vi.fn(async () => { throw new Error("request failed"); }) };
     render(<CenterRemoteAccessSheet {...props} />);
     await act(async () => { document.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })); });
     expect(props.onSave).not.toHaveBeenCalled();


### PR DESCRIPTION
## Outcome

Implements #365: configure the system-wide Cloudflare Access application session duration (default 24h) from the existing remote-access sheet. Newly created entries inherit the saved duration; existing managed entries synchronize in place.

## Non-goals

- No organization-wide SSO, Cloudflare One Client, policy-duration, IdP, email allowlist, service-token, Tunnel, or Vastora login-session changes.
- No production deployment or live Cloudflare account changes in this PR.
- The separate uncommitted landing-readiness changes are not included.

## Interface impact

- Existing remote-access GET/PUT exposes accessSessionDuration and a durable accessSessionSync result.
- Migration 66 adds singleton settings, using the existing backup-before-migration and forward-only lifecycle.
- Duration-only updates preserve Access application identity and policy attachments, expose explicit policy overrides, retain protection on failure, and support retry.

## Validation

- Added persistence, validation, migration/backup, creation, managed-entry synchronization, partial failure/retry, cancellation, timeout, and identity checks.
- Added frontend default, mode visibility, validation, and retry/error-display coverage.
- Added targeted Access tests to required alpha CI; existing frontend and migration gates remain enabled.
- Local tests/build/lint/browser QA were not run, as required by AGENTS.md. Required GitHub CI will validate this PR before merge.
- Real tenant session-expiry behavior remains a post-deployment acceptance check; no claim of live OTP/SSO verification.

## Security review

- Only database-tracked, active managed Access application IDs are synchronized; unrelated or stopped entries are not touched.
- No delete/recreate or policy-duration update is used for duration-only changes. Raw Cloudflare errors stay out of the UI.
- No secrets or production host/account data are added. Center-Agent trust boundaries are unchanged.
