### PR TITLE
fix(web): simplify subscription client cards and HY2 guidance

### DIFF
--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,39 @@
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import { cn } from "@/lib/utils";
+
+export function DropdownMenu(props: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root {...props} />;
+}
+
+export function DropdownMenuTrigger(props: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+export function DropdownMenuContent({ className, align = "start", ...props }: MenuPrimitive.Popup.Props & Pick<MenuPrimitive.Positioner.Props, "align">) {
+  return <MenuPrimitive.Portal>
+    <MenuPrimitive.Positioner align={align} sideOffset={4} className="isolate z-50 outline-none">
+      <MenuPrimitive.Popup
+        data-slot="dropdown-menu-content"
+        className={cn("max-h-(--available-height) min-w-40 overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none", className)}
+        {...props}
+      />
+    </MenuPrimitive.Positioner>
+  </MenuPrimitive.Portal>;
+}
+
+export function DropdownMenuGroup(props: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+export function DropdownMenuItem({ className, variant = "default", ...props }: MenuPrimitive.Item.Props & { variant?: "default" | "destructive" }) {
+  return <MenuPrimitive.Item
+    data-slot="dropdown-menu-item"
+    data-variant={variant}
+    className={cn("relative flex min-h-8 cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 data-[variant=destructive]:data-highlighted:text-destructive data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0", className)}
+    {...props}
+  />;
+}
+
+export function DropdownMenuSeparator({ className, ...props }: MenuPrimitive.Separator.Props) {
+  return <MenuPrimitive.Separator data-slot="dropdown-menu-separator" className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />;
+}

--- a/web/src/views/NodeProtocolControls.test.tsx
+++ b/web/src/views/NodeProtocolControls.test.tsx
@@ -40,6 +40,8 @@ it("defaults to VLESS and adds HY2 without AnyTLS", async () => {
   expect(container.textContent).not.toContain("AnyTLS");
   expect(button(container, "保存协议").disabled).toBe(true);
   await act(async () => { container.querySelector<HTMLElement>("#node-service-hy2")?.click(); });
+  expect(container.textContent).toContain("TLS 证书由系统自动申请并续期");
+  expect(container.textContent).not.toContain("Cloudflare 签发证书");
   await act(async () => { button(container, "保存协议").click(); });
   expect(save).toHaveBeenCalledWith("node-service", { vless: true, hy2: true });
   expect(updated).toHaveBeenCalledOnce();

--- a/web/src/views/NodeProtocolControls.tsx
+++ b/web/src/views/NodeProtocolControls.tsx
@@ -72,7 +72,7 @@ export function NodeProtocolControls({ serviceId, language, onUpdated }: { servi
         <Checkbox id={`${serviceId}-${protocol}`} checked={draft[protocol]} disabled={active || command?.reconciliationRequired} aria-invalid={empty} onCheckedChange={(checked) => setDraft((current) => ({ ...current, [protocol]: checked }))} />
         <FieldLabel htmlFor={`${serviceId}-${protocol}`}>{protocol.toUpperCase()}</FieldLabel>
       </Field>)}
-      {draft.hy2 ? <FieldDescription>{copy(language, "HY2 需要放行节点的 UDP 443，并通过已连接的 Cloudflare 签发证书。", "HY2 needs UDP 443 allowed on the node and a certificate issued through your connected Cloudflare account.")}</FieldDescription> : null}
+      {draft.hy2 ? <FieldDescription>{copy(language, "HY2 需要放行节点的 UDP 443。TLS 证书由系统自动申请并续期。", "HY2 needs UDP 443 allowed on the node. TLS certificates are requested and renewed automatically.")}</FieldDescription> : null}
       {draft.hy2 ? <FieldDescription>{copy(language, "HY2 使用客户端套餐；原 VLESS 节点套餐仍只计算 VLESS 流量。", "HY2 uses client quotas. The existing VLESS node plan counts VLESS traffic only.")}</FieldDescription> : null}
       {empty ? <FieldError>{copy(language, "至少选择一种协议。", "Select at least one protocol.")}</FieldError> : null}
       <Button className="w-fit" disabled={active || empty || (!changed && saved.state !== "failed" && command?.state !== "failed")} onClick={() => void save()} type="button" variant="outline">

--- a/web/src/views/ThreeXUIClientCard.test.tsx
+++ b/web/src/views/ThreeXUIClientCard.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { ThreeXUIClient, ThreeXUIClientInbound } from "../types";
+import { ThreeXUIClientCard } from "./ThreeXUIClientCard";
+
+const client: ThreeXUIClient = { email: "My MacBook", enabled: true, usedBytes: 64 * 1024 ** 3, totalBytes: 0, expiryTime: 0, resetDays: 0, limitIp: 0, inboundIds: [1, 2, 3, 4, 5, 6, 7], hasSubscription: true };
+const inbounds: ThreeXUIClientInbound[] = client.inboundIds.map((id) => ({ id, name: `inbound-${id}`, nodeName: `Node ${id}`, displayName: `🇺🇸 美国｜Node ${id}`, connectHostname: `node-${id}.example.test` }));
+
+function card(value = client, subscriptionAvailable = true, language: "en" | "zh-CN" = "zh-CN") {
+  const container = document.createElement("div");
+  container.innerHTML = renderToStaticMarkup(<ThreeXUIClientCard
+    client={value} inbounds={inbounds} language={language} expiryLabel={language === "zh-CN" ? "永不过期" : "Never"}
+    busy={false} linksDisabled={false} subscriptionAvailable={subscriptionAvailable}
+    onEnabledChange={vi.fn()} onCopySubscription={vi.fn()} onCopyLink={vi.fn()} onEdit={vi.fn()} onReset={vi.fn()} onDelete={vi.fn()}
+  />);
+  return container;
+}
+
+describe("subscription client card", () => {
+  it("collapses the node list without losing full names", () => {
+    const container = card();
+    const details = container.querySelector("details")!;
+    expect(details.open).toBe(false);
+    expect(details.querySelector("summary")?.textContent).toBe("已接入 7 个节点");
+    expect(details.querySelectorAll("li")).toHaveLength(7);
+    expect(details.textContent).toContain("🇺🇸 美国｜Node 7");
+    expect(container.querySelectorAll("h3")).toHaveLength(1);
+    expect(container.querySelector('[data-slot="card-header"]')?.textContent).not.toContain("已接入 7 个节点：");
+  });
+
+  it("separates usage from limits and prioritizes the subscription action", () => {
+    const container = card();
+    expect(container.textContent).toContain("64.0 GB");
+    expect(container.textContent).toContain("不限流量");
+    expect(container.querySelectorAll("dl dt")).toHaveLength(3);
+    const buttons = [...container.querySelectorAll<HTMLButtonElement>('[data-slot="card-footer"] button')];
+    expect(buttons[0].textContent).toBe("复制订阅");
+    expect(buttons[0].disabled).toBe(false);
+    expect(buttons[1].textContent).toBe("编辑");
+    expect(buttons[2].getAttribute("aria-label")).toBe("更多操作：My MacBook");
+    expect(container.textContent).not.toContain("复制 VLESS");
+    expect(container.textContent).not.toContain("删除客户端");
+    expect(container.textContent).not.toContain("同一地址会自动适配");
+  });
+
+  it("handles no nodes, a disabled client and unavailable subscriptions", () => {
+    const container = card({ ...client, email: "A very long client name without truncation", inboundIds: [], enabled: false, totalBytes: 100 * 1024 ** 3, limitIp: 3, resetDays: 30 }, false);
+    expect(container.querySelector("h3")?.textContent).toBe("A very long client name without truncation");
+    expect(container.querySelector("details")).toBeNull();
+    expect(container.textContent).toContain("未连接节点");
+    expect(container.textContent).toContain("已停用");
+    expect(container.textContent).toContain("/ 100.0 GB");
+    expect(container.textContent).toContain("每 30 天");
+    expect(container.textContent).toContain("开启公网订阅后可复制地址");
+    expect(container.querySelector<HTMLButtonElement>('[data-slot="card-footer"] button')?.disabled).toBe(true);
+  });
+
+  it("keeps the English card concise", () => {
+    const container = card(client, true, "en");
+    expect(container.querySelector("summary")?.textContent).toBe("7 connected node(s)");
+    expect(container.textContent).toContain("Data used");
+    expect(container.textContent).toContain("Copy subscription");
+    expect(container.querySelectorAll("dl dd")[0]?.textContent).toBe("Never");
+  });
+});

--- a/web/src/views/ThreeXUIClientCard.tsx
+++ b/web/src/views/ThreeXUIClientCard.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from "react";
+import { ChevronRightIcon, CopyIcon, LinkIcon, MoreHorizontalIcon, PencilIcon, RotateCcwIcon, Trash2Icon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
+import type { Language } from "../translations";
+import type { ThreeXUIClient, ThreeXUIClientInbound } from "../types";
+import { formatBytes } from "./TrafficPlanFields";
+import { copy } from "./shared";
+
+type Props = {
+  client: ThreeXUIClient;
+  inbounds: ThreeXUIClientInbound[];
+  language: Language;
+  expiryLabel: string;
+  busy: boolean;
+  linksDisabled: boolean;
+  subscriptionAvailable: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+  onCopySubscription: () => void;
+  onCopyLink: () => void;
+  onEdit: () => void;
+  onReset: () => void;
+  onDelete: () => void;
+  children?: ReactNode;
+};
+
+export function ThreeXUIClientCard({ client, inbounds, language, expiryLabel, busy, linksDisabled, subscriptionAvailable, onEnabledChange, onCopySubscription, onCopyLink, onEdit, onReset, onDelete, children }: Props) {
+  const nodes = inbounds.filter((inbound) => client.inboundIds.includes(inbound.id));
+  const published = nodes.some((inbound) => inbound.connectHostname);
+
+  return <Card className="@container min-w-0" data-client-email={client.email}>
+    <CardHeader className="grid-cols-[minmax(0,1fr)_auto] gap-x-4">
+      <CardTitle><h3 className="break-words [overflow-wrap:anywhere]">{client.email}</h3></CardTitle>
+      <CardAction className="row-span-1 flex items-center gap-2">
+        <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+          <span>{client.enabled ? copy(language, "已启用", "Enabled") : copy(language, "已停用", "Disabled")}</span>
+          <Switch aria-label={copy(language, `启用 ${client.email}`, `Enable ${client.email}`)} checked={client.enabled} disabled={busy} onCheckedChange={onEnabledChange} />
+        </label>
+      </CardAction>
+      <div className="col-span-2 min-w-0">
+        {nodes.length ? <details className="group/nodes">
+          <summary className="flex min-h-8 w-fit cursor-pointer list-none items-center gap-1 rounded-md text-xs text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+            <span>{copy(language, `已接入 ${nodes.length} 个节点`, `${nodes.length} connected node(s)`)}</span>
+            <ChevronRightIcon aria-hidden="true" className="size-3.5 group-open/nodes:rotate-90" />
+          </summary>
+          <ul aria-label={copy(language, "已接入节点", "Connected nodes")} className="mt-1 grid gap-2 text-xs text-muted-foreground">
+            {nodes.map((node) => <li className="break-words [overflow-wrap:anywhere]" key={node.id}>{node.displayName || node.nodeName || node.name}</li>)}
+          </ul>
+        </details> : <p className="pt-2 text-xs text-muted-foreground">{copy(language, "未连接节点", "No node attached")}</p>}
+      </div>
+    </CardHeader>
+    <CardContent className="flex flex-col gap-4">
+      <div>
+        <p className="text-xs text-muted-foreground">{copy(language, "已用流量", "Data used")}</p>
+        <p className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-1 tabular-nums">
+          <span className="text-2xl font-semibold tracking-tight">{formatBytes(client.usedBytes)}</span>
+          <span className="text-xs text-muted-foreground">{client.totalBytes ? `/ ${formatBytes(client.totalBytes)}` : copy(language, "不限流量", "Unlimited data")}</span>
+        </p>
+      </div>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-xs @min-[22rem]:grid-cols-3">
+        <ClientMetric label={copy(language, "有效期", "Expires")} value={expiryLabel} />
+        <ClientMetric label={copy(language, "自动续期", "Auto-renewal")} value={client.resetDays ? copy(language, `每 ${client.resetDays} 天`, `Every ${client.resetDays} days`) : copy(language, "关闭", "Off")} />
+        <ClientMetric label={copy(language, "设备限制", "Device limit")} value={client.limitIp ? String(client.limitIp) : copy(language, "不限", "Unlimited")} />
+      </dl>
+      {children}
+    </CardContent>
+    <CardFooter className="flex-col items-stretch gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button className="flex-1" disabled={busy || linksDisabled || !subscriptionAvailable} onClick={onCopySubscription}>
+          <CopyIcon aria-hidden="true" data-icon="inline-start" />{copy(language, "复制订阅", "Copy subscription")}
+        </Button>
+        <Button disabled={busy} onClick={onEdit} variant="outline"><PencilIcon aria-hidden="true" data-icon="inline-start" />{copy(language, "编辑", "Edit")}</Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger disabled={busy} render={<Button aria-label={copy(language, `更多操作：${client.email}`, `More actions for ${client.email}`)} size="icon" variant="ghost" />}>
+            <MoreHorizontalIcon aria-hidden="true" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuGroup>
+              <DropdownMenuItem disabled={busy || linksDisabled || !published} onClick={onCopyLink}><LinkIcon aria-hidden="true" />{copy(language, "复制 VLESS", "Copy VLESS")}</DropdownMenuItem>
+              <DropdownMenuItem disabled={busy} onClick={onReset}><RotateCcwIcon aria-hidden="true" />{copy(language, "重置流量", "Reset traffic")}</DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem disabled={busy} onClick={onDelete} variant="destructive"><Trash2Icon aria-hidden="true" />{copy(language, "删除客户端", "Delete client")}</DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {!subscriptionAvailable ? <p className="text-xs text-muted-foreground">{copy(language, "开启公网订阅后可复制地址。", "Enable public subscription to copy its URL.")}</p> : null}
+    </CardFooter>
+  </Card>;
+}
+
+function ClientMetric({ label, value }: { label: string; value: string }) {
+  return <div className="min-w-0"><dt className="text-muted-foreground">{label}</dt><dd className="mt-1 break-words font-medium tabular-nums">{value}</dd></div>;
+}

--- a/web/src/views/ThreeXUIClientsSheet.tsx
+++ b/web/src/views/ThreeXUIClientsSheet.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { CheckIcon, CopyIcon, ExternalLinkIcon, LinkIcon, PencilIcon, PlusIcon, RefreshCwIcon, RotateCcwIcon, ServerIcon, Trash2Icon, UsersIcon } from "lucide-react";
+import { CheckIcon, CopyIcon, ExternalLinkIcon, LinkIcon, PlusIcon, RefreshCwIcon, RotateCcwIcon, ServerIcon, Trash2Icon, UsersIcon } from "lucide-react";
 import { api } from "../api";
 import type { Application, ApplicationCommand, ThreeXUIClient, ThreeXUIClientCommandInput, ThreeXUIClientInbound } from "../types";
 import type { Language } from "../translations";
 import { copy, userError } from "./shared";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
@@ -15,8 +14,9 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useApplicationCommandExecutor } from "../hooks/use-application-command-executor";
 import { clearSecretOperation, commandSecretOperations, commandSecretScope, secretOperation } from "../secret-delivery";
-import { bytesFromGB, dateInputValueInTimeZone, endOfDayEpochInTimeZone, formatBytes, gigabytesFromBytes, nextRenewalDateInTimeZone, SubscriptionTrafficPlanFields } from "./TrafficPlanFields";
+import { bytesFromGB, dateInputValueInTimeZone, endOfDayEpochInTimeZone, gigabytesFromBytes, nextRenewalDateInTimeZone, SubscriptionTrafficPlanFields } from "./TrafficPlanFields";
 import { hasObservedThreeXUIState, mergeCachedCommand, mergeCommandUpdate } from "./threeXUICommandState";
+import { ThreeXUIClientCard } from "./ThreeXUIClientCard";
 
 type Editor = { client?: ThreeXUIClient } | null;
 type RevealedLink = { title: string; value: string; commandId: string; operationKey: string; scope: string } | null;
@@ -187,22 +187,25 @@ export function ThreeXUIClientsSheet({ application, advancedURL, language, onClo
           {!busy && clients.length === 0 && !refreshError ? <Empty className="border"><EmptyHeader><EmptyMedia variant="icon"><UsersIcon /></EmptyMedia><EmptyTitle>{copy(language, "还没有客户端", "No clients yet")}</EmptyTitle><EmptyDescription>{copy(language, "为手机、电脑或路由器各创建一个客户端，便于单独停用和查看流量。", "Create one client per phone, computer, or router so each can be disabled and tracked separately.")}</EmptyDescription>{inbounds.length ? <Button className="mt-3" onClick={() => openEditor({})} size="sm"><PlusIcon data-icon="inline-start" />{copy(language, "添加第一个客户端", "Add first client")}</Button> : null}</EmptyHeader></Empty> : null}
 
           <div className="grid gap-3">
-            {visibleClients.map((client) => {
-              const publishedInbound = inbounds.find((inbound) => inbound.connectHostname && client.inboundIds.includes(inbound.id));
-				const inboundNames = inbounds.filter((inbound) => client.inboundIds.includes(inbound.id)).map((inbound) => inbound.displayName || inbound.nodeName || inbound.name);
-              return <div className="rounded-2xl border bg-card p-4" key={client.email}>
-                <div className="flex flex-wrap items-start gap-3">
-                  <div className="min-w-0 flex-1"><div className="flex flex-wrap items-center gap-2"><h3 className="truncate font-medium">{client.email}</h3><Badge variant={client.enabled ? "secondary" : "outline"}>{client.enabled ? copy(language, "已启用", "Enabled") : copy(language, "已停用", "Disabled")}</Badge></div><p className="mt-1 text-xs text-muted-foreground">{inboundNames.length ? copy(language, `已接入 ${inboundNames.length} 个节点：${inboundNames.join("、")}`, `Connected to ${inboundNames.length} node(s): ${inboundNames.join(", ")}`) : copy(language, "未连接节点", "No node attached")}</p></div>
-                  <Switch aria-label={copy(language, `启用 ${client.email}`, `Enable ${client.email}`)} checked={client.enabled} disabled={busy} onCheckedChange={(enabled) => void run({ action: "set_enabled", email: client.email, enabled }).catch(() => undefined)} />
-                </div>
-                <div className="mt-4 grid gap-3 text-xs sm:grid-cols-4"><Metric label={copy(language, "订阅已用（上下行）", "Subscription used (up + down)")} value={`${formatBytes(client.usedBytes)}${client.totalBytes ? ` / ${formatBytes(client.totalBytes)}` : ""}`} /><Metric label={copy(language, "有效期", "Expires")} value={formatExpiry(client.expiryTime, language, siteTimezone)} /><Metric label={copy(language, "自动续期", "Auto-renewal")} value={client.resetDays ? copy(language, `每 ${client.resetDays} 天`, `Every ${client.resetDays} days`) : copy(language, "关闭", "Off")} /><Metric label={copy(language, "设备数限制", "IP limit")} value={client.limitIp ? String(client.limitIp) : copy(language, "不限", "Unlimited")} /></div>
-	                {resetClient?.email === client.email ? <Alert className="mt-4"><RotateCcwIcon /><AlertTitle>{copy(language, `重置“${client.email}”的订阅用量？`, `Reset subscription usage for “${client.email}”?`)}</AlertTitle><AlertDescription><p>{copy(language, "这会把该客户端在所有 VLESS 节点上的合计用量清零，相当于立即开始一个新套餐周期，且不能撤销。", "This clears the client's combined usage across every VLESS node, immediately starting a new allowance cycle. It cannot be undone.")}</p><div className="mt-3 flex gap-2"><Button disabled={busy} onClick={() => setResetClient(null)} size="sm" variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy} onClick={() => void run({ action: "reset_traffic", email: client.email }).then(() => setResetClient(null)).catch(() => undefined)} size="sm">{copy(language, "确认重置", "Reset usage")}</Button></div></AlertDescription></Alert> : null}
-				{deleteClient?.email === client.email ? <Alert className="mt-4" variant="destructive"><Trash2Icon /><AlertTitle>{copy(language, `删除“${client.email}”？`, `Delete “${client.email}”?`)}</AlertTitle><AlertDescription><p>{copy(language, "该客户端会立即无法连接，此操作不能撤销。", "This client will stop connecting immediately. This cannot be undone.")}</p><div className="mt-3 flex gap-2"><Button disabled={busy} onClick={() => setDeleteClient(null)} size="sm" variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy} onClick={() => void run({ action: "delete", email: client.email }).then(() => setDeleteClient(null)).catch(() => undefined)} size="sm" variant="destructive">{copy(language, "确认删除", "Delete client")}</Button></div></AlertDescription></Alert> : <div className="mt-4 flex flex-wrap gap-2"><Button disabled={busy || Boolean(revealed) || !publishedInbound} onClick={() => void reveal(client, "reveal_link")} size="sm" variant="outline"><LinkIcon data-icon="inline-start" />{copy(language, "复制 VLESS", "Copy VLESS")}</Button><Button disabled={busy || Boolean(revealed) || !command?.subscriptionAvailable} onClick={() => void reveal(client, "reveal_subscription")} size="sm" variant="outline"><LinkIcon data-icon="inline-start" />{copy(language, "复制订阅", "Copy subscription")}</Button><Button disabled={busy} onClick={() => openEditor({ client })} size="icon-sm" title={copy(language, "编辑", "Edit")} variant="ghost"><PencilIcon /><span className="sr-only">{copy(language, "编辑", "Edit")}</span></Button><Button disabled={busy} onClick={() => { setDeleteClient(null); setResetClient(client); }} size="icon-sm" title={copy(language, "重置流量", "Reset traffic")} variant="ghost"><RotateCcwIcon /><span className="sr-only">{copy(language, "重置流量", "Reset traffic")}</span></Button><Button disabled={busy} onClick={() => { setResetClient(null); setDeleteClient(client); }} size="icon-sm" title={copy(language, "删除", "Delete")} variant="ghost"><Trash2Icon /><span className="sr-only">{copy(language, "删除", "Delete")}</span></Button></div>}
-                {!publishedInbound ? <p className="mt-2 text-xs text-muted-foreground">{copy(language, "为入站完成公网发布后才能导出 VLESS 链接。", "Publish the inbound before exporting a VLESS URL.")}</p> : null}
-                {!command?.subscriptionAvailable ? <p className="mt-1 text-xs text-muted-foreground">{copy(language, "开启公网订阅后才能复制订阅地址。", "Enable public subscription before copying a subscription URL.")}</p> : null}
-                {command?.subscriptionAvailable ? <p className="mt-1 text-xs text-muted-foreground">{copy(language, "同一地址会自动适配 OpenClash、Mihomo 和其他客户端。", "The same URL automatically adapts to OpenClash, Mihomo, and other clients.")}</p> : null}
-              </div>;
-            })}
+            {visibleClients.map((client) => <ThreeXUIClientCard
+              key={client.email}
+              client={client}
+              inbounds={inbounds}
+              language={language}
+              expiryLabel={formatExpiry(client.expiryTime, language, siteTimezone)}
+              busy={busy}
+              linksDisabled={Boolean(revealed)}
+              subscriptionAvailable={Boolean(command?.subscriptionAvailable)}
+              onEnabledChange={(enabled) => void run({ action: "set_enabled", email: client.email, enabled }).catch(() => undefined)}
+              onCopySubscription={() => void reveal(client, "reveal_subscription")}
+              onCopyLink={() => void reveal(client, "reveal_link")}
+              onEdit={() => openEditor({ client })}
+              onReset={() => { setDeleteClient(null); setResetClient(client); }}
+              onDelete={() => { setResetClient(null); setDeleteClient(client); }}
+            >
+              {resetClient?.email === client.email ? <Alert><RotateCcwIcon /><AlertTitle>{copy(language, `重置“${client.email}”的订阅用量？`, `Reset subscription usage for “${client.email}”?`)}</AlertTitle><AlertDescription><p>{copy(language, "这会把该客户端在所有 VLESS 节点上的合计用量清零，相当于立即开始一个新套餐周期，且不能撤销。", "This clears the client's combined usage across every VLESS node, immediately starting a new allowance cycle. It cannot be undone.")}</p><div className="mt-3 flex gap-2"><Button disabled={busy} onClick={() => setResetClient(null)} size="sm" variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy} onClick={() => void run({ action: "reset_traffic", email: client.email }).then(() => setResetClient(null)).catch(() => undefined)} size="sm">{copy(language, "确认重置", "Reset usage")}</Button></div></AlertDescription></Alert> : null}
+              {deleteClient?.email === client.email ? <Alert variant="destructive"><Trash2Icon /><AlertTitle>{copy(language, `删除“${client.email}”？`, `Delete “${client.email}”?`)}</AlertTitle><AlertDescription><p>{copy(language, "该客户端会立即无法连接，此操作不能撤销。", "This client will stop connecting immediately. This cannot be undone.")}</p><div className="mt-3 flex gap-2"><Button disabled={busy} onClick={() => setDeleteClient(null)} size="sm" variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy} onClick={() => void run({ action: "delete", email: client.email }).then(() => setDeleteClient(null)).catch(() => undefined)} size="sm" variant="destructive">{copy(language, "确认删除", "Delete client")}</Button></div></AlertDescription></Alert> : null}
+            </ThreeXUIClientCard>)}
           </div>
           {pageCount > 1 ? <div className="flex items-center justify-between"><Button disabled={page <= 1} onClick={() => setPage((value) => Math.max(1, value - 1))} size="sm" variant="outline">{copy(language, "上一页", "Previous")}</Button><span className="text-xs tabular-nums text-muted-foreground">{Math.min(page, pageCount)} / {pageCount}</span><Button disabled={page >= pageCount} onClick={() => setPage((value) => Math.min(pageCount, value + 1))} size="sm" variant="outline">{copy(language, "下一页", "Next")}</Button></div> : null}
         </div>
@@ -300,8 +303,6 @@ function clientEditorDraft(client: ThreeXUIClient | undefined, inbounds: ThreeXU
 function sameSelection(left: number[], right: number[]) {
   return left.length === right.length && left.every((id) => right.includes(id));
 }
-
-function Metric({ label, value }: { label: string; value: string }) { return <div><p className="text-muted-foreground">{label}</p><p className="mt-1 font-medium tabular-nums">{value}</p></div>; }
 
 function formatExpiry(value: number, language: Language, timeZone?: string) {
   if (!value) return copy(language, "永不过期", "Never");

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -1185,8 +1185,10 @@ describe("network and app views", () => {
     });
     expect(create).toHaveBeenCalledWith({ applicationId: "three-x-ui", action: "list" });
     expect(document.body.textContent).toContain("MacBook");
-    expect(document.body.textContent).toContain("已接入 1 个节点：edge-worker");
-    expect(document.body.textContent).toContain("订阅已用（上下行）");
+    expect(document.body.textContent).toContain("已接入 1 个节点");
+    expect(document.querySelector<HTMLDetailsElement>('details:has([aria-label="已接入节点"])')?.open).toBe(false);
+    expect(document.querySelector('[aria-label="已接入节点"]')?.textContent).toContain("edge-worker");
+    expect(document.body.textContent).toContain("已用流量");
     expect(document.body.textContent).toContain("日常管理");
     act(() => [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("编辑") || button.querySelector(".sr-only")?.textContent === "编辑")?.click());
     expect(document.body.textContent).toContain("客户端额度（可选）");
@@ -1205,8 +1207,9 @@ describe("network and app views", () => {
       await Promise.resolve();
     });
     expect(create).toHaveBeenCalledWith({ applicationId: "three-x-ui", action: "update", email: "MacBook", newEmail: "MacBook", inboundIds: [9, 10], totalBytes: 10 * 1024 ** 3, resetDays: 0, expiryTime: 0, limitIp: 2 });
+    await act(async () => { document.querySelector<HTMLButtonElement>('button[aria-label="更多操作：MacBook"]')?.click(); });
     await act(async () => {
-      [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("复制 VLESS"))?.click();
+      [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find((item) => item.textContent?.includes("复制 VLESS"))?.click();
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -1229,7 +1232,8 @@ describe("network and app views", () => {
     expect([...document.querySelectorAll("button")].filter((button) => button.textContent?.trim() === "复制订阅")).toHaveLength(1);
     expect([...document.querySelectorAll("button")].some((button) => button.textContent?.trim() === "OpenClash")).toBe(false);
     const resetCallsBeforeConfirmation = create.mock.calls.filter(([input]) => input.action === "reset_traffic").length;
-    act(() => document.querySelector<HTMLButtonElement>('button[title="重置流量"]')?.click());
+    await act(async () => { document.querySelector<HTMLButtonElement>('button[aria-label="更多操作：MacBook"]')?.click(); });
+    await act(async () => { [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find((item) => item.textContent?.includes("重置流量"))?.click(); });
     expect(document.body.textContent).toContain("所有 VLESS 节点上的合计用量清零");
     expect(create.mock.calls.filter(([input]) => input.action === "reset_traffic")).toHaveLength(resetCallsBeforeConfirmation);
     await act(async () => {
@@ -1237,6 +1241,10 @@ describe("network and app views", () => {
       await Promise.resolve();
     });
     expect(create).toHaveBeenCalledWith({ applicationId: "three-x-ui", action: "reset_traffic", email: "MacBook" });
+    await act(async () => { document.querySelector<HTMLButtonElement>('button[aria-label="更多操作：MacBook"]')?.click(); });
+    await act(async () => { [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find((item) => item.textContent?.includes("删除客户端"))?.click(); });
+    expect(document.body.textContent).toContain("删除“MacBook”？");
+    expect(create.mock.calls.some(([input]) => input.action === "delete")).toBe(false);
   });
 
   it("shows cached clients immediately while refreshing and formats expiry in the Site timezone", async () => {


### PR DESCRIPTION
## Outcome

Ship the remaining subscription-client UI polish and correct the HY2 certificate explanation.

- Extract a compact 3x-ui client card using the existing themed Card components.
- Collapse connected node names by default while retaining the full list.
- Make traffic usage, subscription copying, and editing easier to find.
- Move VLESS link copying, traffic reset, and deletion into an accessible menu; preserve explicit reset/delete confirmation and existing command/secret handling.
- Describe HY2 certificates as automatically requested and renewed rather than issued by Cloudflare.

## Issue closure

User-requested follow-up; no additional issue is claimed as completed.

## Non-goals

- No API, database, Agent, quota, certificate lifecycle, or authentication changes.
- No unrelated PRs are merged.
- This PR does not initialize the production catalog signing root or environment. The current program-release preflight correctly blocks publication until those separately provisioned prerequisites exist.

## Interface impact

Frontend only. Uses the existing Base UI dependency and shared semantic theme. No package dependency change.

## Validation

- [x] Required repository CI gates passed on final head `4c10a12040e74f5a8345176f67d85704f2f121f7`: [CI](https://github.com/petauron/vastora/actions/runs/34674669124) and [CodeQL gate](https://github.com/petauron/vastora/actions/runs/34674669130). Frontend lint/tests/build/audit and security scanning passed. Existing alpha/path-based skips are unchanged.
- [x] Tests cover the compact card, collapsed node list, unavailable subscriptions, disabled clients, English/Chinese presentation, more-menu actions, reset/delete confirmation, and HY2 wording.
- [x] Validation evidence is accurately reported: no new local tests, build, typecheck, linter, or browser QA were run during this submission, per AGENTS.md. Git diff whitespace checks passed; repository CI will validate the committed snapshot.

## Security review

- [x] No secret, private host, account, or runtime data is added.
- [x] Center-Agent trust boundaries and existing secret-delivery operations are unchanged.
- [x] Destructive operations still require confirmation; menu selection alone does not issue a delete command.
