### PR TITLE
fix(catalog): provision approved production trust root

### DIFF
--- a/.github/workflows/catalog-publish.yml
+++ b/.github/workflows/catalog-publish.yml
@@ -82,8 +82,8 @@ jobs:
           CATALOG_BIN: ${{ runner.temp }}/catalog-bin
           CATALOG_WORK: ${{ runner.temp }}/catalog-publication
           CATALOG_KEY_DIRECTORY: ${{ runner.temp }}/catalog-signers
-          AWS_ACCESS_KEY_ID: ${{ secrets.CATALOG_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CATALOG_R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           AWS_EC2_METADATA_DISABLED: 'true'
           R2_BUCKET_NAME: ${{ vars.CATALOG_R2_BUCKET_NAME }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,3 +9,10 @@ paths = ['''^\.vastora/''']
 description = "Cloudflare OAuth public client identifier"
 paths = ['''^internal/center/cloudflare_oauth\.go$''']
 regexes = ['''565bf36df0a8deb0fde1bd27367a44bd''']
+
+[[allowlists]]
+description = "Reviewed public TUF root identifier, not a signing private key"
+targetRules = ["generic-api-key"]
+condition = "AND"
+paths = ['''^catalog/trust/README\.md$''']
+regexes = ['''^e7892d2fba95f7f7cb9aa9cb62b9b8ebae0b993409d3a5485a2b38d9319ab0e4$''']

--- a/catalog/trust/1.root.json
+++ b/catalog/trust/1.root.json
@@ -1,0 +1,71 @@
+{
+	"signatures": [
+		{
+			"keyid": "e7892d2fba95f7f7cb9aa9cb62b9b8ebae0b993409d3a5485a2b38d9319ab0e4",
+			"sig": "ba47f61b9d1944723c958e7052c44761e73a3d9310a87eaa6aa21d0b260f3be7b876e01e5bfbc1f6cc533b2243e0d9c99a30e59a158617bea9af48624573420e"
+		}
+	],
+	"signed": {
+		"_type": "root",
+		"consistent_snapshot": true,
+		"expires": "2027-09-12T05:15:43Z",
+		"keys": {
+			"40654782ea6cc00c3cb3a4c72dae115bfd968285bbedd5215dd5db1cb8729f7d": {
+				"keytype": "ed25519",
+				"keyval": {
+					"public": "fa8b526484a88efaaeaffa9cf52f4606a5add4a4ea2876ac6b28ae48c8635f1d"
+				},
+				"scheme": "ed25519"
+			},
+			"4188e2884ee729b8cac4c74ae07743193d883d01d0d1c15a59ce2722d4521436": {
+				"keytype": "ed25519",
+				"keyval": {
+					"public": "0677ded04f4b219100aa8de2c369cf93c798fad372d68945d8d3f24e65e6be9d"
+				},
+				"scheme": "ed25519"
+			},
+			"8467c57a2d14aec0f030b0935096c24716558eb6bb9d66d5ad7d8ecaf828d84e": {
+				"keytype": "ed25519",
+				"keyval": {
+					"public": "e86690a8bcf296659106168f169a46c01832d42b27880a8466c74ce4611bcb63"
+				},
+				"scheme": "ed25519"
+			},
+			"e7892d2fba95f7f7cb9aa9cb62b9b8ebae0b993409d3a5485a2b38d9319ab0e4": {
+				"keytype": "ed25519",
+				"keyval": {
+					"public": "d6125be7390e5d9ab6bc7d5592733d557b15f2c691455f5460a1911420e0b04d"
+				},
+				"scheme": "ed25519"
+			}
+		},
+		"roles": {
+			"root": {
+				"keyids": [
+					"e7892d2fba95f7f7cb9aa9cb62b9b8ebae0b993409d3a5485a2b38d9319ab0e4"
+				],
+				"threshold": 1
+			},
+			"snapshot": {
+				"keyids": [
+					"8467c57a2d14aec0f030b0935096c24716558eb6bb9d66d5ad7d8ecaf828d84e"
+				],
+				"threshold": 1
+			},
+			"targets": {
+				"keyids": [
+					"40654782ea6cc00c3cb3a4c72dae115bfd968285bbedd5215dd5db1cb8729f7d"
+				],
+				"threshold": 1
+			},
+			"timestamp": {
+				"keyids": [
+					"4188e2884ee729b8cac4c74ae07743193d883d01d0d1c15a59ce2722d4521436"
+				],
+				"threshold": 1
+			}
+		},
+		"spec_version": "1.0.31",
+		"version": 1
+	}
+}

--- a/catalog/trust/README.md
+++ b/catalog/trust/README.md
@@ -23,4 +23,16 @@ The program release workflow checks the public chain before creating a new
 release. Catalog publication checks it before signing approval. Both reject
 missing or invalid roots; tests use temporary, independently generated test keys.
 Root provisioning and production configuration are operator actions, not
-performed by the development tests. No production root is included yet.
+performed by the development tests.
+
+## Initial production root
+
+`1.root.json` is the existing independently generated Ed25519 public root from
+2026-09-12. It expires at 2027-09-12T05:15:43Z and authorizes distinct root,
+targets, snapshot, and timestamp keys, each with a threshold of one.
+
+Root key ID: `e7892d2fba95f7f7cb9aa9cb62b9b8ebae0b993409d3a5485a2b38d9319ab0e4`.
+This is single-maintainer custody, not a multi-party signing policy. The root
+private key remains outside the repository and GitHub. Only online role keys
+belong in the protected `catalog-signing` environment, restricted to protected
+branches and requiring an approved deployment.

--- a/docs/catalog-release-guide.md
+++ b/docs/catalog-release-guide.md
@@ -24,7 +24,7 @@ separately and pass `--official-catalog-root`; no initial trust is fetched from 
 ## Catalog release checklist
 
 Distribution base: `https://downloads.petauron.com/vastora/catalog/`.
-Objects belong under `vastora/catalog/` in the existing download bucket; do not
+Objects belong under `vastora/catalog/` in the existing `petauron-downloads` bucket; do not
 replace the bucket's other project or installer objects. The mutable pointer is
 `vastora/catalog/timestamp.json`, not a file at the bucket root. This path choice
 does not provision the signing environment or upload the first publication.
@@ -52,9 +52,9 @@ conditions in its [S3 API compatibility reference](https://developers.cloudflare
 7. Refresh a Center without changing its program version. Check the new catalog
    revision and explicitly install or upgrade the selected application.
 
-The hosting path is selected; initial root provisioning and the production
-publication environment are not yet configured by this change. Do not describe the catalog
-as live until those steps and the end-to-end publication check have succeeded.
+The approved initial public root is checked in, and the protected publication
+environment uses the existing online role keys. Do not describe the catalog as
+live until the end-to-end publication check has succeeded.
 See [distribution design](official-catalog-distribution.md) for the current
 implementation checklist and trust limitations.
 
@@ -77,13 +77,15 @@ configuration and fails closed if it cannot read/confirm it. Operator setup:
   the signer verifies authorization against the reviewed root. No root role is
   accepted by this interface. Keys are materialized only in a temporary private
   directory and removed at job exit; none enter artifacts or command output.
-- Environment secrets `CATALOG_R2_ACCESS_KEY_ID` and
-  `CATALOG_R2_SECRET_ACCESS_KEY`: dedicated object read/write credentials scoped
-  as narrowly as R2 permits to the existing download bucket, not account-admin
-  credentials. The script only writes `vastora/catalog/`; this is not a claim
-  that R2 credentials themselves enforce a per-prefix boundary.
+- Organization secrets `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY`, already
+  granted to this repository, are reused with operator approval. These credentials
+  are shared with other project releases, not dedicated catalog credentials.
+  The publisher receives them only after the protected deployment is approved
+  and writes only `vastora/catalog/`; this is not a claim that the credentials
+  themselves enforce a per-prefix boundary. Do not broaden their existing scope
+  or copy them into repository files or logs.
 - Environment variables `CATALOG_R2_BUCKET_NAME` (the existing `download`
-  bucket) and `CATALOG_CLOUDFLARE_ACCOUNT_ID`.
+  domain's bucket, `petauron-downloads`) and `CATALOG_CLOUDFLARE_ACCOUNT_ID`.
 
 The GitHub record is `catalog-r<N>`, explicitly a prerelease and never marked
 Latest. Before any R2 write, its draft asset `catalog-publication.json` retains


### PR DESCRIPTION
## Summary

- Provision the existing approved public TUF root generated on 2026-09-12; no keys were regenerated.
- Keep the root private key local; provision only the three online role keys into the protected catalog-signing environment with a required deployment reviewer and protected-branch policy.
- Reuse organization R2 credentials with explicit operator approval. The existing uploader remains restricted to vastora/catalog/ in petauron-downloads. Credentials are not copied or exposed.
- Scope the Gitleaks false-positive exception to the exact public root identifier, exact README path and generic-api-key rule; all other secret detection remains enabled.

## Validation

Root/catalog verification passed on the first head. Fresh CI is required for the credential wiring and narrow false-positive adjustment. No local tests or builds were run. No A1 deployment or root private-key upload.