### PR TITLE
fix: restore Pulse containers and unblock pending agent updates

### DIFF
--- a/internal/agent/docker_executor.go
+++ b/internal/agent/docker_executor.go
@@ -373,7 +373,7 @@ func (e ApplicationExecutor) containerMatchesInstallation(ctx context.Context, c
 	if err != nil {
 		return false, fmt.Errorf("agent: verify %s ownership for offline restore: %w", installation.AppKey, err)
 	}
-	imageName := map[string]string{threeXUIKey: "3x-ui", cpaKey: "cli-proxy-api", keeperKey: "keeper"}[installation.AppKey]
+	imageName := map[string]string{threeXUIKey: "3x-ui", cpaKey: "cli-proxy-api", keeperKey: "keeper", pulse.ServiceKey: "pulse"}[installation.AppKey]
 	expectedImage, err := declaredImage(installation.Manifest, imageName)
 	if err != nil {
 		return false, err

--- a/internal/agent/docker_executor_test.go
+++ b/internal/agent/docker_executor_test.go
@@ -16,7 +16,38 @@ import (
 	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/client"
 	"github.com/petauron/vastora/internal/catalog"
+	"github.com/petauron/vastora/internal/pulse"
 )
+
+func TestPulseRestoreResolvesSignedImageBeforeComparingContainer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/_ping") {
+			w.Header().Set("API-Version", "1.55")
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, "/containers/"+pulseContainer+"/json") {
+			t.Errorf("unexpected Docker endpoint: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Id": "pulse-container",
+			"Config": map[string]any{
+				"Image":  "retained-old-image",
+				"Labels": applicationResourceLabels(pulse.ServiceKey, "pulse", "application", "deployment"),
+			},
+		})
+	}))
+	defer server.Close()
+	matched, err := (ApplicationExecutor{DockerSocket: server.URL}).containerMatchesInstallation(context.Background(), pulseContainer, AppliedInstallation{
+		AppKey: pulse.ServiceKey, ApplicationID: "application", InstanceID: "deployment",
+		Manifest: catalog.AppManifest{Images: []catalog.Image{{Name: "pulse", Reference: "ghcr.io/petauron/pulse:v0.1.0-alpha.2"}}},
+	})
+	if err != nil || matched {
+		t.Fatalf("expected an image mismatch, not a missing manifest image: matched=%v err=%v", matched, err)
+	}
+}
 
 func TestDeclaredImagePullOptionsUseOnlyMatchingEphemeralCredential(t *testing.T) {
 	image := "registry.example.test:5443/team/app@sha256:" + strings.Repeat("a", 64)

--- a/internal/center/center_update.go
+++ b/internal/center/center_update.go
@@ -182,7 +182,9 @@ func (s *Server) centerUpdateStatus(ctx context.Context, refreshOfficial bool) C
 			return result
 		}
 		result.AgentRollout = &rollout
-		if rollout.Pending != 0 || rollout.Updating != 0 {
+		// Waiting for rollout readiness is not an active update. Keep the
+		// completed Center update available for checks and subsequent upgrades.
+		if rollout.Updating != 0 {
 			result.State = "applying"
 			result.Phase = "agents"
 			result.Progress = 98

--- a/internal/center/center_update_test.go
+++ b/internal/center/center_update_test.go
@@ -116,7 +116,7 @@ func TestCenterUpdateStatusReportsVerifiedHostProgress(t *testing.T) {
 	}
 }
 
-func TestCenterUpdateWaitsForTheRemoteAgentRollout(t *testing.T) {
+func TestCenterUpdateDoesNotBlockOnUnqueuedRemoteAgents(t *testing.T) {
 	previousVersion := Version
 	Version = "0.1.0-alpha.99"
 	defer func() { Version = previousVersion }()
@@ -130,9 +130,16 @@ func TestCenterUpdateWaitsForTheRemoteAgentRollout(t *testing.T) {
 		TargetVersion: Version,
 		Message:       "Center was updated successfully.",
 	}}
-	server := &Server{store: store, updates: updater, releaseChecker: fixedReleaseChecker{version: Version}}
+	server := &Server{store: store, updates: updater, releaseChecker: fixedReleaseChecker{version: "0.1.0-alpha.100"}}
 	status := server.centerUpdateStatus(context.Background(), false)
-	if status.State != "applying" || status.Phase != "agents" || status.Progress != 98 || status.AgentRollout == nil || status.AgentRollout.Pending != 1 {
+	if status.State != "succeeded" || !status.UpdateAvailable || status.AgentRollout == nil || status.AgentRollout.Pending != 1 {
+		t.Fatalf("unqueued Agents blocked the completed Center update: %#v", status)
+	}
+	if _, err := store.QueueAgentUpdates(context.Background(), Version); err != nil {
+		t.Fatal(err)
+	}
+	status = server.centerUpdateStatus(context.Background(), false)
+	if status.State != "applying" || status.Phase != "agents" || status.Progress != 98 || status.AgentRollout == nil || status.AgentRollout.Updating != 1 {
 		t.Fatalf("unexpected remote Agent rollout status: %#v", status)
 	}
 }


### PR DESCRIPTION
## Summary
- Resolve the Pulse signed image during retained container recovery.
- Do not report unqueued Agent updates as an active Center update or block a newer Center release.
- Preserve the active rollout lock and readiness checks.

## Verification
- Added regression coverage for Pulse image resolution and pending versus queued Agent rollout state.
- Local tests were not run per repository policy; required CI must pass before merge.
- Unrelated UI changes are excluded. No production deployment performed.