### PR TITLE
feat(nodes): stop offline agent access without removing workloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       - run: make go-format-check go-static-check
       - name: Verify Agent update recovery invariants
         run: go test ./cmd/vastora ./internal/agent ./internal/center -run '^(TestHostUpdate|TestAgentUpdate|TestUninstall.*Updater|TestCancelledUpdater)' -count=1
+      - name: Verify offline Agent access revocation
+        run: go test ./internal/center -run '^(TestStop.*AgentAccess|TestRevocation)' -count=1
       - name: Verify Cloudflare Access session configuration
         run: go test ./internal/center -run 'Test.*(AccessSession|CenterRemoteAccess|CloudflareIntegration)' -count=1
       - name: Verify network recovery availability

--- a/internal/center/agent_access_test.go
+++ b/internal/center/agent_access_test.go
@@ -1,0 +1,150 @@
+package center
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/petauron/vastora/internal/networking"
+)
+
+func enrollAccessTestNode(t *testing.T, store *Store, name, address string) AgentCredential {
+	t.Helper()
+	return enrollOrchestrationNode(t, store, name, NodeCapabilities{Docker: true, Gateway: true},
+		[]networking.Candidate{{Address: address, Interface: "eth0", Kind: networking.KindLAN}},
+		networking.Profile{ServiceAddress: address, LANAddress: address, EnabledKinds: []string{networking.KindLAN}})
+}
+
+func TestStopOfflineAgentAccessPreservesApplicationsAndGateway(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	clock := store.now()
+	store.now = func() time.Time { return clock }
+	node := enrollAccessTestNode(t, store, "offline-node", "10.0.0.80")
+	other := enrollAccessTestNode(t, store, "other-node", "10.0.0.81")
+	deployment, err := store.CreateDeployment(ctx, DeploymentRequest{AgentID: node.ID, AppKey: cpaAppKey, Config: json.RawMessage(`{"debug":false}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO applications(id,name,node_id,site_id,app_key,status,created_at,updated_at)
+		SELECT 'preserved-app','Preserved app',id,site_id,'test/preserved','running','','' FROM agents WHERE id=?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	clock = clock.Add(time.Minute)
+	if err := store.DisableAgent(ctx, node.ID); err == nil {
+		t.Fatal("test node did not retain its active dependencies")
+	}
+	if err := store.RevokeAgentCredential(ctx, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordAgentHeartbeat(ctx, node.ID, node.Credential, NodeHeartbeat{Version: "test"}); err == nil {
+		t.Fatal("stopped Agent heartbeat was accepted")
+	}
+	if _, err := store.WaitAndClaimNextTask(ctx, node.ID, node.Credential, 0); err == nil {
+		t.Fatal("stopped Agent could claim a pending task")
+	}
+	if err := store.authenticateAgent(ctx, other.ID, other.Credential); err != nil {
+		t.Fatalf("other node access changed: %v", err)
+	}
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, agent := range agents {
+		if agent.ID == node.ID {
+			found = true
+			if agent.Status != "active" || agent.Connected || !agent.CredentialRevoked {
+				t.Fatalf("access-stop status: status=%s connected=%t revoked=%t", agent.Status, agent.Connected, agent.CredentialRevoked)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("access stop deleted the node record")
+	}
+	var applicationStatus, deploymentState string
+	var gateways, uninstalls int
+	if err := store.db.QueryRow(`SELECT status FROM applications WHERE id='preserved-app'`).Scan(&applicationStatus); err != nil || applicationStatus != "running" {
+		t.Fatalf("application changed: %s, %v", applicationStatus, err)
+	}
+	if err := store.db.QueryRow(`SELECT state FROM deployments WHERE id=?`, deployment.ID).Scan(&deploymentState); err != nil || deploymentState != "pending" {
+		t.Fatalf("pending deployment changed: %s, %v", deploymentState, err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM site_gateways WHERE agent_id=?`, node.ID).Scan(&gateways); err != nil || gateways != 1 {
+		t.Fatalf("gateway association changed: %d, %v", gateways, err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM deployments WHERE agent_id=? AND operation='uninstall'`, node.ID).Scan(&uninstalls); err != nil || uninstalls != 0 {
+		t.Fatalf("access stop queued an uninstall: %d, %v", uninstalls, err)
+	}
+}
+
+func TestStopAgentAccessInvalidatesReconnectGrantsAndAllowsExplicitNewGrant(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	clock := store.now()
+	store.now = func() time.Time { return clock }
+	if _, err := store.db.Exec(`INSERT INTO settings(key,value) VALUES(?,?), (?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value`, agentConnectionModeSetting, "lan", agentConnectURLSetting, "https://center.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	node := enrollAccessTestNode(t, store, "offline-node", "10.0.0.80")
+	other := enrollAccessTestNode(t, store, "other-node", "10.0.0.81")
+	clock = clock.Add(time.Minute)
+	stale, err := store.CreateAgentReconnectEnrollment(ctx, node.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrelated, err := store.CreateAgentReconnectEnrollment(ctx, other.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Generating a reconnect command already revokes the old credential. An
+	// explicit access stop must still succeed and invalidate that pending grant.
+	for i := 0; i < 2; i++ {
+		if err := store.RevokeAgentCredential(ctx, node.ID); err != nil {
+			t.Fatalf("repeated access stop failed: %v", err)
+		}
+	}
+	if _, err := store.AgentEnrollmentInstallProfile(ctx, stale.Token); err == nil {
+		t.Fatal("stale reconnect install profile remained available")
+	}
+	if _, err := store.EnrollAgent(ctx, stale.Token, "test", "linux", "amd64", testAgentPublicKey(t)); err == nil {
+		t.Fatal("old reconnect command restored access")
+	}
+	if _, err := store.AgentEnrollmentInstallProfile(ctx, unrelated.Token); err != nil {
+		t.Fatalf("unrelated reconnect grant changed: %v", err)
+	}
+	current, err := store.CreateAgentReconnectEnrollment(ctx, node.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := store.EnrollAgent(ctx, current.Token, "test", "linux", "amd64", testAgentPublicKey(t))
+	if err != nil || replacement.ID != node.ID {
+		t.Fatalf("new explicit reconnect did not reuse the node: %v", err)
+	}
+	if err := store.authenticateAgent(ctx, replacement.ID, replacement.Credential); err != nil {
+		t.Fatalf("new credential rejected: %v", err)
+	}
+	if err := store.authenticateAgent(ctx, node.ID, node.Credential); err == nil {
+		t.Fatal("old credential was revived")
+	}
+}
+
+func TestStopAgentAccessRollsBackIfGrantRevocationFails(t *testing.T) {
+	store := openOrchestrationStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	node := enrollAccessTestNode(t, store, "rollback-node", "10.0.0.80")
+	if _, err := store.db.Exec(`CREATE TRIGGER reject_access_revoke BEFORE DELETE ON agent_enrollment_operations
+		BEGIN SELECT RAISE(ABORT, 'test refusal'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RevokeAgentCredential(ctx, node.ID); err == nil {
+		t.Fatal("partial revocation was accepted")
+	}
+	if err := store.authenticateAgent(ctx, node.ID, node.Credential); err != nil {
+		t.Fatalf("failed revocation was not rolled back: %v", err)
+	}
+}

--- a/internal/center/store_agent.go
+++ b/internal/center/store_agent.go
@@ -554,8 +554,16 @@ func validAgentEnrollmentOperationID(value string) bool {
 // RevokeAgentCredential immediately closes the Agent control channel without
 // changing workload or topology state. It is intentionally independent from
 // DisableAgent, whose business preconditions may require applications to stop.
+// Existing reconnect grants are invalidated in the same transaction. A new
+// administrator-issued reconnect command is required to restore management.
 func (s *Store) RevokeAgentCredential(ctx context.Context, agentID string) error {
-	result, err := s.db.ExecContext(ctx, `UPDATE agents SET credential_revoked_at = ? WHERE id = ? AND status = 'active' AND credential_revoked_at = ''`, s.now().UTC().Format(time.RFC3339Nano), strings.TrimSpace(agentID))
+	agentID = strings.TrimSpace(agentID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	result, err := tx.ExecContext(ctx, `UPDATE agents SET credential_revoked_at = CASE WHEN credential_revoked_at = '' THEN ? ELSE credential_revoked_at END WHERE id = ? AND status = 'active'`, s.now().UTC().Format(time.RFC3339Nano), agentID)
 	if err != nil {
 		return fmt.Errorf("center: revoke Agent credential: %w", err)
 	}
@@ -563,7 +571,21 @@ func (s *Store) RevokeAgentCredential(ctx context.Context, agentID string) error
 	if changed != 1 {
 		return errors.New("center: active Agent credential was not found")
 	}
-	s.taskChanges.notify("agent:" + strings.TrimSpace(agentID))
+	if _, err := tx.ExecContext(ctx, `DELETE FROM secrets WHERE id IN (
+		SELECT bootstrap_secret_id FROM agent_enrollment_tokens WHERE target_agent_id = ? AND bootstrap_secret_id IS NOT NULL
+	)`, agentID); err != nil {
+		return fmt.Errorf("center: revoke Agent reconnect bootstrap: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_enrollment_tokens WHERE target_agent_id = ?`, agentID); err != nil {
+		return fmt.Errorf("center: revoke Agent reconnect command: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_enrollment_operations WHERE agent_id = ?`, agentID); err != nil {
+		return fmt.Errorf("center: revoke Agent enrollment recovery: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.taskChanges.notify("agent:" + agentID)
 	return nil
 }
 

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -9,6 +9,22 @@ afterEach(() => {
 });
 
 describe("Center API client", () => {
+  it("stops access by node identity without requesting uninstall or deletion", async () => {
+    document.cookie = "vastora_csrf=csrf-value; Path=/";
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ revoked: true }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.revokeAgentCredential("agent/a b");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [path, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe("/api/v1/agents/agent%2Fa%20b/revoke");
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("same-origin");
+    expect(new Headers(init.headers).get("X-CSRF-Token")).toBe("csrf-value");
+    expect(JSON.parse(String(init.body))).toEqual({});
+  });
+
   it("keeps application installation separate from publication", async () => {
     document.cookie = "vastora_csrf=csrf-value; Path=/";
     const fetchMock = vi.fn().mockResolvedValue(

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -116,6 +116,7 @@ export const api = {
 	updateAgent: (agentId: string, name: string, siteId: string) => request<{ updated: boolean }>(`/api/v1/agents/${encodeURIComponent(agentId)}`, { method: "PATCH", body: JSON.stringify({ name, siteId }) }),
 	startAgentUpdate: (agentId: string) => request<AgentUpdate>(`/api/v1/agents/${encodeURIComponent(agentId)}/updates`, { method: "POST", body: "{}" }),
 	disableAgent: (agentId: string) => request<{ disabled: boolean }>(`/api/v1/agents/${encodeURIComponent(agentId)}/disable`, { method: "POST", body: "{}" }),
+	revokeAgentCredential: (agentId: string) => request<{ revoked: boolean }>(`/api/v1/agents/${encodeURIComponent(agentId)}/revoke`, { method: "POST", body: "{}" }),
 	deleteAgent: (agentId: string) => request<{ deleted: boolean }>(`/api/v1/agents/${encodeURIComponent(agentId)}`, { method: "DELETE", body: "{}" }),
 	applications: (signal?: AbortSignal) => request<{ applications: Application[] }>("/api/v1/applications", { signal }),
 	revealApplicationCredentials: (applicationId: string, currentPassword: string) => request<ApplicationCredentials>(`/api/v1/applications/${encodeURIComponent(applicationId)}/credentials/reveal`, { method: "POST", body: JSON.stringify({ currentPassword }) }),

--- a/web/src/app-data.catalog.test.tsx
+++ b/web/src/app-data.catalog.test.tsx
@@ -13,7 +13,7 @@ import { AppsView } from "./views/AppsView";
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const status: CenterStatus = { version: "test", agentInstallerAvailable: true, agentConnectionMode: "lan", agentConnectUrl: "https://center.example.com" };
-const node = { id: "node", name: "Test node", connected: true, status: "active", siteId: "site", capabilities: { docker: true }, networkProfile: { serviceAddress: "10.0.0.2" } } as AgentView;
+const node = { id: "node", name: "Test node", connected: true, credentialRevoked: false, status: "active", siteId: "site", capabilities: { docker: true }, networkProfile: { serviceAddress: "10.0.0.2" } } as AgentView;
 const official: CatalogSource = {
   id: "vastora-official", displayName: "Vastora Official", url: "https://downloads.example.com/vastora/catalog",
   publicKey: "", customCASet: false, bearerTokenSet: false, enabled: true, status: "pending", refreshIntervalSeconds: 3600,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -288,6 +288,7 @@ export type AgentView = {
   enrolledAt: string;
   lastSeenAt: string;
   connected: boolean;
+  credentialRevoked: boolean;
   siteId: string;
   roles: string[];
   capabilities: { docker: boolean; gateway: boolean; tunnel: boolean; metrics: boolean; logs: boolean };

--- a/web/src/views/AppStore.test.tsx
+++ b/web/src/views/AppStore.test.tsx
@@ -119,7 +119,7 @@ describe("app store cards", () => {
     const data = {
       apps: [app()],
       sources: [],
-      agents: [{ id: "collector", connected: true, capabilities: { docker: false }, networkProfile: { serviceAddress: "10.0.0.2" } } as AgentView],
+      agents: [{ id: "collector", connected: true, credentialRevoked: false, capabilities: { docker: false }, networkProfile: { serviceAddress: "10.0.0.2" } } as AgentView],
       applications: [{ id: "monitor", appKey: "vastora-official/pulse", status: "running", installedVersion: "0.1.0-alpha.2" } as Application],
       services: [], publications: [],
     } as unknown as AppData;

--- a/web/src/views/AppsView.retry.test.tsx
+++ b/web/src/views/AppsView.retry.test.tsx
@@ -25,8 +25,8 @@ function fixture(id = "pulse-agent"): AppData {
     registryCredentials: [], sources: [], organizations: [], sites: [], routes: [],
     actions: [], integrations: [], threeXUIControllerMigrations: [],
     agents: [
-      { id: "first", name: "AKKO CN2", connected: true, siteId: "site", capabilities: { docker: true }, networkProfile: { serviceAddress: "10.0.0.1" } },
-      { id: "failed-node", name: "DataWave CN2", connected: true, siteId: "site", capabilities: { docker: true }, networkProfile: { serviceAddress: "10.0.0.2" } },
+      { id: "first", name: "AKKO CN2", connected: true, credentialRevoked: false, siteId: "site", capabilities: { docker: true }, networkProfile: { serviceAddress: "10.0.0.1" } },
+      { id: "failed-node", name: "DataWave CN2", connected: true, credentialRevoked: false, siteId: "site", capabilities: { docker: true }, networkProfile: { serviceAddress: "10.0.0.2" } },
     ],
     apps: [{ key: appKey, sourceId: "vastora-official", fetchedAt: "2026-09-11T00:00:00Z", app: {
       id, version: "0.1.0-alpha.2", name: { en: "Collector", "zh-CN": "探针" },

--- a/web/src/views/NodesView.tsx
+++ b/web/src/views/NodesView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { CheckCircle2Icon, CircleArrowUpIcon, MapPinIcon, NetworkIcon, PlusIcon, RotateCcwIcon, ServerIcon, Settings2Icon, ShieldCheckIcon, TerminalIcon, Trash2Icon } from "lucide-react";
+import { CheckCircle2Icon, CircleArrowUpIcon, MapPinIcon, NetworkIcon, PlusIcon, RotateCcwIcon, ServerIcon, Settings2Icon, ShieldCheckIcon, TerminalIcon, Trash2Icon, UnplugIcon } from "lucide-react";
 import { api } from "../api";
 import { validCenterURL } from "../lib/network";
 import type { AppData, Mutate, Screen } from "../App";
@@ -19,6 +19,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { RuntimeRecoveryAlert } from "./RuntimeRecoveryAlert";
+import { StopNodeAccessSheet } from "./StopNodeAccessSheet";
 
 export { validCenterURL } from "../lib/network";
 
@@ -40,6 +41,8 @@ export function agentInstallCommand({ centerURL, enrollment, installerAvailable 
 export function NodesView({ data, language, mutate, onAddFirstNodeHandled, onNavigate, startAdding = false }: { data: AppData; language: Language; mutate: Mutate; onAddFirstNodeHandled?: () => void; onNavigate: (screen: Screen) => void; startAdding?: boolean }) {
   const [adding, setAdding] = useState(false);
   const [editing, setEditing] = useState<AgentView | null>(null);
+  const [stoppingAccessID, setStoppingAccessID] = useState<string | null>(null);
+  const stoppingAccessAgent = data.agents.find((agent) => agent.id === stoppingAccessID);
   const [reconnecting, setReconnecting] = useState<{ agent: AgentView; enrollment: AgentEnrollment | null; busy: boolean; error: string } | null>(null);
   const reconnectRequest = useRef(0);
   const currentEditing = editing ? data.agents.find((agent) => agent.id === editing.id) ?? editing : null;
@@ -68,7 +71,8 @@ export function NodesView({ data, language, mutate, onAddFirstNodeHandled, onNav
     <PageHeading title={copy(language, "节点", "Nodes")} description={copy(language, "节点是运行应用的设备。添加后，Center 会自动发现它的网络。", "Nodes are devices that run apps. Center discovers their networks after they join.")} action={<Button onClick={() => setAdding(true)}><PlusIcon data-icon="inline-start" />{copy(language, "添加节点", "Add node")}</Button>} />
     {data.agents.length === 0 ? <Empty className="border"><EmptyHeader><EmptyMedia variant="icon"><ServerIcon /></EmptyMedia><EmptyTitle>{copy(language, "添加第一台节点", "Add your first node")}</EmptyTitle><EmptyDescription>{copy(language, "当前 Center 主机或另一台受支持的 Linux 设备都可以作为节点；复制一条命令即可按需安装 Docker 和 Agent。", "The current Center host or another supported Linux device can be a node. Copy one command to install Docker when needed and then install Agent.")}</EmptyDescription><Button className="mt-3" onClick={() => setAdding(true)}><PlusIcon data-icon="inline-start" />{copy(language, "开始添加", "Get started")}</Button></EmptyHeader></Empty> : <div className="flex flex-col gap-7">{siteGroups.map(({ site, agents }) => <section className="flex flex-col gap-3" key={site.id}><div className="flex items-center gap-2"><MapPinIcon className="size-4 text-muted-foreground" /><h2 className="text-sm font-semibold">{site.name}</h2><Badge variant="secondary">{site.code}</Badge><span className="text-xs text-muted-foreground">{copy(language, `${agents.length} 台节点`, `${agents.length} node${agents.length === 1 ? "" : "s"}`)}</span></div><div className="grid gap-4 lg:grid-cols-2">{agents.map((agent) => <NodeCard agent={agent} data={data} key={agent.id} language={language} onApplications={() => onNavigate("apps")} onConfigure={() => setEditing(agent)} onNetwork={() => onNavigate("network")} onReconnect={() => void beginReconnect(agent)} />)}</div></section>)}</div>}
     <AddNodeSheet data={data} language={language} onClose={() => { setAdding(false); onAddFirstNodeHandled?.(); }} onJoined={() => { setAdding(false); onAddFirstNodeHandled?.(); onNavigate("network"); }} open={adding} />
-    <NodeSettingsSheet agent={currentEditing} data={data} language={language} mutate={mutate} onClose={() => setEditing(null)} />
+    <NodeSettingsSheet agent={currentEditing} data={data} language={language} mutate={mutate} onClose={() => setEditing(null)} onStopAccess={() => { if (currentEditing) { setStoppingAccessID(currentEditing.id); setEditing(null); } }} />
+    {stoppingAccessAgent ? <StopNodeAccessSheet agent={stoppingAccessAgent} key={stoppingAccessAgent.id} language={language} mutate={mutate} onClose={() => setStoppingAccessID(null)} /> : null}
     <ReconnectNodeSheet agent={currentReconnecting} busy={reconnecting?.busy ?? false} enrollment={reconnecting?.enrollment ?? null} error={reconnecting?.error ?? ""} installerAvailable={data.status.agentInstallerAvailable} language={language} onClose={closeReconnect} onRetry={() => { if (currentReconnecting) void beginReconnect(currentReconnecting); }} />
   </section>;
 }
@@ -77,7 +81,7 @@ function NodeCard({ agent, data, language, onApplications, onConfigure, onNetwor
   const site = data.sites.find((value) => value.id === agent.siteId);
   const selectedGateway = Boolean(site?.gatewayNodes.includes(agent.id));
   const architecture = agent.architecture === "arm64" ? "ARM64" : "x64";
-  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><ServerIcon />{agent.name}</CardTitle><CardDescription>{copy(language, "位置", "Location")}：{site?.name ?? agent.siteId} · {agent.version}</CardDescription><CardAction><StateBadge value={agent.status === "disabled" ? "disabled" : agent.connected ? "connected" : "offline"} /></CardAction></CardHeader><CardContent className="flex flex-col gap-4"><div className="flex flex-wrap gap-2"><Badge variant="outline">{architecture}</Badge>{agent.capabilities.docker ? <Badge variant="secondary">{copy(language, "运行应用", "Runs apps")}</Badge> : null}{selectedGateway ? <Badge variant="default">{copy(language, "当前位置网关", "Location gateway")}</Badge> : agent.capabilities.gateway ? <Badge variant="outline">{copy(language, "可作为网关", "Gateway capable")}</Badge> : null}{agent.capabilities.tunnel ? <Badge variant="outline">Cloudflare</Badge> : null}</div><dl className="grid grid-cols-2 gap-4 text-sm"><div><dt className="text-muted-foreground">{copy(language, "网络", "Network")}</dt><dd className="mt-1 font-medium">{agent.networkProfile ? copy(language, "已确认", "Confirmed") : copy(language, "需要确认", "Needs confirmation")}</dd></div><div><dt className="text-muted-foreground">{copy(language, "最后在线", "Last seen")}</dt><dd className="mt-1 font-medium">{formatDate(language, agent.lastSeenAt)}</dd></div><div className="col-span-2"><dt className="text-muted-foreground">{copy(language, "私有服务地址", "Private service address")}</dt><dd className="mt-1 font-mono text-xs">{agent.networkProfile?.serviceAddress || "—"}</dd></div></dl><RuntimeRecoveryAlert agent={agent} language={language} onApplications={onApplications} /></CardContent><CardFooter className="justify-end gap-2">{agent.status === "active" && !agent.networkProfile ? <Button onClick={onNetwork} size="sm"><NetworkIcon data-icon="inline-start" />{copy(language, "确认网络", "Confirm network")}</Button> : null}{agent.status === "active" && !agent.connected ? <Button onClick={onReconnect} size="sm" variant="outline"><RotateCcwIcon data-icon="inline-start" />{copy(language, "重新接入", "Reconnect")}</Button> : null}{agent.status === "disabled" ? <Button onClick={onConfigure} size="sm" variant="outline"><Trash2Icon data-icon="inline-start" />{copy(language, "删除节点", "Delete node")}</Button> : null}{agent.status === "active" ? <Button onClick={onConfigure} size="sm" variant="outline"><Settings2Icon data-icon="inline-start" />{copy(language, "管理", "Manage")}</Button> : null}</CardFooter></Card>;
+  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><ServerIcon />{agent.name}</CardTitle><CardDescription>{copy(language, "位置", "Location")}：{site?.name ?? agent.siteId} · {agent.version}</CardDescription><CardAction><StateBadge language={language} value={agent.status === "disabled" ? "disabled" : agent.credentialRevoked ? "access_stopped" : agent.connected ? "connected" : "offline"} /></CardAction></CardHeader><CardContent className="flex flex-col gap-4"><div className="flex flex-wrap gap-2"><Badge variant="outline">{architecture}</Badge>{agent.capabilities.docker ? <Badge variant="secondary">{copy(language, "运行应用", "Runs apps")}</Badge> : null}{selectedGateway ? <Badge variant="default">{copy(language, "当前位置网关", "Location gateway")}</Badge> : agent.capabilities.gateway ? <Badge variant="outline">{copy(language, "可作为网关", "Gateway capable")}</Badge> : null}{agent.capabilities.tunnel ? <Badge variant="outline">Cloudflare</Badge> : null}</div><dl className="grid grid-cols-2 gap-4 text-sm"><div><dt className="text-muted-foreground">{copy(language, "网络", "Network")}</dt><dd className="mt-1 font-medium">{agent.networkProfile ? copy(language, "已确认", "Confirmed") : copy(language, "需要确认", "Needs confirmation")}</dd></div><div><dt className="text-muted-foreground">{copy(language, "最后在线", "Last seen")}</dt><dd className="mt-1 font-medium">{formatDate(language, agent.lastSeenAt)}</dd></div><div className="col-span-2"><dt className="text-muted-foreground">{copy(language, "私有服务地址", "Private service address")}</dt><dd className="mt-1 font-mono text-xs">{agent.networkProfile?.serviceAddress || "—"}</dd></div></dl><RuntimeRecoveryAlert agent={agent} language={language} onApplications={onApplications} /></CardContent><CardFooter className="justify-end gap-2">{agent.status === "active" && !agent.networkProfile ? <Button onClick={onNetwork} size="sm"><NetworkIcon data-icon="inline-start" />{copy(language, "确认网络", "Confirm network")}</Button> : null}{agent.status === "active" && !agent.connected ? <Button onClick={onReconnect} size="sm" variant="outline"><RotateCcwIcon data-icon="inline-start" />{copy(language, "重新接入", "Reconnect")}</Button> : null}{agent.status === "disabled" ? <Button onClick={onConfigure} size="sm" variant="outline"><Trash2Icon data-icon="inline-start" />{copy(language, "删除节点", "Delete node")}</Button> : null}{agent.status === "active" ? <Button onClick={onConfigure} size="sm" variant="outline"><Settings2Icon data-icon="inline-start" />{copy(language, "管理", "Manage")}</Button> : null}</CardFooter></Card>;
 }
 
 function AddNodeSheet({ data, language, onClose, onJoined, open }: { data: AppData; language: Language; onClose: () => void; onJoined: () => void; open: boolean }) {
@@ -187,7 +191,7 @@ function ReconnectNodeSheet({ agent, busy, enrollment, error, installerAvailable
   );
 }
 
-function NodeSettingsSheet({ agent, data, language, mutate, onClose }: { agent: AgentView | null; data: AppData; language: Language; mutate: Mutate; onClose: () => void }) {
+function NodeSettingsSheet({ agent, data, language, mutate, onClose, onStopAccess }: { agent: AgentView | null; data: AppData; language: Language; mutate: Mutate; onClose: () => void; onStopAccess: () => void }) {
   const [name, setName] = useState("");
   const [siteID, setSiteID] = useState("");
   const [gateway, setGateway] = useState(false);
@@ -199,6 +203,7 @@ function NodeSettingsSheet({ agent, data, language, mutate, onClose }: { agent: 
   const [danger, setDanger] = useState(false);
   const [confirmation, setConfirmation] = useState("");
   const deleting = agent?.status === "disabled";
+  const canStopAccess = agent?.status === "active" && !agent.connected;
   useEffect(() => {
     if (!agent) return;
     setName(agent.name);
@@ -233,7 +238,7 @@ function NodeSettingsSheet({ agent, data, language, mutate, onClose }: { agent: 
     }
   };
   const disable = async () => {
-    if (!agent || busy || confirmation !== agent.name) return;
+    if (!agent || busy || confirmation.trim() !== agent.name.trim()) return;
     setBusy(true); setError("");
     try {
       await mutate(() => deleting ? api.deleteAgent(agent.id) : api.disableAgent(agent.id), deleting ? copy(language, "节点已删除，服务器上的数据未改动。", "Node deleted. Server data was not changed.") : copy(language, "节点已停用，原凭据已失效。", "Node disabled and its credential is no longer accepted."));
@@ -268,6 +273,7 @@ function NodeSettingsSheet({ agent, data, language, mutate, onClose }: { agent: 
           {error ? <FieldError>{error}</FieldError> : null}
         </div> : <form className="flex min-h-0 flex-1 flex-col" onSubmit={(event) => void submit(event)}>
           <div className="flex-1 overflow-y-auto px-4"><FieldGroup>
+            {agent?.credentialRevoked ? <Alert><UnplugIcon aria-hidden="true" /><AlertTitle>{copy(language, "已停止接入", "Access stopped")}</AlertTitle><AlertDescription>{copy(language, "旧 Agent 无法再连接 Center，应用和数据仍保留。需要恢复管理时，请使用“重新接入”。", "The old Agent cannot connect to Center. Apps and data are kept. Use Reconnect to restore management.")}</AlertDescription></Alert> : null}
             <Field><FieldLabel htmlFor="node-name">{copy(language, "名称", "Name")}</FieldLabel><Input id="node-name" maxLength={128} onChange={(event) => setName(event.target.value)} required value={name} /></Field>
             <Field><FieldLabel htmlFor="node-site"><MapPinIcon data-icon="inline-start" />{copy(language, "位置", "Location")}</FieldLabel><SelectControl id="node-site" onValueChange={setSiteID} options={data.sites.map((site) => ({ value: site.id, label: site.name }))} value={siteID} /></Field>
             <div className="rounded-xl border p-4">
@@ -282,9 +288,9 @@ function NodeSettingsSheet({ agent, data, language, mutate, onClose }: { agent: 
             {commandKind ? <Alert><TerminalIcon /><AlertTitle>{copy(language, "在节点运行一次", "Run once on the node")}</AlertTitle><AlertDescription><p>{copy(language, "命令会更新 systemd 配置并重启 Agent，Center 会自动看到新用途。", "The command updates systemd, restarts Agent, and Center detects the new purpose automatically.")}</p><div className="relative mt-3"><code className="block break-all rounded-lg bg-muted p-3 pr-12 text-xs leading-5">{purposeCommand}</code><CopyButton className="absolute right-1.5 top-1.5" label={copy(language, "复制命令", "Copy command")} language={language} size="icon-sm" value={purposeCommand} /></div></AlertDescription></Alert> : null}
             {error ? <FieldError>{error}</FieldError> : null}
           </FieldGroup></div>
-          <SheetFooter className="justify-between"><Button onClick={() => setDanger(true)} type="button" variant="ghost"><Trash2Icon data-icon="inline-start" />{copy(language, "停用节点", "Disable node")}</Button><div className="flex gap-2"><Button onClick={onClose} type="button" variant="outline">{copy(language, "关闭", "Close")}</Button><Button disabled={busy || !name || name === agent?.name && siteID === agent?.siteId} type="submit">{busy ? <Spinner data-icon="inline-start" /> : null}{copy(language, "保存信息", "Save details")}</Button></div></SheetFooter>
+          <SheetFooter className="flex-wrap justify-between"><div className="flex gap-2">{canStopAccess ? <Button disabled={busy} onClick={onStopAccess} type="button" variant="outline"><UnplugIcon aria-hidden="true" data-icon="inline-start" />{copy(language, "停止接入", "Stop access")}</Button> : null}<Button disabled={busy} onClick={() => setDanger(true)} type="button" variant="ghost"><Trash2Icon data-icon="inline-start" />{copy(language, "停用节点", "Disable node")}</Button></div><div className="flex gap-2"><Button onClick={onClose} type="button" variant="outline">{copy(language, "关闭", "Close")}</Button><Button disabled={busy || !name || name === agent?.name && siteID === agent?.siteId} type="submit">{busy ? <Spinner data-icon="inline-start" /> : null}{copy(language, "保存信息", "Save details")}</Button></div></SheetFooter>
         </form>}
-        {danger ? <SheetFooter><Button disabled={busy} onClick={() => { if (deleting) onClose(); else { setDanger(false); setError(""); } }} variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy || confirmation !== agent?.name} onClick={() => void disable()} variant="destructive">{busy ? <Spinner data-icon="inline-start" /> : null}{deleting ? copy(language, "删除节点", "Delete node") : copy(language, "停用节点", "Disable node")}</Button></SheetFooter> : null}
+        {danger ? <SheetFooter><Button disabled={busy} onClick={() => { if (deleting) onClose(); else { setDanger(false); setError(""); } }} variant="outline">{copy(language, "取消", "Cancel")}</Button><Button disabled={busy || !agent || confirmation.trim() !== agent.name.trim()} onClick={() => void disable()} variant="destructive">{busy ? <Spinner data-icon="inline-start" /> : null}{deleting ? copy(language, "删除节点", "Delete node") : copy(language, "停用节点", "Disable node")}</Button></SheetFooter> : null}
       </SheetContent>
     </Sheet>
   );

--- a/web/src/views/RuntimeRecoveryAlert.test.tsx
+++ b/web/src/views/RuntimeRecoveryAlert.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 const agentFixture = (): AgentView => ({
   id: "agent-a", name: "Node A", version: "test", operatingSystem: "linux", architecture: "amd64",
   status: "active", appliedInstallations: 1, enrolledAt: "2026-09-12T00:00:00Z", lastSeenAt: "2026-09-12T00:00:00Z",
-  connected: true, siteId: "site-a", roles: ["worker"],
+  connected: true, credentialRevoked: false, siteId: "site-a", roles: ["worker"],
   capabilities: { docker: true, gateway: false, tunnel: false, metrics: false, logs: false },
   networkCandidates: [], gatewayHealthy: false, remoteUpdateSupported: true, runtimeRecovery: "application",
   runtimeRecoveryApplications: [

--- a/web/src/views/StopNodeAccessSheet.tsx
+++ b/web/src/views/StopNodeAccessSheet.tsx
@@ -1,0 +1,68 @@
+import { useState, type FormEvent } from "react";
+import { UnplugIcon } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Spinner } from "@/components/ui/spinner";
+import { api } from "../api";
+import type { Mutate } from "../App";
+import type { AgentView } from "../types";
+import type { Language } from "../translations";
+import { copy, userError } from "./shared";
+
+export function StopNodeAccessSheet({ agent, language, mutate, onClose }: { agent: AgentView; language: Language; mutate: Mutate; onClose: () => void }) {
+  const [confirmation, setConfirmation] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const nameMatches = confirmation.trim() === agent.name.trim();
+  const invalidName = confirmation.length > 0 && !nameMatches;
+  const stateChanged = agent.status !== "active" || agent.connected;
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (busy || !nameMatches || stateChanged) return;
+    setBusy(true);
+    setError("");
+    try {
+      await mutate(() => api.revokeAgentCredential(agent.id), copy(language, "已停止此节点接入，应用和数据已保留。", "Node access stopped. Apps and data were kept."));
+      onClose();
+    } catch (submitError) {
+      setError(userError(language, submitError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return <Sheet open onOpenChange={(open) => { if (!open && !busy) onClose(); }}>
+    <SheetContent showCloseButton={!busy}>
+      <SheetHeader>
+        <SheetTitle>{copy(language, "停止节点接入", "Stop node access")}</SheetTitle>
+        <SheetDescription>{copy(language, "无需节点在线，也无需先卸载应用。", "The node does not need to be online, and apps do not need to be uninstalled first.")}</SheetDescription>
+      </SheetHeader>
+      <form className="flex min-h-0 flex-1 flex-col" onSubmit={(event) => void submit(event)}>
+        <div className="flex-1 overflow-y-auto px-4">
+          <FieldGroup>
+            <Alert>
+              <UnplugIcon aria-hidden="true" />
+              <AlertTitle className="break-words">{agent.name}</AlertTitle>
+              <AlertDescription>{copy(language, "旧 Agent 和此前生成的重新接入命令将无法再接入 Center。不会卸载应用、删除记录或清理服务器数据，也不会关闭已有代理服务或私网连接。恢复管理时需重新生成接入命令。", "The old Agent and previously generated reconnect commands will no longer be accepted by Center. This does not uninstall apps, delete records, clean server data, or stop existing proxy services or private-network connections. Generate a new reconnect command to restore management.")}</AlertDescription>
+            </Alert>
+            <Field data-invalid={invalidName}>
+              <FieldLabel htmlFor="stop-node-access-name">{copy(language, `输入“${agent.name}”确认`, `Type “${agent.name}” to confirm`)}</FieldLabel>
+              <Input aria-invalid={invalidName} aria-describedby="stop-node-access-name-hint" autoCapitalize="none" autoComplete="off" autoCorrect="off" autoFocus disabled={busy} id="stop-node-access-name" onChange={(event) => setConfirmation(event.target.value)} spellCheck={false} value={confirmation} />
+              <FieldDescription id="stop-node-access-name-hint">{copy(language, "使用上方的节点名称，不是订阅名称；空格和连字符不同。", "Use the node name above, not its subscription name. Spaces and hyphens are different.")}</FieldDescription>
+              {invalidName ? <FieldError>{copy(language, "名称不一致，请核对后重试。", "The name does not match. Check it and try again.")}</FieldError> : null}
+            </Field>
+            {stateChanged ? <FieldError role="alert">{copy(language, "节点状态已变化，请关闭后重新操作。", "The node status changed. Close this panel and try again.")}</FieldError> : null}
+            {error ? <FieldError role="alert">{error}</FieldError> : null}
+          </FieldGroup>
+        </div>
+        <SheetFooter>
+          <Button disabled={busy} onClick={onClose} type="button" variant="outline">{copy(language, "取消", "Cancel")}</Button>
+          <Button disabled={busy || !nameMatches || stateChanged} type="submit" variant="destructive">{busy ? <Spinner data-icon="inline-start" /> : null}{copy(language, "停止接入", "Stop access")}</Button>
+        </SheetFooter>
+      </form>
+    </SheetContent>
+  </Sheet>;
+}

--- a/web/src/views/pulse-access.test.ts
+++ b/web/src/views/pulse-access.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentView, AppData, Application, Service } from "../types";
 import { canInstall, eligibleAppNodes, gatewaysForKind, installBlocker, pulsePrivateAccess } from "./appAccess";
 
-const agent = { id: "collector", name: "Collector", connected: true, capabilities: { docker: false }, networkProfile: { serviceAddress: "10.0.0.2", enabledKinds: ["lan"] } } as AgentView;
+const agent = { id: "collector", name: "Collector", connected: true, credentialRevoked: false, capabilities: { docker: false }, networkProfile: { serviceAddress: "10.0.0.2", enabledKinds: ["lan"] } } as AgentView;
 const controller = { id: "monitor", appKey: "vastora-official/pulse", status: "running", installedVersion: "0.1.0-alpha.2" } as Application;
 const dashboard = { id: "dashboard", applicationId: "monitor", name: "dashboard", status: "ready", protocol: "http" } as Service;
 const data = { agents: [agent], applications: [controller], services: [dashboard], publications: [] } as unknown as AppData;

--- a/web/src/views/shared.tsx
+++ b/web/src/views/shared.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
-import { CheckIcon, CircleAlertIcon, CircleCheckIcon, Clock3Icon, CopyIcon, ShieldAlertIcon } from "lucide-react";
+import { CheckIcon, CircleAlertIcon, CircleCheckIcon, Clock3Icon, CopyIcon, ShieldAlertIcon, UnplugIcon } from "lucide-react";
 import type { Language } from "../translations";
 import type { AppView } from "../types";
 import { Badge } from "@/components/ui/badge";
@@ -95,8 +95,9 @@ export function PageHeading({ title, description, action }: { title: string; des
 export function StateBadge({ value, language = document.documentElement.lang === "zh-CN" ? "zh-CN" : "en" }: { value: string; language?: Language }) {
   const good = ["ready", "running", "succeeded", "configured", "connected", "active", "healthy"].includes(value);
   const bad = ["failed", "degraded", "offline", "lease_expired", "recovery", "expired"].includes(value);
-  const Icon = good ? CircleCheckIcon : bad ? CircleAlertIcon : Clock3Icon;
+  const Icon = value === "access_stopped" ? UnplugIcon : good ? CircleCheckIcon : bad ? CircleAlertIcon : Clock3Icon;
   const labels: Record<string, [string, string]> = {
+    access_stopped: ["已停止接入", "Access stopped"],
     expired: ["需刷新", "Refresh required"],
     ready: ["就绪", "Ready"], running: ["运行中", "Running"], succeeded: ["成功", "Succeeded"], configured: ["已配置", "Configured"], connected: ["已连接", "Connected"], active: ["正常", "Active"], healthy: ["健康", "Healthy"], stale: ["使用缓存", "Using cache"],
     failed: ["失败", "Failed"], degraded: ["异常", "Degraded"], recovery: ["需恢复", "Recovery needed"], offline: ["离线", "Offline"], lease_expired: ["已重试", "Retried"], pending: ["等待中", "Pending"], applying: ["配置中", "Applying"], stopped: ["已停止", "Stopped"], disabled: ["未启用", "Disabled"], unconfigured: ["未配置", "Not configured"], queued: ["已排队", "Queued"], claimed: ["执行中", "In progress"]

--- a/web/src/views/views.test.tsx
+++ b/web/src/views/views.test.tsx
@@ -46,7 +46,7 @@ const dashboard = (): AppData => ({
   sources: [], organizations: [], routes: [], actions: [], integrations: [], threeXUIControllerMigrations: [],
   systemDomain: { namespace: "vastora.example.com", centerUrl: "https://center.vastora.example.com", headscaleUrl: "https://headscale.vastora.example.com", cloudflareZone: "example.com", aliases: [], activePublications: 0, pendingCleanup: 0, builtinHeadscale: true, cloudflareOAuthAvailable: true },
   sites: [{ id: "site", organizationId: "org", name: "Home", code: "home", description: "", timezone: "Asia/Singapore", domainSuffix: "home.example", status: "active", gatewayNodes: ["agent"], gatewayStatus: "ready", createdAt: "2026-08-18T00:00:00Z", updatedAt: "2026-08-18T00:00:00Z" }],
-  agents: [{ id: "agent", name: "home-server", version: "test", operatingSystem: "linux", architecture: "amd64", status: "active", appliedInstallations: 1, enrolledAt: "2026-08-18T00:00:00Z", lastSeenAt: "2026-08-18T00:00:00Z", connected: true, siteId: "site", roles: ["worker", "gateway"], capabilities: { docker: true, gateway: true, tunnel: true, metrics: false, logs: false }, networkCandidates: [{ address: "192.168.1.2", interface: "eth0", kind: "lan", observedAt: "2026-08-18T00:00:00Z" }], networkProfile: { serviceAddress: "192.168.1.2", lanAddress: "192.168.1.2", enabledKinds: ["lan"], directPublic: false }, gatewayHealthy: true, remoteUpdateSupported: true }],
+  agents: [{ id: "agent", name: "home-server", version: "test", operatingSystem: "linux", architecture: "amd64", status: "active", appliedInstallations: 1, enrolledAt: "2026-08-18T00:00:00Z", lastSeenAt: "2026-08-18T00:00:00Z", connected: true, credentialRevoked: false, siteId: "site", roles: ["worker", "gateway"], capabilities: { docker: true, gateway: true, tunnel: true, metrics: false, logs: false }, networkCandidates: [{ address: "192.168.1.2", interface: "eth0", kind: "lan", observedAt: "2026-08-18T00:00:00Z" }], networkProfile: { serviceAddress: "192.168.1.2", lanAddress: "192.168.1.2", enabledKinds: ["lan"], directPublic: false }, gatewayHealthy: true, remoteUpdateSupported: true }],
   apps: [{ key: "vastora-official/komari-agent", sourceId: "vastora-official", fetchedAt: "2026-08-18T00:00:00Z", app: { id: "komari-agent", version: "1.2.60", name: { en: "Komari Agent", "zh-CN": "Komari 探针" }, description: { en: "Monitoring", "zh-CN": "监控探针" }, hostAccess: true, config: [] } }],
   registryCredentials: [],
   centerRemoteAccess: { available: true, enabled: false, status: "disabled" },
@@ -2035,6 +2035,98 @@ describe("network and app views", () => {
     });
     await act(async () => confirm?.click());
     expect(remove).toHaveBeenCalledWith(data.agents[0].id);
+  });
+
+  it("stops an offline node's access without requiring its apps or gateway to be removed", async () => {
+    const data = dashboard();
+    data.agents[0].name = "DMIT CN2";
+    data.agents[0].connected = false;
+    const revoke = vi.spyOn(api, "revokeAgentCredential").mockResolvedValue({ revoked: true });
+    const disable = vi.spyOn(api, "disableAgent");
+    const remove = vi.spyOn(api, "deleteAgent");
+    const deploy = vi.spyOn(api, "createDeployment");
+    const container = render(<NodesView data={data} language="zh-CN" mutate={async (operation) => { await operation(); }} onNavigate={() => undefined} />);
+    act(() => [...container.querySelectorAll("button")].find((button) => button.textContent === "管理")?.click());
+    act(() => [...document.querySelectorAll("button")].find((button) => button.textContent === "停止接入")?.click());
+    const input = document.querySelector<HTMLInputElement>("#stop-node-access-name")!;
+    const confirm = () => [...document.querySelectorAll("button")].find((button) => button.textContent === "停止接入" && button.type === "submit")!;
+    expect(confirm().disabled).toBe(true);
+    expect(document.body.textContent).toContain("无需节点在线");
+    expect(document.body.textContent).toContain("不会卸载应用、删除记录或清理服务器数据");
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, "DMIT-CN2");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(confirm().disabled).toBe(true);
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, " DMIT CN2 ");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(confirm().disabled).toBe(false);
+    await act(async () => confirm().click());
+    expect(revoke).toHaveBeenCalledExactlyOnceWith(data.agents[0].id);
+    expect(disable).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+    expect(deploy).not.toHaveBeenCalled();
+    expect(document.querySelector("#stop-node-access-name")).toBeNull();
+  });
+
+  it("does not offer offline access stop for a connected node", () => {
+    const container = render(<NodesView data={dashboard()} language="zh-CN" mutate={async () => undefined} onNavigate={() => undefined} />);
+    act(() => [...container.querySelectorAll("button")].find((button) => button.textContent === "管理")?.click());
+    expect([...document.querySelectorAll("button")].some((button) => button.textContent === "停止接入")).toBe(false);
+  });
+
+  it("shows stopped access distinctly from offline and preserves reconnect", () => {
+    const data = dashboard();
+    data.agents[0].connected = false;
+    data.agents[0].credentialRevoked = true;
+    const container = render(<NodesView data={data} language="zh-CN" mutate={async () => undefined} onNavigate={() => undefined} />);
+    expect(container.textContent).toContain("已停止接入");
+    expect(container.textContent).not.toContain("离线");
+    expect([...container.querySelectorAll("button")].some((button) => button.textContent === "重新接入")).toBe(true);
+  });
+
+  it("keeps access-stop failures inline and does nothing on cancellation", async () => {
+    const data = dashboard();
+    data.agents[0].connected = false;
+    const revoke = vi.spyOn(api, "revokeAgentCredential").mockRejectedValue(new Error("Failed to fetch"));
+    const container = render(<NodesView data={data} language="zh-CN" mutate={async (operation) => { await operation(); }} onNavigate={() => undefined} />);
+    act(() => [...container.querySelectorAll("button")].find((button) => button.textContent === "管理")?.click());
+    act(() => [...document.querySelectorAll("button")].find((button) => button.textContent === "停止接入")?.click());
+    act(() => [...document.querySelectorAll("button")].find((button) => button.textContent === "取消")?.click());
+    expect(revoke).not.toHaveBeenCalled();
+    act(() => [...container.querySelectorAll("button")].find((button) => button.textContent === "管理")?.click());
+    act(() => [...document.querySelectorAll("button")].find((button) => button.textContent === "停止接入")?.click());
+    const input = document.querySelector<HTMLInputElement>("#stop-node-access-name")!;
+    expect(input.value).toBe("");
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, data.agents[0].name);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => [...document.querySelectorAll("button")].find((button) => button.textContent === "停止接入" && button.type === "submit")?.click());
+    expect(input.value).toBe(data.agents[0].name);
+    expect(document.body.textContent).toContain("无法连接 Center");
+    expect(revoke).toHaveBeenCalledOnce();
+  });
+
+  it("blocks the stale confirmation if the offline node reconnects", () => {
+    const data = dashboard();
+    data.agents[0].connected = false;
+    const mutate = async () => undefined;
+    const container = render(<NodesView data={data} language="zh-CN" mutate={mutate} onNavigate={() => undefined} />);
+    act(() => [...container.querySelectorAll("button")].find((button) => button.textContent === "管理")?.click());
+    act(() => [...document.querySelectorAll("button")].find((button) => button.textContent === "停止接入")?.click());
+    const input = document.querySelector<HTMLInputElement>("#stop-node-access-name")!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, data.agents[0].name);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const next = { ...data, agents: [{ ...data.agents[0], connected: true }] };
+    act(() => root?.render(<ThemeProvider><NodesView data={next} language="zh-CN" mutate={mutate} onNavigate={() => undefined} /></ThemeProvider>));
+    expect(document.body.textContent).toContain("节点状态已变化");
+    expect([...document.querySelectorAll("button")].find((button) => button.textContent === "停止接入" && button.type === "submit")?.disabled).toBe(true);
   });
 
   it("queues supported Agent updates through Center and keeps purpose changes explicit", async () => {


### PR DESCRIPTION
## Summary

- Add **Nodes → Manage → Stop access** for offline nodes, independently of uninstalling applications or disabling/deleting their records.
- Show a distinct access-stopped state, preserve reconnect, and confirm against the system node name with whitespace-tolerant input and inline feedback.
- Reuse the authenticated, CSRF-protected credential-revocation endpoint. Revoke pending reconnect grants and enrollment recovery responses atomically; repeat requests are safe.
- Preserve applications, pending deployments, gateway associations, server data, and private-network connections. Restoring management requires a new administrator-issued reconnect command.

## Review

- Requests target the immutable Agent ID rather than a subscription display name.
- Revocation is scoped to the selected Agent; failed grant cleanup rolls back credential revocation.
- No database schema migration, production action, version bump, or release is included.

## Validation

- Added backend regression cases for retained workloads/topology, rejected old credentials, invalidated reconnect commands, explicit reconnection, and atomic rollback.
- Added frontend/API cases for exact target identity, confirmation input, cancellation, stale online state, and inline errors.
- Added the focused backend cases to the existing Alpha CI job so they execute before merge.
- GitHub CI passed for commit 8d706e3: focused offline-access/revocation tests, Go quality and recovery/integration checks, frontend lint/tests/build, deployment checks, security scans, and official catalog checks. Both required gates passed under the existing Alpha policy; jobs already disabled by that policy remain skipped.
- Local tests, lint, build, type checks, and browser QA were not run, per repository instructions.
