### PR TITLE
fix(release): preserve independent catalog during R2 cleanup

### DIFF
--- a/scripts/reconcile-installer-r2.sh
+++ b/scripts/reconcile-installer-r2.sh
@@ -86,13 +86,13 @@ list_keys() {
     page_number=$((page_number + 1))
     page="$temporary_dir/list-$page_number.json"
     if [ -n "$continuation" ]; then
-      aws_r2 list-objects-v2 --bucket "$bucket" --prefix "vastora/" --max-keys 1000 --continuation-token "$continuation" > "$page"
+      aws_r2 list-objects-v2 --bucket "$bucket" --prefix "$release_root" --max-keys 1000 --continuation-token "$continuation" > "$page"
     else
-      aws_r2 list-objects-v2 --bucket "$bucket" --prefix "vastora/" --max-keys 1000 > "$page"
+      aws_r2 list-objects-v2 --bucket "$bucket" --prefix "$release_root" --max-keys 1000 > "$page"
     fi
     if ! jq -e 'all(.Contents[]?;
       (.Key | type == "string") and
-      (.Key | test("^vastora/[A-Za-z0-9._/-]+$")) and
+      (.Key | test("^vastora/releases/[A-Za-z0-9._/-]+$")) and
       (.Key | contains("//") | not) and
       (.Key | split("/") | all(. != "" and . != "." and . != ".."))
     )' "$page" >/dev/null; then
@@ -134,12 +134,14 @@ for key in "$manifest_key" "$activated_key"; do
 done
 
 expected="$temporary_dir/expected-keys"
+# The current pointer is read and verified separately. Listing and deletion
+# must never include sibling namespaces such as the independent app catalog.
 {
-  printf '%s\n' "$current_key" "$manifest_key" "$activated_key"
+  printf '%s\n' "$manifest_key" "$activated_key"
   jq -r '.assets[].key' "$current_manifest"
 } | sort -u > "$expected"
-if [ "$(wc -l < "$expected" | tr -d ' ')" != "6" ]; then
-  echo "R2 current release does not resolve to exactly six protected objects." >&2
+if [ "$(wc -l < "$expected" | tr -d ' ')" != "5" ]; then
+  echo "R2 current release does not resolve to exactly five protected release objects." >&2
   exit 1
 fi
 
@@ -209,4 +211,4 @@ if ! cmp -s "$current_manifest" "$final_pointer"; then
   echo "R2 current release pointer changed during reconciliation." >&2
   exit 1
 fi
-echo "Reconciled R2 to the six protected objects for Vastora $version."
+echo "Reconciled R2 release objects for Vastora $version and preserved its current pointer."

--- a/scripts/test-publish-installer-r2.sh
+++ b/scripts/test-publish-installer-r2.sh
@@ -95,6 +95,7 @@ case "$operation" in
     printf '{}\n'
     ;;
   list-objects-v2)
+    [ "$prefix" = "vastora/releases/" ] || { echo 'Installer cleanup listed outside its release prefix.' >&2; exit 2; }
     keys_file="$FAKE_R2_DIR/list-keys"
     find "$FAKE_R2_DIR/objects" -type f | sed "s|^$FAKE_R2_DIR/objects/||" | sort |
       awk -v prefix="$prefix" 'index($0, prefix) == 1' > "$keys_file"
@@ -174,6 +175,13 @@ if "$script_dir/publish-installer-r2.sh" stage --version "$newer_version" --buck
 fi
 
 mkdir -p "$fake_r2/objects/vastora/releases/v0.0.0-stale"
