### PR TITLE
fix: simplify app update status and reuse release compiler caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,30 @@ jobs:
         if: needs.prepare.outputs.release_retry != 'true'
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.0.0
 
+      # Register cache saving before cache-dance: post steps run in reverse
+      # order, so extraction must finish before actions/cache uploads it.
+      - name: Restore Go compiler caches
+        if: needs.prepare.outputs.release_retry != 'true'
+        id: go-cache
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ runner.temp }}/vastora-go-cache
+          key: release-go-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod', 'go.sum', 'Dockerfile.center', 'scripts/trim-go-build-cache.sh') }}-${{ needs.prepare.outputs.release_sha }}
+          restore-keys: |
+            release-go-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod', 'go.sum', 'Dockerfile.center', 'scripts/trim-go-build-cache.sh') }}-
+
+      - name: Inject Go compiler caches
+        if: needs.prepare.outputs.release_retry != 'true'
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          scratch-dir: ${{ runner.temp }}/vastora-cache-dance
+          skip-extraction: ${{ steps.go-cache.outputs.cache-hit == 'true' }}
+          cache-map: |
+            {
+              "${{ runner.temp }}/vastora-go-cache/amd64": {"id": "vastora-go-build-amd64", "target": "/root/.cache/go-build"},
+              "${{ runner.temp }}/vastora-go-cache/arm64": {"id": "vastora-go-build-arm64", "target": "/root/.cache/go-build"}
+            }
+
       - name: Log in to GitHub Container Registry
         if: needs.prepare.outputs.release_retry != 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.0.0

--- a/Dockerfile.center
+++ b/Dockerfile.center
@@ -38,6 +38,7 @@ RUN GOTOOLCHAIN=go1.26.6 go mod download && \
     find /go/pkg/mod/cache/download -type f -name '*.zip' -delete
 COPY --link cmd/ ./cmd/
 COPY --link internal/ ./internal/
+COPY scripts/trim-go-build-cache.sh /trim-go-build-cache.sh
 
 FROM go-source AS binary-amd64
 COPY --link --from=dante-amd64 /out/ /src/internal/dantebundle/assets/
@@ -45,7 +46,7 @@ ARG VASTORA_VERSION=0.1.0-dev
 RUN --mount=type=cache,id=vastora-go-build-amd64,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOTOOLCHAIN=go1.26.6 go build -trimpath \
     -ldflags="-s -w -X github.com/petauron/vastora/internal/center.Version=${VASTORA_VERSION} -X github.com/petauron/vastora/internal/agent.Version=${VASTORA_VERSION}" \
-    -o /out/vastora ./cmd/vastora
+    -o /out/vastora ./cmd/vastora && sh /trim-go-build-cache.sh
 
 FROM go-source AS binary-arm64
 COPY --link --from=dante-arm64 /out/ /src/internal/dantebundle/assets/
@@ -53,7 +54,7 @@ ARG VASTORA_VERSION=0.1.0-dev
 RUN --mount=type=cache,id=vastora-go-build-arm64,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOTOOLCHAIN=go1.26.6 go build -trimpath \
     -ldflags="-s -w -X github.com/petauron/vastora/internal/center.Version=${VASTORA_VERSION} -X github.com/petauron/vastora/internal/agent.Version=${VASTORA_VERSION}" \
-    -o /out/vastora ./cmd/vastora
+    -o /out/vastora ./cmd/vastora && sh /trim-go-build-cache.sh
 
 FROM binary-amd64 AS center-amd64
 FROM binary-arm64 AS center-arm64

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -37,6 +37,15 @@ require_in "$publish_job" '          outputs: type=image,name=${{ env.CENTER_IMA
 require_in "$publish_job" '          provenance: mode=max'
 require_in "$publish_job" '          cache-to: type=registry,ref=${{ env.CENTER_IMAGE }}:buildcache,mode=max,compression=zstd,compression-level=3,ignore-error=true'
 require_in "$publish_job" '          sbom: true'
+require_in "$publish_job" '      - name: Restore Go compiler caches'
+require_in "$publish_job" '      - name: Inject Go compiler caches'
+require_in "$publish_job" '          path: ${{ runner.temp }}/vastora-go-cache'
+require_in "$publish_job" "          skip-extraction: \${{ steps.go-cache.outputs.cache-hit == 'true' }}"
+for architecture in amd64 arm64; do
+  require_in "$publish_job" "\"id\": \"vastora-go-build-$architecture\""
+done
+require_in "$(cat "$project_dir/Dockerfile.center")" 'COPY scripts/trim-go-build-cache.sh /trim-go-build-cache.sh'
+require_in "$(cat "$project_dir/scripts/trim-go-build-cache.sh")" '536870912'
 require_in "$publish_job" '      - name: Smoke-test released Center image'
 require_in "$publish_job" '          actual_version="$(docker run --rm --platform linux/amd64 --network none --read-only'
 require_in "$publish_job" '            "$CENTER_IMAGE@$IMAGE_DIGEST" version)"'

--- a/scripts/trim-go-build-cache.sh
+++ b/scripts/trim-go-build-cache.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# Only runs inside the Linux build image, after compilation. Keep each
+# architecture's newest compiler artifacts within 512 MiB before exporting.
+# Go cache filenames are hashes; discarded entries are safely rebuilt by Go.
+# Do not include modules, toolchains, npm or Docker layers in this cache.
+find /root/.cache/go-build -type f -printf '%T@ %s %p\n' |
+  LC_ALL=C sort -k1,1nr |
+  awk '{ bytes += $2; if (bytes > 536870912) print $3 }' |
+  xargs -r rm --