+# Installer cleanup must coexist with independently published catalog files
+# and other objects in the shared download bucket.
+mkdir -p "$fake_r2/objects/vastora/catalog/targets" "$fake_r2/objects/pulse"
+printf 'catalog root\n' > "$fake_r2/objects/vastora/catalog/1.root.json"
+printf 'catalog target\n' > "$fake_r2/objects/vastora/catalog/targets/catalog.json"
+printf 'unrelated\n' > "$fake_r2/objects/vastora/unexpected-object"
+printf 'pulse release\n' > "$fake_r2/objects/pulse/release.json"
 stale_number=1
 while [ "$stale_number" -le 1002 ]; do
   : > "$fake_r2/objects/vastora/releases/v0.0.0-stale/object-$stale_number"
@@ -181,13 +189,17 @@ while [ "$stale_number" -le 1002 ]; do
 done
 "$script_dir/reconcile-installer-r2.sh" --bucket "$bucket" --endpoint "$endpoint" --dry-run > "$temporary_dir/dry-run.txt"
 grep -Fq "vastora/releases/v$version/install.sh" "$temporary_dir/dry-run.txt"
-
-printf 'unexpected\n' > "$fake_r2/objects/vastora/unexpected-object"
-if "$script_dir/reconcile-installer-r2.sh" --bucket "$bucket" --endpoint "$endpoint" >/dev/null 2>&1; then
-  echo "R2 reconciliation accepted an unknown Vastora prefix." >&2
+if grep -Eq 'Would delete: (vastora/catalog/|vastora/unexpected-object|pulse/)' "$temporary_dir/dry-run.txt"; then
+  echo "R2 reconciliation included unrelated objects in its deletion plan." >&2
   exit 1
 fi
-rm "$fake_r2/objects/vastora/unexpected-object"
+
+printf 'unsafe\n' > "$fake_r2/objects/vastora/releases/unsafe object"
+if "$script_dir/reconcile-installer-r2.sh" --bucket "$bucket" --endpoint "$endpoint" >/dev/null 2>&1; then
+  echo "R2 reconciliation accepted an unsafe release object key." >&2
+  exit 1
+fi
+rm "$fake_r2/objects/vastora/releases/unsafe object"
 
 touch "$fake_r2/change-pointer"
 if "$script_dir/reconcile-installer-r2.sh" --bucket "$bucket" --endpoint "$endpoint" >/dev/null 2>&1; then
@@ -211,7 +223,11 @@ fi
 rm "$fake_r2/skip-delete"
 
 "$script_dir/reconcile-installer-r2.sh" --bucket "$bucket" --endpoint "$endpoint" >/dev/null
-test "$(find "$fake_r2/objects/vastora" -type f | wc -l | tr -d ' ')" = "6"
+test "$(find "$fake_r2/objects/vastora/releases" -type f | wc -l | tr -d ' ')" = "5"
+test "$(cat "$fake_r2/objects/vastora/catalog/1.root.json")" = 'catalog root'
+test "$(cat "$fake_r2/objects/vastora/catalog/targets/catalog.json")" = 'catalog target'
+test "$(cat "$fake_r2/objects/vastora/unexpected-object")" = 'unrelated'
+test "$(cat "$fake_r2/objects/pulse/release.json")" = 'pulse release'
 test -f "$fake_r2/objects/vastora/current.json"
 test -f "$fake_r2/objects/vastora/releases/v$newer_version/activated.json"
 test ! -e "$fake_r2/objects/vastora/releases/v$version/manifest.json"


### PR DESCRIPTION
## 原因
alpha.124 发布在清理旧安装文件时失败：脚本枚举整个 vastora/，将独立商店目录 vastora/catalog/1.root.json 误判为异常对象。

## 修复
- 只枚举、校验及删除 vastora/releases/ 中的旧安装产物。
- current.json 继续独立校验，保留当前版本的全部文件和并发变更保护。
- 补充商店目录、同级对象及其他项目文件保持不变的回归用例，保留分页、非法键、删除失败及指针变化测试。

## 验证
按仓库约定未运行本地测试；由本 PR 的 deployment-check 与必需 CI 检查验证。

## 发布
用于恢复已有 alpha.124 发布，不调整程序版本、不修改线上服务。