--- a/web/src/views/InstalledApps.tsx
+++ b/web/src/views/InstalledApps.tsx
@@ -142,7 +142,7 @@ function ControllerBand({ instance, language, onClients, onManage, onUpgrade }: 
     <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
       <span className="text-xs text-muted-foreground">{copy(language, "订阅主机", "Subscription controller")}</span>
       <span className="truncate text-sm font-medium" title={agent?.name ?? application.nodeId}>{agent?.name ?? application.nodeId}</span>
-      {application.status !== "running" ? <StateBadge language={language} value={application.status} /> : null}
+      {instance.activeChange || application.status !== "running" ? <ApplicationPrimaryStatus instance={instance} language={language} /> : null}
       {webAttention ? <span className="text-xs text-destructive">{copy(language, "入口待处理", "Access needs attention")}</span> : null}
     </div>
     <div className="flex flex-wrap items-center gap-2">
@@ -158,15 +158,26 @@ function ControllerBand({ instance, language, onClients, onManage, onUpgrade }: 
 
 function ApplicationUpdate({ instance, language, onUpgrade }: { instance: InstalledAppInstance; language: Language; onUpgrade: (application: Application) => void }) {
   const { application, app, agent, activeChange } = instance;
-  if (!application.updateAvailable) return null;
+  if (!application.updateAvailable || activeChange) return null;
   const legacy = application.appKey === threeXUIAppKey && application.role === "master" && Boolean(application.controllerApplicationId) && application.id !== application.controllerApplicationId;
-  const updating = activeChange?.operation === "upgrade";
-  const disabled = Boolean(activeChange) || !agent?.connected || legacy || catalogInstallBlocked(app);
+  const disabled = !agent?.connected || legacy || catalogInstallBlocked(app) || ["pending", "deploying"].includes(application.status);
   const name = agent?.name ?? application.nodeId;
   return <Button aria-label={copy(language, `更新 ${name} 的应用`, `Update application on ${name}`)} className="max-md:min-h-11" disabled={disabled} onClick={() => onUpgrade(application)} size="sm" variant="outline" title={copy(language, `更新到 v${application.availableVersion}`, `Update to v${application.availableVersion}`)}>
-    {updating ? <Spinner aria-hidden="true" data-icon="inline-start" /> : null}
-    {updating ? copy(language, "更新中", "Updating") : application.status === "failed" ? copy(language, "重试更新", "Retry update") : copy(language, "更新", "Update")}
+    {application.status === "failed" ? copy(language, "重试更新", "Retry update") : copy(language, "更新", "Update")}
   </Button>;
+}
+
+function ApplicationPrimaryStatus({ instance, language }: { instance: InstalledAppInstance; language: Language }) {
+  const { application, activeChange } = instance;
+  if (activeChange) return <Badge role="status" variant={activeChange.reconciliationRequired ? "destructive" : "outline"}>
+    {activeChange.reconciliationRequired ? <ShieldAlertIcon aria-hidden="true" data-icon="inline-start" /> : <Spinner aria-hidden="true" data-icon="inline-start" className="motion-reduce:animate-none" />}
+    {activeChange.reconciliationRequired ? copy(language, "需要恢复", "Recovery required")
+      : activeChange.operation === "upgrade" ? copy(language, "正在更新", "Updating")
+      : copy(language, `正在${operationLabel(language, activeChange.operation)}`, `${operationLabel(language, activeChange.operation)} in progress`)}
+  </Badge>;
+  return application.status === "running"
+    ? <span className="inline-flex items-center gap-2"><span aria-hidden="true" className="apps-status-dot bg-latency-fast" />{copy(language, "运行中", "Running")}</span>
+    : <StateBadge language={language} value={application.status} />;
 }
 
 function ApplicationStatus({ instance, language, onUpgrade }: { instance: InstalledAppInstance; language: Language; onUpgrade: (application: Application) => void }) {
@@ -175,13 +186,9 @@ function ApplicationStatus({ instance, language, onUpgrade }: { instance: Instal
   const syncFailed = application.role === "worker" && (!instance.controller || !["ready", "pending", "applying"].includes(application.nodeSyncStatus ?? ""));
 
   return <div className="flex flex-col items-start gap-1.5">
-    {application.status === "running" ? <span className="inline-flex items-center gap-2"><span aria-hidden="true" className="apps-status-dot bg-latency-fast" />{copy(language, "运行中", "Running")}</span> : <StateBadge language={language} value={application.status} />}
-    {activeChange ? <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-      {activeChange.reconciliationRequired ? <ShieldAlertIcon aria-hidden="true" className="size-3.5 shrink-0 text-destructive" /> : <Spinner aria-hidden="true" />}
-      {activeChange.reconciliationRequired ? copy(language, "需要继续恢复", "Recovery required") : copy(language, `正在${operationLabel(language, activeChange.operation)}`, `${operationLabel(language, activeChange.operation)} in progress`)}
-    </span> : application.status === "failed" ? <span className="text-xs text-destructive">{copy(language, "最近一次操作失败，应用仍保留", "Last operation failed; the app is still installed")}</span> : null}
-    {syncing ? <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"><Spinner aria-hidden="true" />{copy(language, "正在接入订阅主机", "Connecting to controller")}</span> : null}
-    {syncFailed ? <span className="text-xs text-destructive">{copy(language, "尚未接入订阅主机", "Controller not connected")}</span> : null}
+    <ApplicationPrimaryStatus instance={instance} language={language} />
+    {!activeChange && syncing ? <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"><Spinner aria-hidden="true" />{copy(language, "正在接入订阅主机", "Connecting to controller")}</span> : null}
+    {!activeChange && syncFailed ? <span className="text-xs text-destructive">{copy(language, "尚未接入订阅主机", "Controller not connected")}</span> : null}
     {agent && !agent.connected ? <span className="text-xs text-destructive">{copy(language, "节点离线", "Node offline")}</span> : null}
     <ApplicationUpdate instance={instance} language={language} onUpgrade={onUpgrade} />
   </div>;

--- a/web/src/views/shared.tsx
+++ b/web/src/views/shared.tsx
@@ -102,6 +102,7 @@ export function StateBadge({ value, language = document.documentElement.lang ===
   const Icon = value === "access_stopped" ? UnplugIcon : good ? CircleCheckIcon : bad ? CircleAlertIcon : Clock3Icon;
   const labels: Record<string, [string, string]> = {
     removing: ["正在移除", "Removing"],
+    deploying: ["正在处理", "In progress"],
     removal_failed: ["移除未完成", "Removal incomplete"],
     access_stopped: ["已停止接入", "Access stopped"],
     expired: ["需刷新", "Refresh required"],


### PR DESCRIPTION
## Changes
- Show one localized progress status during application updates; hide duplicate update controls.
- Reuse isolated amd64/arm64 Go compiler caches across releases, capped at 512 MiB each.
- Keep existing Alpha minimum CI and release artifact checks.

## Verification
- Static review completed. No local tests/builds run per repository policy.
- Required CI and actual release build provide verification; warm-cache timing remains to be measured.